### PR TITLE
Il badge delle stelle non lo ricalcolava nessuno dal 19 luglio

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,6 @@ This project is for educational purposes only. It is provided as-is, with no war
   <a href="https://github.com/feder-cr/invisible_playwright/blob/main/LICENSE"><img src="https://raw.githubusercontent.com/feder-cr/invisible_playwright/main/docs/badges/license.svg" alt="License: MIT"></a>
   <a href="https://www.python.org/downloads/"><img src="https://raw.githubusercontent.com/feder-cr/invisible_playwright/main/docs/badges/python.svg" alt="Python 3.11+"></a>
   <a href="https://github.com/feder-cr/firefox_antidetect_patch/releases"><img src="https://raw.githubusercontent.com/feder-cr/invisible_playwright/main/docs/badges/firefox.svg" alt="Firefox 151.0"></a>
-  <a href="https://github.com/feder-cr/invisible_playwright/stargazers"><img src="https://raw.githubusercontent.com/feder-cr/invisible_playwright/main/docs/badges/stars.svg" alt="GitHub stars"></a>
+  <a href="https://github.com/feder-cr/invisible_playwright/stargazers"><img src="https://raw.githubusercontent.com/feder-cr/invisible_playwright/badges/docs/badges/stars.svg" alt="GitHub stars"></a>
   <a href="https://github.com/feder-cr/invisible_firefox/releases/tag/usage-counter"><img src="https://raw.githubusercontent.com/feder-cr/invisible_playwright/badges/docs/badges/launches.svg" alt="browser launches"></a>
 </p>

--- a/docs/badges/stars.svg
+++ b/docs/badges/stars.svg
@@ -1,16 +1,16 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="79" height="20" role="img" aria-label="Stars: 1.8k">
-<title>Stars: 1.8k</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="20" role="img" aria-label="Stars: 1.88k">
+<title>Stars: 1.88k</title>
 <linearGradient id="s" x2="0" y2="100%"><stop offset="0" stop-color="#bbb" stop-opacity=".1"/><stop offset="1" stop-opacity=".1"/></linearGradient>
-<clipPath id="r"><rect width="79" height="20" rx="3" fill="#fff"/></clipPath>
+<clipPath id="r"><rect width="80" height="20" rx="3" fill="#fff"/></clipPath>
 <g clip-path="url(#r)">
 <rect width="43" height="20" fill="#555"/>
-<rect x="43" width="36" height="20" fill="#e8a317"/>
-<rect width="79" height="20" fill="url(#s)"/>
+<rect x="43" width="37" height="20" fill="#e8a317"/>
+<rect width="80" height="20" fill="url(#s)"/>
 </g>
 <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">
 <text x="21.5" y="15" fill="#010101" fill-opacity=".3">Stars</text>
 <text x="21.5" y="14">Stars</text>
-<text x="61.0" y="15" fill="#010101" fill-opacity=".3">1.8k</text>
-<text x="61.0" y="14">1.8k</text>
+<text x="61.5" y="15" fill="#010101" fill-opacity=".3">1.88k</text>
+<text x="61.5" y="14">1.88k</text>
 </g>
 </svg>


### PR DESCRIPTION
Il badge delle stelle era un SVG scritto a mano il 19 luglio, quando ho tolto shields.io, e da allora non lo rigenerava nessuno script. Diceva 1.8k mentre le stelle erano 1886: mancavano 14 stelle perche' il numero fosse proprio sbagliato.

Adesso lo produce lo stesso renderer del badge dei lanci, dallo snapshot giornaliero, e lo legge dal ramo badges come l'altro. Il ramo serve perche' main richiede il check gate e un commit diretto via API viene rifiutato con 409.