### PR TITLE
fix: strip '*' prefix from sha256sum filenames in checksums parser

### DIFF
--- a/src/invisible_playwright/download.py
+++ b/src/invisible_playwright/download.py
@@ -96,7 +96,9 @@ def _parse_checksums(text: str) -> dict[str, str]:
             continue
         parts = line.split()
         if len(parts) >= 2:
-            out[parts[-1]] = parts[0]
+            # sha256sum uses ' *' or '  ' prefix for binary vs text mode
+            key = parts[-1].lstrip("*")
+            out[key] = parts[0]
     return out
 
 


### PR DESCRIPTION
The checksums.txt files use the standard sha256sum format where binary files have a '*' prefix. The parser used parts[-1] as key directly, including the '*', so lookups failed.