### PR TITLE
I test dell'installazione ereditavano l'ambiente di chi li lanciava

### DIFF
--- a/tests/test_e2e_hermetic.py
+++ b/tests/test_e2e_hermetic.py
@@ -1,0 +1,129 @@
+"""I due file e2e della PUBBLICAZIONE non lasciano passare l'ambiente nel venv.
+
+**Perche' questo file esiste.** `test_release_e2e.py` e `test_upgrade_e2e.py`
+creano un venv e ci installano il pacchetto DALL'INDICE: sono l'unica cosa che
+verifica cosa riceve un utente. Ma un venv EREDITA l'ambiente, e fino al
+2026-08-14 `subprocess.run(env=None)` glielo passava intatto. Misurato il
+2026-08-11: `PYTHONPATH` verso i sorgenti del banco e `INVISIBLE_SEAL_FILE`
+verso un sigillo locale hanno prodotto **sedici fallimenti in un giorno, nessuno
+del prodotto**. E il verso pericoloso e' l'altro: un VERDE che arriva da un
+ambiente che nessun utente ha.
+
+**Perche' e' un test e non un commento.** Il rimedio vive in DUE copie, una per
+file, e la duplicazione e' imposta da un gate del core
+(`test_no_install_e2e_file_imports_a_package_the_runner_does_not_have`, in
+`invisible_core/tests/test_marker_vocabulary.py`): quei file devono raccogliersi
+con solo stdlib e pytest sul runner, quindi un modulo condiviso sarebbe un
+errore di raccolta. Due copie divergono, a meno che qualcosa non le confronti.
+
+Il caso che conta e' l'ULTIMO: il controllo che dimostra che senza la correzione
+la variabile passerebbe davvero. Un test che verifica solo la versione corretta
+non distingue "il rimedio funziona" da "il problema non esisteva".
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+QUI = Path(__file__).resolve().parent
+FILE_E2E = ("test_release_e2e.py", "test_upgrade_e2e.py")
+
+#: Le variabili misurate, piu' quella aggiunta per costruzione. Se un file
+#: dimenticasse una di queste, il confronto fra le due copie qui sotto lo
+#: riporterebbe come divergenza.
+ATTESE = ("PYTHONPATH", "INVISIBLE_SEAL_FILE", "PYTHONHOME")
+
+
+def _carica(nome: str):
+    """Importa il modulo e2e dal PERCORSO, non dal nome.
+
+    Il nome dipenderebbe da come pytest ha popolato `sys.path`, e questo test
+    deve valere anche fuori da una corsa che raccoglie quei file.
+    """
+    percorso = QUI / nome
+    spec = importlib.util.spec_from_file_location(nome[:-3] + "_letto", percorso)
+    modulo = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(modulo)
+    return modulo
+
+
+@pytest.fixture(scope="module")
+def moduli():
+    return {n: _carica(n) for n in FILE_E2E}
+
+
+def test_entrambi_i_file_dichiarano_le_stesse_variabili(moduli):
+    """Due copie che divergono sono peggio di una copia sola."""
+    visto = {n: tuple(m._NON_ERMETICHE) for n, m in moduli.items()}
+    valori = set(visto.values())
+    assert len(valori) == 1, (
+        "i due file e2e ripuliscono ambienti DIVERSI, quindi uno dei due lascia "
+        "passare qualcosa che l'altro ferma:\n  "
+        + "\n  ".join("%s -> %s" % (n, v) for n, v in sorted(visto.items())))
+    assert valori.pop() == ATTESE, (
+        "l'elenco e' cambiato senza aggiornare questo test. Le tre attese sono "
+        "%s: le prime due sono misurate (sedici rossi il 2026-08-11), la terza "
+        "e' PYTHONHOME, che redirige la libreria standard e romperebbe il venv "
+        "prima che esegua una riga." % (ATTESE,))
+
+
+@pytest.mark.parametrize("nome", FILE_E2E)
+def test_clean_env_toglie_le_variabili_e_lascia_le_altre(moduli, nome, monkeypatch):
+    m = moduli[nome]
+    monkeypatch.setenv("PYTHONPATH", "/c/src/firefox-stealth/release/invisible_core/src")
+    monkeypatch.setenv("INVISIBLE_SEAL_FILE", "C:/tmp/seal-locale.json")
+    monkeypatch.setenv("PYTHONHOME", "/opt/altrove")
+    monkeypatch.setenv("UNA_QUALSIASI", "resta")
+
+    env, tolte = m._clean_env()
+
+    for k in ATTESE:
+        assert k not in env, "%s: %s e' ancora nell'ambiente del sottoprocesso" % (nome, k)
+    assert sorted(tolte) == sorted(ATTESE), (
+        "%s: dice di aver tolto %s" % (nome, tolte))
+    assert env.get("UNA_QUALSIASI") == "resta", (
+        "%s: ha ripulito piu' del dovuto. Un ambiente svuotato rompe cose che "
+        "non c'entrano - PATH, TEMP, le variabili del proxy - e la correzione "
+        "diventa un difetto nuovo." % nome)
+
+
+@pytest.mark.parametrize("nome", FILE_E2E)
+def test_il_sottoprocesso_non_le_vede_davvero(moduli, nome, monkeypatch):
+    """Il percorso VERO: non `_clean_env` in isolamento, ma `_run`.
+
+    E' la differenza fra provare l'aiutante e provare cio' che il file fa. Il
+    difetto originale non era in un aiutante: era `env=None` nella chiamata.
+    """
+    m = moduli[nome]
+    monkeypatch.setenv("PYTHONPATH", "/percorso/del/banco")
+    monkeypatch.setenv("INVISIBLE_SEAL_FILE", "C:/tmp/seal-locale.json")
+
+    script = ("import os;"
+              "print(os.environ.get('PYTHONPATH'), os.environ.get('INVISIBLE_SEAL_FILE'))")
+    out = m._run([sys.executable, "-c", script], timeout=60).stdout.strip()
+    assert out == "None None", (
+        "%s: il sottoprocesso lanciato da _run vede ancora l'ambiente del "
+        "chiamante: %r" % (nome, out))
+
+
+def test_controllo_senza_il_rimedio_la_variabile_PASSEREBBE(monkeypatch):
+    """L'input noto-cattivo, che qui e' il MONDO PRIMA della correzione.
+
+    Senza questo, i tre test sopra non distinguono "il rimedio funziona" da "il
+    problema non esisteva". Riproduce la chiamata com'era - `env=None` - e
+    pretende che la variabile arrivi a destinazione.
+    """
+    monkeypatch.setenv("PYTHONPATH", "/percorso/del/banco")
+    script = "import os; print(os.environ.get('PYTHONPATH'))"
+    r = subprocess.run([sys.executable, "-c", script], capture_output=True,
+                       text=True, timeout=60, env=None)
+    assert r.stdout.strip() == "/percorso/del/banco", (
+        "il controllo non riproduce il difetto: con env=None la variabile "
+        "dovrebbe passare, e non e' passata. Allora i test qui sopra non stanno "
+        "dimostrando quello che sembrano dimostrare, ed e' il BANCO a essere "
+        "rotto - non il rimedio a funzionare. Ottenuto: %r" % r.stdout)

--- a/tests/test_release_e2e.py
+++ b/tests/test_release_e2e.py
@@ -41,6 +41,47 @@ import sys
 
 import pytest
 
+# The variables that must NOT cross into a venv this file builds.
+#
+# A venv inherits the environment, and these two walk straight through it into
+# the thing under test. Measured 2026-08-11:
+#
+#   PYTHONPATH           pointing at the workbench sources makes the venv import
+#                        the workbench core instead of the installed one. 5
+#                        failures here and 2 in test_upgrade_e2e.py on Linux,
+#                        every one of them "requires invisible-core==18.13.0 /
+#                        installed 18.14.0". The product was not involved.
+#   INVISIBLE_SEAL_FILE  pointing at a LOCAL seal makes the four tests that
+#                        download the published release fail with "the active
+#                        seal is a LOCAL seal with no published assets". 4
+#                        failures, on Windows AND Linux, that went away by
+#                        re-running the same file without it: 9 of 9 passed.
+#   PYTHONHOME           same mechanism as PYTHONPATH and worse - it redirects
+#                        the standard library, so the venv python is broken
+#                        before it runs a line. Not measured here; added because
+#                        it cannot be right and would be unreadable if it hit.
+#
+# Sixteen failures in one day, none of them the product. And the dangerous
+# direction is the other one: a GREEN that comes from an environment no user
+# has. These tests are the only thing that checks the install path, so their
+# verdict must not depend on the shell that launched them.
+_NON_ERMETICHE = ("PYTHONPATH", "INVISIBLE_SEAL_FILE", "PYTHONHOME")
+
+
+def _clean_env(base=None):
+    """L'ambiente da passare a un sottoprocesso, senza le variabili che filtrano.
+
+    Torna anche cosa ha tolto, cosi' il messaggio di errore puo' dirlo: una
+    variabile rimossa in silenzio e' la stessa classe di difetto di una
+    ereditata in silenzio, solo con il segno cambiato.
+    """
+    env = dict(os.environ if base is None else base)
+    tolte = [k for k in _NON_ERMETICHE if k in env]
+    for k in tolte:
+        env.pop(k, None)
+    return env, tolte
+
+
 # ── venv mechanics, LOCAL ON PURPOSE ────────────────────────────────────────
 # These three live in `invisible_core.testing` and every other suite in the
 # three repos imports them from there. NOT this file. The job that runs it
@@ -55,14 +96,25 @@ import pytest
 # the path. The core's suite now parses these files and refuses the import, so
 # the rule does not depend on this comment being read.
 def _run(cmd, *, timeout: int = 600, check: bool = True, env=None, cwd=None):
+    # `env=None` significava EREDITA, che e' esattamente il difetto. Adesso il
+    # default e' l'ambiente ripulito; passare `env=` esplicitamente lo ripulisce
+    # comunque, perche' un chiamante che costruisce un ambiente parte quasi
+    # sempre da `os.environ`.
+    env, tolte = _clean_env(env)
     r = subprocess.run([str(c) for c in cmd], capture_output=True, text=True,
                        timeout=timeout, env=env,
                        cwd=str(cwd) if cwd is not None else None)
     if check and r.returncode != 0:
+        nota = ""
+        if tolte:
+            nota = ("\n--- ambiente ---\nrimosse prima di lanciare: {}\n"
+                    "(sono le variabili che entrerebbero nel venv e lo farebbero "
+                    "misurare qualcosa che non e' cio' che riceve un utente)"
+                    .format(", ".join(tolte)))
         raise AssertionError(
-            "{} exited {}\n--- stdout ---\n{}\n--- stderr ---\n{}".format(
+            "{} exited {}\n--- stdout ---\n{}\n--- stderr ---\n{}{}".format(
                 " ".join(str(c) for c in cmd), r.returncode,
-                r.stdout[-3000:], r.stderr[-3000:]))
+                r.stdout[-3000:], r.stderr[-3000:], nota))
     return r
 
 
@@ -98,10 +150,13 @@ make_venv = _make_venv
 # Reading it from the VENV is also the more honest question: what a user gets
 # is what the installed package says, not what this checkout says.
 def _upstream_version(py: Path) -> str:
+    # `_clean_env()` e non l'ambiente ereditato: questa e' la lettura che decide
+    # quale COPIA del pacchetto risponde, ed e' proprio quella che `PYTHONPATH`
+    # dirotta sui sorgenti del banco.
     out = subprocess.run(
         [str(py), "-c",
          "from invisible_playwright.constants import FIREFOX_UPSTREAM_VERSION as v; print(v)"],
-        capture_output=True, text=True, timeout=60)
+        capture_output=True, text=True, timeout=60, env=_clean_env()[0])
     assert out.returncode == 0, (
         "could not read FIREFOX_UPSTREAM_VERSION from the installed package: "
         + (out.stdout or "") + " " + (out.stderr or ""))
@@ -309,8 +364,13 @@ def test_binary_executes_after_fetch(clean_venv: Path, isolated_cache_env: dict)
         # Linux binary path on Windows host - skip launch, the previous
         # ensure_binary() already proved cache landed correctly.
         pytest.skip("Cross-platform binary launch from Windows requires WSL.")
+    # Anche qui `_clean_env()`, e non perche' Firefox legga `PYTHONPATH`: non lo
+    # legge. Perche' cosi' in questo file NON c'e' un solo sottoprocesso lanciato
+    # con l'ambiente ereditato, quindi non c'e' un'eccezione da ricordare ne' un
+    # esempio da ricopiare. Costa niente.
     r = subprocess.run([str(binary_path), "--version"],
-                       capture_output=True, text=True, timeout=30)
+                       capture_output=True, text=True, timeout=30,
+                       env=_clean_env()[0])
     text = (r.stdout + r.stderr).lower()
     upstream = _upstream_version(clean_venv)
     assert "firefox" in text and upstream in text, (

--- a/tests/test_upgrade_e2e.py
+++ b/tests/test_upgrade_e2e.py
@@ -37,6 +37,39 @@ import subprocess
 
 import pytest
 
+# Le variabili che NON devono attraversare un venv costruito qui, e la copia di
+# `_clean_env` accanto a loro.
+#
+# **La duplicazione con `test_release_e2e.py` e' voluta e c'e' un gate che la
+# pretende**: `test_no_install_e2e_file_imports_a_package_the_runner_does_not_have`
+# nel core parsa questi file e rifiuta ogni import di modulo che non sia stdlib,
+# pytest, packaging o pip, con il messaggio "Keep the helpers local in these
+# files - the duplication is the point". Un modulo condiviso qui sarebbe un
+# errore di RACCOLTA sul runner, cioe' un job rosso che non ha testato niente.
+# Fattorizzare e' la mossa giusta ovunque tranne che in questi due file.
+#
+# Misurato 2026-08-11: `PYTHONPATH` verso i sorgenti del banco fa importare al
+# venv il core del banco invece di quello installato (2 fallimenti qui, 5
+# nell'altro file); `INVISIBLE_SEAL_FILE` verso un sigillo locale fa fallire i
+# test che scaricano la release pubblicata. Sedici rossi in un giorno, nessuno
+# del prodotto - e il verso pericoloso e' l'altro: un verde da un ambiente che
+# nessun utente ha.
+_NON_ERMETICHE = ("PYTHONPATH", "INVISIBLE_SEAL_FILE", "PYTHONHOME")
+
+
+def _clean_env(base=None):
+    """L'ambiente per un sottoprocesso, senza le variabili che filtrano.
+
+    Torna anche cosa ha tolto: una variabile rimossa in silenzio e' la stessa
+    classe di difetto di una ereditata in silenzio, col segno cambiato.
+    """
+    env = dict(os.environ if base is None else base)
+    tolte = [k for k in _NON_ERMETICHE if k in env]
+    for k in tolte:
+        env.pop(k, None)
+    return env, tolte
+
+
 # ── venv mechanics, LOCAL ON PURPOSE ────────────────────────────────────────
 # These three live in `invisible_core.testing` and every other suite in the
 # three repos imports them from there. NOT this file. The job that runs it
@@ -51,14 +84,24 @@ import pytest
 # the path. The core's suite now parses these files and refuses the import, so
 # the rule does not depend on this comment being read.
 def _run(cmd, *, timeout: int = 600, check: bool = True, env=None, cwd=None):
+    # `env=None` significava EREDITA, che e' il difetto. Adesso il default e'
+    # l'ambiente ripulito, e anche un `env=` esplicito viene ripulito, perche'
+    # chi ne costruisce uno parte quasi sempre da `os.environ`.
+    env, tolte = _clean_env(env)
     r = subprocess.run([str(c) for c in cmd], capture_output=True, text=True,
                        timeout=timeout, env=env,
                        cwd=str(cwd) if cwd is not None else None)
     if check and r.returncode != 0:
+        nota = ""
+        if tolte:
+            nota = ("\n--- ambiente ---\nrimosse prima di lanciare: {}\n"
+                    "(sono le variabili che entrerebbero nel venv e gli farebbero "
+                    "misurare qualcosa che non e' cio' che riceve un utente)"
+                    .format(", ".join(tolte)))
         raise AssertionError(
-            "{} exited {}\n--- stdout ---\n{}\n--- stderr ---\n{}".format(
+            "{} exited {}\n--- stdout ---\n{}\n--- stderr ---\n{}{}".format(
                 " ".join(str(c) for c in cmd), r.returncode,
-                r.stdout[-3000:], r.stderr[-3000:]))
+                r.stdout[-3000:], r.stderr[-3000:], nota))
     return r
 
 


### PR DESCRIPTION
env=None in subprocess.run non vuol dire ambiente vuoto: vuol dire eredita. Quindi PYTHONPATH e INVISIBLE_SEAL_FILE entravano nei venv che questi test costruiscono, e il venv importava il core del banco invece di quello installato. Sedici rossi in un giorno, nessuno del prodotto - e il verso pericoloso e' l'altro, un verde da un ambiente che nessun utente ha.

La duplicazione fra i due file resta: un modulo condiviso qui sarebbe un errore di raccolta sul runner, che ha solo pytest. A tenerle allineate c'e' un test che le confronta, piu' il controllo che riproduce il mondo di prima.