### PR TITLE
Strumenti per debuggare l'impiccamento dell'e2e la' dove succede

### DIFF
--- a/.github/workflows/e2e-hunt.yml
+++ b/.github/workflows/e2e-hunt.yml
@@ -1,0 +1,109 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# e2e-hunt.yml - gira la suite e2e in CICLO finche' non cattura un impiccamento.
+#
+# Perche' esiste. Il job e2e si impicca nel 12% delle corse (4 su 33 fra il
+# 2026-08-01 e il 08-13) e uccide il job al tetto dei 40 minuti. Al 12% una corsa
+# verde non dimostra niente e servono ~18 giri per avere il 90% di probabilita' di
+# vederne uno: aspettare che succeda da solo su una PR significa aspettare giorni
+# e bruciare il tempo di qualcun altro ogni volta.
+#
+# E perche' QUI e non in locale. Il difetto si manifesta su Linux sotto xvfb. Una
+# caccia sulla macchina di sviluppo (Windows) puo' benissimo non riprodurlo mai, e
+# un negativo li' non direbbe niente su questo ambiente.
+#
+# Non parte da solo: solo `workflow_dispatch`. Non e' un cancello, e' uno
+# strumento di indagine, e non deve entrare fra i contesti richiesti.
+# ─────────────────────────────────────────────────────────────────────────────
+name: e2e hunt
+
+on:
+  workflow_dispatch:
+    inputs:
+      giri:
+        description: "Quanti giri al massimo (al 12% ne servono ~18 per il 90%)"
+        required: false
+        default: "18"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  hunt:
+    name: caccia (linux, xvfb)
+    runs-on: ubuntu-24.04
+    # 18 giri da ~6 minuti piu' l'installazione. Generoso di proposito: il tetto
+    # qui non deve MAI essere la cosa che ferma la caccia, altrimenti torniamo a
+    # un job ucciso che non spiega niente, che e' il difetto di partenza.
+    timeout-minutes: 300
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with: { fetch-depth: 1 }
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with: { python-version: '3.11' }
+      - name: Install wrapper + test deps (+ pinned Playwright)
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install ".[dev]"
+          python -m pip install "playwright==$(cat scripts/playwright_pin.txt)"
+      - name: System deps (xvfb + Firefox runtime libs)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y xvfb
+          sudo "$(which python)" -m playwright install-deps firefox
+      - name: Fetch the published firefox binary
+        run: echo "FF=$(python -m invisible_playwright fetch | tail -1)" >> "$GITHUB_ENV"
+
+      - name: Ciclo finche' non cattura
+        env:
+          PYTHONUNBUFFERED: "1"
+          INVPW_TEST_WATCHDOG_FILE: ${{ runner.temp }}/e2e-watchdog.log
+        run: |
+          set -u
+          giri="${{ inputs.giri }}"
+          mkdir -p "${RUNNER_TEMP}/giri"
+          catturato=0
+          for n in $(seq 1 "$giri"); do
+            log="${RUNNER_TEMP}/giri/giro_$(printf '%02d' "$n").log"
+            t0=$(date +%s)
+            set +e
+            xvfb-run -a python -u scripts/run_e2e.py "$FF" > "$log" 2>&1
+            code=$?
+            set -e
+            dur=$(( $(date +%s) - t0 ))
+            # Un impiccamento adesso NON e' piu' un job ucciso: la scadenza per
+            # test lo trasforma in un fallimento, e il banner lo nomina.
+            if grep -aq "Timeout" "$log" && grep -aq "Stack of" "$log"; then
+              echo "::error::giro $n: IMPICCAMENTO CATTURATO dopo ${dur}s"
+              echo "--- l'ultimo test che ha parlato ---"
+              grep -aE "::.*(PASSED|SKIPPED|FAILED)" "$log" | tail -3
+              echo "--- lo stack ---"
+              sed -n '/Timeout/,$p' "$log" | head -60
+              catturato=1
+              break
+            fi
+            echo "giro $n/$giri: exit=$code, ${dur}s"
+          done
+          if [ "$catturato" = "0" ]; then
+            echo "::warning::$giri giri, nessun impiccamento catturato."
+            echo "Se il tasso qui e' lo stesso del 12%, la probabilita' di questo"
+            echo "esito e' $(python -c "print(round(100*0.88**$giri))")%, quindi non e' una prova"
+            echo "che il difetto non ci sia: e' una misura del tasso con questo campione."
+          fi
+          # Il passo fallisce SOLO se ha catturato: cosi' il rosso significa
+          # "trovato", non "rotto", ed e' il rosso che si va a leggere.
+          exit "$catturato"
+
+      - name: Portare fuori tutte le prove
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: e2e-hunt-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            ${{ runner.temp }}/giri
+            ${{ runner.temp }}/e2e-watchdog.log
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -102,8 +102,32 @@ jobs:
       # job risultava `cancelled` e i passi successivi non partivano affatto. Con
       # `--timeout 420 --timeout-method thread` il processo muore a 7 minuti e il
       # passo fallisce NORMALMENTE, quindi da qui le prove escono.
