### PR TITLE
Il badge dei lanci era fermo: si pubblicava su un branch protetto

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,5 +256,5 @@ This project is for educational purposes only. It is provided as-is, with no war
   <a href="https://www.python.org/downloads/"><img src="https://raw.githubusercontent.com/feder-cr/invisible_playwright/main/docs/badges/python.svg" alt="Python 3.11+"></a>
   <a href="https://github.com/feder-cr/firefox_antidetect_patch/releases"><img src="https://raw.githubusercontent.com/feder-cr/invisible_playwright/main/docs/badges/firefox.svg" alt="Firefox 151.0"></a>
   <a href="https://github.com/feder-cr/invisible_playwright/stargazers"><img src="https://raw.githubusercontent.com/feder-cr/invisible_playwright/main/docs/badges/stars.svg" alt="GitHub stars"></a>
-  <a href="https://github.com/feder-cr/invisible_firefox/releases/tag/usage-counter"><img src="https://raw.githubusercontent.com/feder-cr/invisible_playwright/main/docs/badges/launches.svg" alt="browser launches"></a>
+  <a href="https://github.com/feder-cr/invisible_firefox/releases/tag/usage-counter"><img src="https://raw.githubusercontent.com/feder-cr/invisible_playwright/badges/docs/badges/launches.svg" alt="browser launches"></a>
 </p>


### PR DESCRIPTION
Il README mostra 1,64M mentre il numero vero e' 1,78M: 140.000 lanci non
contati. Il badge si aggiorna con l'API dei contenuti, cioe' un commit diretto
su main, e da quando main richiede il contesto `gate` quella chiamata fallisce
con 409. Il difetto era invisibile perche' la stessa automazione salva anche il
CSV dei download, e quella parte funzionava.

Il badge ora vive sul branch `badges`, non protetto. Verificato prima di aprire
questa PR: il nuovo URL risponde 200, image/svg+xml, e legge 1.78M.