### PR TITLE
L'e2e nomina il test su cui si pianta, e non parte su PR di sola documentazione

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,6 +25,14 @@ on:
       - 'LICENSE'
   pull_request:
     branches: [main]
+    # The same filter as `push` above, which had it and this one did not. A
+    # docs-only PR (#54, deleting the Pages site) therefore spun up the full
+    # browser bench, hung, and burned the whole 40-minute timeout on a change no
+    # test can observe. The filter belongs on BOTH triggers or it is not a filter.
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
   workflow_dispatch:
 
 permissions:

--- a/scripts/run_e2e.py
+++ b/scripts/run_e2e.py
@@ -56,7 +56,18 @@ def main() -> int:
         "--reruns", "2", "--reruns-delay", "1",
         "--only-rerun", _RERUN_SIGNATURES,
         "-p", "no:cacheprovider",
-        "-q", "--tb=short",
+        # -v, not -q, and the reason is a hang we could not name twice.
+        # Under -q pytest emits one character per test and the line only
+        # reaches the log when it is full, so a run that dies mid-line says
+        # nothing about where it died. Measured 2026-08-12 on two runs of the
+        # SAME commit: both printed the identical `.s....[ 50%]` line at 78
+        # seconds, one then finished in 4:47 and the other was killed by the
+        # 40-minute timeout with no second line - so the hang was somewhere in
+        # tests 73-141 and that is as close as the log could get. Same symptom
+        # on 2026-08-04. PYTHONUNBUFFERED was already set and is not the
+        # missing piece: the output does stream, the GRANULARITY was wrong.
+        # One line per test costs 141 lines and names the last one that ran.
+        "-v", "--tb=short",
     ] + sys.argv[2:]
     print(f"[run_e2e] binary={binary}")
     print(f"[run_e2e] {' '.join(cmd)}")


### PR DESCRIPTION
Due volte il job e2e e' stato ucciso dal timeout di 40 minuti contro una durata
normale di 4:47. Sullo stesso commit il tentativo 2 e' verde in 5 minuti, quindi
e' intermittente e non dipende da cio' che si spedisce.

Il log non diceva su quale test perche' -q stampa un carattere per test e la riga
arriva solo quando e' piena. Con -v e' una riga per test. E paths-ignore c'era su
push e non su pull_request, per questo la #54 di sola documentazione ha bruciato
i 40 minuti interi.