+      # Uno strumento che non si vede e' indistinguibile da uno che non c'e'.
+      # L'annuncio che il cane da guardia stampa all'apertura del file finisce
+      # dentro `pytest_runtest_setup`, che pytest CATTURA: nel log del job non
+      # compare, quindi da qui non si poteva distinguere "armato" da "inerte".
+      # Questo passo glielo chiede al file, che e' l'unica prova che esista.
+      - name: Il cane da guardia era armato?
+        if: always()
+        run: |
+          f="${RUNNER_TEMP}/e2e-watchdog.log"
+          if [ -s "$f" ]; then
+            # `|| true` e non e' cosmetico: `grep -c` che conta ZERO esce 1, e
+            # GitHub lancia i blocchi `run:` con `bash -e`. Senza, questo passo
+            # moriva esattamente sulle corse SANE - quelle con zero stack - cioe'
+            # avrebbe fatto fallire ogni e2e verde. Trovato eseguendo il blocco
+            # estratto dallo YAML nei quattro stati, non rileggendolo.
+            sorvegliati=$(grep -ac '^---' "$f" || true)
+            stack=$(grep -ac 'Timeout' "$f" || true)
+            echo "armato: ${sorvegliati} test sorvegliati, ${stack} stack scritti"
+          else
+            echo "::warning::il file del cane da guardia e' assente o vuoto: lo strumento NON era armato, e un impiccamento non lascerebbe niente"
+          fi
+
+      # `always()` e non `failure()`: il file serve anche quando la corsa e'
+      # verde, perche' e' l'unica prova che lo strumento funzioni.
       - name: Portare fuori le prove dell'impiccamento
