### PR TITLE
Una scadenza non e' un flake: smettere di ritentarla, e darne una per test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest>=7", "build>=1", "ruff>=0.6", "pytest-rerunfailures>=14", "playwright>=1.55,<=1.61.0"]
+dev = ["pytest>=7", "build>=1", "ruff>=0.6", "pytest-rerunfailures>=14", "pytest-timeout>=2", "playwright>=1.55,<=1.61.0"]
 
 [tool.pytest.ini_options]
 markers = [

--- a/scripts/run_e2e.py
+++ b/scripts/run_e2e.py
@@ -69,10 +69,18 @@ def main() -> int:
         # the job. 420s is 4.5x the slowest legitimate test measured on CI
         # (test_webgl_readpixels_no_masking_signature, 94.4s; the second slowest
         # is 11.4s and the whole suite is 318s), and 1/6 of the job budget.
-        # On Linux this interrupts the test and the suite carries on; on Windows
-        # pytest-timeout falls back to the thread method, which dumps the stack
-        # of the hung test and ends the run - less graceful, still named.
+        # METHOD=thread, not the signal default, and that is the whole point.
+        # Measured 2026-08-13 on the run of this very change: the suite wedged in
+        # `test_hover_triggers_mouseenter` and the 420s signal deadline came and
+        # went with NOTHING at 19.3 minutes, 21 minutes, 40. SIGALRM is delivered
+        # to the main thread and Python runs the handler at the next bytecode
+        # boundary; Playwright's sync API is blocked in a greenlet waiting on the
+        # driver socket, so that boundary never arrives. A watchdog THREAD does
+        # not need the hung thread to cooperate: it dumps every thread's stack
+        # and ends the process. The suite does not carry on, which is the price,
+        # and in exchange a hang stops being anonymous.
         "--timeout", "420",
+        "--timeout-method", "thread",
         "-p", "no:cacheprovider",
         # -v, not -q, and the reason is a hang we could not name twice.
         # Under -q pytest emits one character per test and the line only

--- a/scripts/run_e2e.py
+++ b/scripts/run_e2e.py
@@ -55,6 +55,24 @@ def main() -> int:
         "-o", "addopts=",            # override the default 'not e2e' deselection
         "--reruns", "2", "--reruns-delay", "1",
         "--only-rerun", _RERUN_SIGNATURES,
+        # A DEADLINE is not a flake, and retrying one multiplies it by three.
+        # `Timeout` in the signatures above was written for Playwright's
+        # TimeoutError, but it also matches `subprocess.TimeoutExpired` -
+        # measured, 2 tests produced 4 reruns - and the release/upgrade e2e
+        # spend their time in `pip install` calls whose timeouts run to 300s
+        # each. Retried twice that is 900s for one test, and the two files sum
+        # to 10050s of timeout budget against a 2400s job. That is how the job
+        # was killed at 40 minutes twice with nothing to show for it.
+        "--rerun-except", "TimeoutExpired",   # a subprocess deadline
+        "--rerun-except", "Timeout >",        # pytest-timeout's own deadline
+        # And a per-test deadline, so a hang FAILS WITH A NAME instead of eating
+        # the job. 420s is 4.5x the slowest legitimate test measured on CI
+        # (test_webgl_readpixels_no_masking_signature, 94.4s; the second slowest
+        # is 11.4s and the whole suite is 318s), and 1/6 of the job budget.
+        # On Linux this interrupts the test and the suite carries on; on Windows
+        # pytest-timeout falls back to the thread method, which dumps the stack
+        # of the hung test and ends the run - less graceful, still named.
+        "--timeout", "420",
         "-p", "no:cacheprovider",
         # -v, not -q, and the reason is a hang we could not name twice.
         # Under -q pytest emits one character per test and the line only


### PR DESCRIPTION
Causa dell'impiccamento del job e2e a 40 minuti. Non era il browser:
--only-rerun contiene `Timeout`, scritto per Playwright, e cattura anche
subprocess.TimeoutExpired, triplicando i pip install dei test release/upgrade.
Somma dei loro timeout 10.050s, ritentati 30.150, contro un tetto di 2.400.

Due --rerun-except piu' --timeout 420. Validato nelle due direzioni: il timeout
di sottoprocesso passa da 2 rerun a 0, il flake vero del browser resta a 2.