### PR TITLE
Replace the Telegram handoff with an in-page scrape chat

### DIFF
--- a/docs/assets/scrapeorbit.css
+++ b/docs/assets/scrapeorbit.css
@@ -430,3 +430,165 @@ a { color: inherit; text-decoration: none; }
   *, *::before, *::after { animation: none !important; scroll-behavior: auto !important; transition: none !important; }
   .result { opacity: 1; transform: none; }
 }
+
+/* ---------- Scrape chat (lead capture) ---------- */
+.chat-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+  display: grid;
+  place-items: center;
+  padding: 20px;
+  background: rgba(3, 4, 9, 0.72);
+  -webkit-backdrop-filter: blur(6px);
+  backdrop-filter: blur(6px);
+  animation: chat-fade 0.2s ease;
+}
+@keyframes chat-fade { from { opacity: 0; } to { opacity: 1; } }
+.chat-panel {
+  width: min(440px, 100%);
+  max-height: min(86vh, 640px);
+  display: flex;
+  flex-direction: column;
+  background: linear-gradient(var(--bg-2), var(--bg-2)) padding-box,
+              linear-gradient(140deg, var(--border-lit), rgba(124, 92, 255, 0.35)) border-box;
+  border: 1.5px solid transparent;
+  border-radius: 18px;
+  overflow: hidden;
+  box-shadow: 0 40px 100px -30px rgba(0, 0, 0, 0.9);
+  animation: chat-rise 0.28s cubic-bezier(0.2, 0.7, 0.2, 1);
+}
+@keyframes chat-rise { from { transform: translateY(16px) scale(0.98); opacity: 0; } to { transform: none; opacity: 1; } }
+.chat-head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 15px 18px;
+  border-bottom: 1px solid var(--border);
+}
+.chat-glyph {
+  flex: none;
+  width: 40px; height: 40px;
+  display: grid; place-items: center;
+  border-radius: 10px;
+  background: #fff;
+  overflow: hidden;
+  font-family: var(--display);
+  font-weight: 800;
+  color: #04120f;
+}
+.chat-glyph img { width: 100%; height: 100%; object-fit: contain; display: block; }
+.chat-head-body { flex: 1; min-width: 0; }
+.chat-co { font-weight: 700; font-size: 1.02rem; }
+.chat-dom { font-family: var(--mono); font-size: 0.78rem; color: var(--muted); }
+.chat-close {
+  flex: none;
+  width: 32px; height: 32px;
+  border: none;
+  background: none;
+  color: var(--muted);
+  font-size: 1.5rem;
+  line-height: 1;
+  cursor: pointer;
+  border-radius: 8px;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+.chat-close:hover { background: var(--panel-2); color: var(--text); }
+.chat-body {
+  flex: 1;
+  min-height: 180px;
+  overflow-y: auto;
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 11px;
+}
+.msg {
+  max-width: 84%;
+  padding: 10px 14px;
+  border-radius: 15px;
+  font-size: 0.95rem;
+  line-height: 1.45;
+  animation: msg-in 0.22s ease;
+}
+@keyframes msg-in { from { opacity: 0; transform: translateY(5px); } to { opacity: 1; transform: none; } }
+.msg.bot {
+  align-self: flex-start;
+  background: var(--panel-2);
+  border: 1px solid var(--border);
+  border-bottom-left-radius: 5px;
+}
+.msg.user {
+  align-self: flex-end;
+  background: var(--accent);
+  color: #04120f;
+  font-weight: 500;
+  border-bottom-right-radius: 5px;
+}
+.msg b { font-weight: 700; }
+.dots { display: inline-flex; gap: 4px; padding: 3px 0; }
+.dots i {
+  width: 6px; height: 6px;
+  border-radius: 50%;
+  background: var(--muted);
+  animation: chat-dot 1.2s infinite ease-in-out;
+}
+.dots i:nth-child(2) { animation-delay: 0.18s; }
+.dots i:nth-child(3) { animation-delay: 0.36s; }
+@keyframes chat-dot { 0%, 60%, 100% { opacity: 0.3; transform: translateY(0); } 30% { opacity: 1; transform: translateY(-3px); } }
+.chips { display: flex; flex-wrap: wrap; gap: 8px; align-self: flex-start; max-width: 100%; }
+.chip {
+  font-family: var(--mono);
+  font-size: 0.8rem;
+  padding: 8px 13px;
+  border-radius: 999px;
+  border: 1px solid var(--border-lit);
+  background: rgba(56, 240, 200, 0.08);
+  color: var(--accent);
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+.chip:hover { background: var(--accent); color: #04120f; }
+.chat-input {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px;
+  border-top: 1px solid var(--border);
+}
+.chat-input input {
+  flex: 1;
+  min-width: 0;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 11px;
+  color: var(--text);
+  font-family: var(--sans);
+  font-size: 1rem;
+  padding: 12px 14px;
+  outline: none;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+.chat-input input:focus { border-color: var(--border-lit); box-shadow: 0 0 0 3px rgba(56, 240, 200, 0.12); }
+.chat-input input:disabled { opacity: 0.6; }
+.chat-input input::placeholder { color: var(--faint); }
+.chat-send {
+  flex: none;
+  width: 44px; height: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: 11px;
+  background: var(--accent);
+  color: #04120f;
+  cursor: pointer;
+  box-shadow: 0 0 20px rgba(56, 240, 200, 0.3);
+  transition: transform 0.15s ease, box-shadow 0.2s ease;
+}
+.chat-send:hover { transform: translateY(-1px); box-shadow: 0 0 30px rgba(56, 240, 200, 0.5); }
+.chat-send:disabled { opacity: 0.5; cursor: default; box-shadow: none; transform: none; }
+.chat-send svg { width: 20px; height: 20px; }
+@media (max-width: 560px) {
+  .chat-panel { max-height: 92vh; border-radius: 14px; }
+}

--- a/docs/assets/scrapeorbit.js
+++ b/docs/assets/scrapeorbit.js
@@ -8,7 +8,10 @@
 (function () {
   "use strict";
 
-  var TELEGRAM = "federcr";
+  // Web3Forms access key: a PUBLISHABLE front-end key (like the Brandfetch id).
+  // The scrape request lands in the account owner's inbox. Not a secret.
+  var WEB3FORMS_KEY = "209e0f52-da13-4b13-9296-c62b97034ac6";
+  var WEB3FORMS_URL = "https://api.web3forms.com/submit";
 
   // Paste your free Brandfetch client id here. It is a PUBLISHABLE key meant to
   // live in front-end code (rate-limited by referrer), not a secret. Empty =
@@ -30,13 +33,172 @@
     .then(function (data) { if (Array.isArray(data)) fallback = data; })
     .catch(function () {});
 
-  function scrapeMessage(company) {
-    return "Hi! I'd like to scrape data for: " + company + ". Can you help?";
+  /* ---- Scrape chat: a ChatGPT-style lead capture. The company is already set
+     from the clicked result; we ask for an email, then what to scrape, then
+     hand the request to Web3Forms. It collects a request and promises a
+     follow-up - it does not pretend to be a live AI returning data. ---- */
+
+  var chat = null; // { company, domain, email, step } while a chat is open
+
+  function makeEl(tag, cls, html) {
+    var e = document.createElement(tag);
+    if (cls) e.className = cls;
+    if (html != null) e.innerHTML = html;
+    return e;
+  }
+  function validEmail(s) {
+    return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(String(s).trim());
+  }
+  var ARROW = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.3" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg>';
+
+  function openScrapeChat(item) {
+    var domain = cleanDomain(item.desc) || cleanDomain(item.name);
+    chat = { company: item.name, domain: domain, email: "", step: "email" };
+
+    var overlay = makeEl("div", "chat-overlay");
+    overlay.id = "chat-overlay";
+    overlay.innerHTML =
+      '<div class="chat-panel" role="dialog" aria-modal="true" aria-label="Scrape request">' +
+        '<div class="chat-head">' +
+          '<span class="chat-glyph" id="chat-glyph">' + escapeHtml(initial(item.name)) + '</span>' +
+          '<div class="chat-head-body">' +
+            '<div class="chat-co">' + escapeHtml(item.name) + '</div>' +
+            '<div class="chat-dom">' + escapeHtml(domain) + '</div>' +
+          '</div>' +
+          '<button class="chat-close" id="chat-close" aria-label="Close">&#215;</button>' +
+        '</div>' +
+        '<div class="chat-body" id="chat-body"></div>' +
+        '<form class="chat-input" id="chat-form">' +
+          '<input id="chat-field" type="text" autocomplete="off" placeholder="Your email" aria-label="Message">' +
+          '<button class="chat-send" type="submit" aria-label="Send">' + ARROW + '</button>' +
+        '</form>' +
+      '</div>';
+    document.body.appendChild(overlay);
+    document.body.style.overflow = "hidden";
+
+    loadInto(overlay.querySelector("#chat-glyph"), [item.logo, item.logoFallback].filter(Boolean));
+    overlay.querySelector("#chat-close").addEventListener("click", closeChat);
+    overlay.addEventListener("mousedown", function (e) { if (e.target === overlay) closeChat(); });
+    document.addEventListener("keydown", chatEsc);
+    overlay.querySelector("#chat-form").addEventListener("submit", onChatSubmit);
+
+    botSay("Nice pick. Where should we send your <b>" + escapeHtml(domain) + "</b> data?", function () {
+      field().focus();
+    });
   }
 
-  function openTelegram(company) {
-    var url = "https://t.me/" + TELEGRAM + "?text=" + encodeURIComponent(scrapeMessage(company));
-    window.open(url, "_blank", "noopener");
+  function chatEsc(e) { if (e.key === "Escape") closeChat(); }
+  function closeChat() {
+    var o = document.getElementById("chat-overlay");
+    if (o) o.parentNode.removeChild(o);
+    document.body.style.overflow = "";
+    document.removeEventListener("keydown", chatEsc);
+    chat = null;
+  }
+  function body() { return document.getElementById("chat-body"); }
+  function field() { return document.getElementById("chat-field"); }
+  function scrollDown() { var b = body(); if (b) b.scrollTop = b.scrollHeight; }
+  function addMsg(cls, html) {
+    var b = body(); if (!b) return null;
+    var m = makeEl("div", "msg " + cls, html);
+    b.appendChild(m); scrollDown(); return m;
+  }
+  function userSay(text) { addMsg("user", escapeHtml(text)); }
+  function botSay(html, done) {
+    var t = addMsg("bot typing", '<span class="dots"><i></i><i></i><i></i></span>');
+    setTimeout(function () {
+      if (!t || !t.parentNode) return;
+      t.classList.remove("typing");
+      t.innerHTML = html;
+      scrollDown();
+      if (done) done();
+    }, 650);
+  }
+  function offerChips(list) {
+    var b = body(); if (!b) return;
+    var wrap = makeEl("div", "chips");
+    list.forEach(function (c) {
+      var chip = makeEl("button", "chip", escapeHtml(c));
+      chip.type = "button";
+      chip.addEventListener("click", function () {
+        if (wrap.parentNode) wrap.parentNode.removeChild(wrap);
+        sendRequest(c);
+      });
+      wrap.appendChild(chip);
+    });
+    b.appendChild(wrap); scrollDown();
+  }
+
+  function onChatSubmit(e) {
+    e.preventDefault();
+    if (!chat) return;
+    var fld = field();
+    var val = fld ? fld.value.trim() : "";
+    if (!val) { if (fld) fld.focus(); return; }
+
+    if (chat.step === "email") {
+      userSay(val);
+      fld.value = "";
+      if (!validEmail(val)) {
+        botSay("Hmm, that doesn't look like an email. Mind trying again?", function () { fld.focus(); });
+        return;
+      }
+      chat.email = val;
+      chat.step = "request";
+      botSay("Perfect. What do you want to scrape from <b>" + escapeHtml(chat.domain) + "</b>?", function () {
+        fld.placeholder = "e.g. all product prices and titles";
+        offerChips(["Prices and titles", "Reviews and ratings", "Product images", "Contact info"]);
+        fld.focus();
+      });
+      return;
+    }
+    if (chat.step === "request") { sendRequest(val); }
+  }
+
+  function sendRequest(reqText) {
+    if (!chat || chat.step === "sending" || chat.step === "done") return;
+    var fld = field();
+    if (fld) fld.value = "";
+    userSay(reqText);
+    chat.step = "sending";
+    if (fld) fld.placeholder = "Sending...";
+    var t = addMsg("bot typing", '<span class="dots"><i></i><i></i><i></i></span>');
+
+    var payload = {
+      access_key: WEB3FORMS_KEY,
+      subject: "ScrapeOrbit request: " + chat.company + " (" + chat.domain + ")",
+      from_name: "ScrapeOrbit",
+      company: chat.company,
+      website: chat.domain,
+      email: chat.email,
+      replyto: chat.email,
+      scrape_request: reqText,
+      botcheck: ""
+    };
+    fetch(WEB3FORMS_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "Accept": "application/json" },
+      body: JSON.stringify(payload)
+    }).then(function (r) { return r.json(); }).then(function (data) {
+      if (t && t.parentNode) t.parentNode.removeChild(t);
+      if (data && data.success) {
+        chat.step = "done";
+        botSay("On it. We'll email your <b>" + escapeHtml(chat.domain) + "</b> data to <b>" + escapeHtml(chat.email) + "</b> shortly.", lockInput);
+      } else {
+        chat.step = "request";
+        botSay("Something went wrong sending that. Try again in a moment?", function () { if (fld) { fld.placeholder = "Tell us what to scrape"; fld.focus(); } });
+      }
+    }).catch(function () {
+      if (t && t.parentNode) t.parentNode.removeChild(t);
+      chat.step = "request";
+      botSay("Couldn't reach the server. Check your connection and try again.", function () { if (fld) { fld.placeholder = "Tell us what to scrape"; fld.focus(); } });
+    });
+  }
+
+  function lockInput() {
+    var fld = field(), send = document.querySelector(".chat-send");
+    if (fld) { fld.disabled = true; fld.placeholder = "Request sent"; }
+    if (send) send.disabled = true;
   }
 
   function setStatus(text, kind) {
@@ -110,7 +272,7 @@
           '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2 3 14h7l-1 8 10-12h-7z"/></svg>' +
           "Scrape</button>";
       row.querySelector(".scrape-btn").addEventListener("click", function () {
-        openTelegram(it.name);
+        openScrapeChat(it);
       });
       results.appendChild(row);
     });

--- a/docs/index.html
+++ b/docs/index.html
@@ -30,7 +30,7 @@
     <span class="brand-name">Scrape<span class="brand-accent">Orbit</span></span>
   </a>
   <nav class="nav-links" aria-label="Primary">
-    <a class="nav-cta" href="https://t.me/federcr" target="_blank" rel="noopener">Talk to us</a>
+    <a class="nav-cta" href="https://github.com/feder-cr/invisible_playwright" target="_blank" rel="noopener">GitHub</a>
   </nav>
 </header>
 
@@ -97,8 +97,8 @@
       </article>
       <article class="feature">
         <span class="feat-key">DIRECT</span>
-        <h3>One-tap handoff</h3>
-        <p>The scrape button opens a direct channel with your target already in the message.</p>
+        <h3>Tell us what to pull</h3>
+        <p>Hit scrape, drop your email, and describe exactly what you need. We take it from there.</p>
       </article>
       <article class="feature">
         <span class="feat-key">STEALTH</span>
@@ -117,10 +117,9 @@
     <div class="cta-panel">
       <p class="section-tag">// ready when you are</p>
       <h2 class="cta-title">Name a company. We'll bring back the data.</h2>
-      <p class="cta-sub">Scroll up, run a scan, hit scrape. Or reach out directly.</p>
+      <p class="cta-sub">Scroll up, run a scan, and tell us exactly what to pull.</p>
       <div class="cta-row">
         <a class="btn-primary" href="#top">Run a scan</a>
-        <a class="btn-ghost" href="https://t.me/federcr" target="_blank" rel="noopener">Message on Telegram</a>
       </div>
     </div>
   </section>


### PR DESCRIPTION
The Scrape button now opens an in-page chat (company preset, email, then what to scrape) that submits via Web3Forms, instead of opening Telegram. Removes the two Telegram links from the site. Front-end only.