-        if: failure()
+        if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: e2e-watchdog-${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -88,4 +88,25 @@ jobs:
         # actually comes from.
         env:
           PYTHONUNBUFFERED: "1"
+          # Il cane da guardia di tests/conftest.py: a 150s dentro UN test scrive
+          # QUI lo stack di ogni thread, e lo ripete. Due stack identici dicono
+          # bloccato, due diversi dicono lento - diagnosi opposte che nessun altro
+          # strumento distingue. Su FILE e non su stderr perche' pytest redirige i
+          # descrittori a livello di sistema: cio' che e' catturato si perde
+          # quando il processo viene ucciso, cioe' nel caso per cui esiste.
+          INVPW_TEST_WATCHDOG_FILE: ${{ runner.temp }}/e2e-watchdog.log
         run: xvfb-run -a python -u scripts/run_e2e.py "$FF"
+
+      # Gira SOLO se il passo sopra fallisce, e prima del 2026-08-13 non poteva
+      # esistere: l'impiccamento veniva ucciso dal tetto dei 40 minuti, quindi il
+      # job risultava `cancelled` e i passi successivi non partivano affatto. Con
+      # `--timeout 420 --timeout-method thread` il processo muore a 7 minuti e il
+      # passo fallisce NORMALMENTE, quindi da qui le prove escono.
+      - name: Portare fuori le prove dell'impiccamento
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: e2e-watchdog-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/e2e-watchdog.log
+          if-no-files-found: warn
+          retention-days: 14

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,86 @@
+import faulthandler
 import os
 import random
 import sys
+import tempfile
 from pathlib import Path
 
 import pytest
+
+# ── Il cane da guardia che dice DOVE e' fermo, mentre e' ancora fermo ─────────
+#
+# L'e2e si impicca nel 12% delle corse su CI (4 su 33, dal 2026-08-01 al 08-13) e
+# fino al 2026-08-13 non lasciava niente: il job veniva ucciso dal tetto dei 40
+# minuti, quindi risultava `cancelled` e non `failure`, e i passi successivi non
+# giravano. `--timeout 420 --timeout-method thread` in run_e2e.py adesso lo uccide
+# a 7 minuti stampando lo stack, ma sette minuti sono lunghi e uno stack solo non
+# dice se il processo e' FERMO o soltanto lento.
+#
+# Questo lo dice: a 150 secondi dentro UN test stampa lo stack di ogni thread, e
+# lo ripete. Due dump identici significano bloccato; due dump diversi significano
+# lento. Sono due diagnosi opposte e nessun altro strumento le distingue.
+#
+# 150 secondi perche' il test legittimo piu' lento misurato in CI e'
+# `test_webgl_readpixels_no_masking_signature` a 94,4 s, e il secondo a 11,4: su
+# una corsa sana non stampa niente, e su un runner lento al massimo stampa una
+# volta, che e' output e non un fallimento.
+#
+# Su FILE, non su stderr, e non e' un dettaglio: con la cattura predefinita
+# pytest redirige i descrittori 1 e 2 a livello di sistema operativo, quindi
+# anche scrivere sul `sys.__stderr__` originale finisce nel buffer di cattura -
+# che pytest mostra solo a fallimento avvenuto, e qui il processo viene UCCISO.
+# Provato: con la soglia a 3 secondi su un test bloccato in `accept()`, la stessa
+# chiamata stampa quattro stack se lanciata a mano e ZERO sotto pytest. Un file
+# sopravvive all'uccisione e su CI si carica come artifact.
+_WATCHDOG_S = float(os.environ.get("INVPW_TEST_WATCHDOG_S", "150"))
+_WATCHDOG_FILE = os.environ.get(
+    "INVPW_TEST_WATCHDOG_FILE",
+    str(Path(tempfile.gettempdir()) / "invpw-e2e-watchdog.log"))
+_watchdog_handle = None
+
+
+def _watchdog_open():
+    """Apre il file alla PRIMA occorrenza, non all'avvio della sessione.
+
+    Solo i test `e2e` sono sorvegliati: sono gli unici che aprono un browser, e
+    l'unico impiccamento misurato vive li'. Armarlo anche sulla suite unitaria
+    scriveva 439 righe di intestazione per 38 KB di file a ogni corsa, cioe'
+    rumore su un banco che non ne aveva bisogno.
+    """
+    global _watchdog_handle
+    if _watchdog_handle is not None or _WATCHDOG_S <= 0:
+        return _watchdog_handle
+    try:
+        _watchdog_handle = open(_WATCHDOG_FILE, "a", buffering=1, encoding="utf-8")
+    except OSError:
+        # Un cane da guardia che fa fallire la suite per un problema PROPRIO e'
+        # peggio del difetto che sorveglia.
+        return None
+    _watchdog_handle.write("\n=== sessione avviata, soglia %ss ===\n" % _WATCHDOG_S)
+    print("[watchdog] stack dei test oltre %ss -> %s" % (_WATCHDOG_S, _WATCHDOG_FILE))
+    return _watchdog_handle
+
+
+def pytest_runtest_setup(item):
+    if item.get_closest_marker("e2e") is None:
+        return
+    handle = _watchdog_open()
+    if handle is not None:
+        handle.write("\n--- %s ---\n" % item.nodeid)
+        faulthandler.dump_traceback_later(_WATCHDOG_S, repeat=True, file=handle)
+
+
+def pytest_runtest_teardown(item, nextitem):
+    if _watchdog_handle is not None:
+        faulthandler.cancel_dump_traceback_later()
+
+
+def pytest_unconfigure(config):
+    global _watchdog_handle
+    if _watchdog_handle is not None:
+        faulthandler.cancel_dump_traceback_later()
+        _watchdog_handle.close()
+        _watchdog_handle = None
 
 # GUARDED, and not for tidiness. The user-path e2e files are collected in an
 # environment that deliberately does NOT have this package installed - they


### PR DESCRIPTION
Il difetto vive su Linux sotto xvfb e si presenta nel 12% delle corse, quindi
gli strumenti devono stare su CI: una caccia sulla macchina di sviluppo gira su
Windows e un negativo li' non direbbe niente.

Un cane da guardia che a 150s dentro un test scrive lo stack di ogni thread su
file, l'artifact che lo porta fuori, e un workflow che cicla la suite fino a
catturare. La logica del ciclo e' stata eseguita nei tre esiti possibili.