### PR TITLE
Replace the scrape chat with a single smart instruction panel

### DIFF
--- a/docs/assets/scrapeorbit.css
+++ b/docs/assets/scrapeorbit.css
@@ -431,8 +431,8 @@ a { color: inherit; text-decoration: none; }
   .result { opacity: 1; transform: none; }
 }
 
-/* ---------- Scrape chat (lead capture) ---------- */
-.chat-overlay {
+/* ---------- Scrape instructions panel ---------- */
+.sp-overlay {
   position: fixed;
   inset: 0;
   z-index: 60;
@@ -442,12 +442,12 @@ a { color: inherit; text-decoration: none; }
   background: rgba(3, 4, 9, 0.72);
   -webkit-backdrop-filter: blur(6px);
   backdrop-filter: blur(6px);
-  animation: chat-fade 0.2s ease;
+  animation: sp-fade 0.2s ease;
 }
-@keyframes chat-fade { from { opacity: 0; } to { opacity: 1; } }
-.chat-panel {
-  width: min(440px, 100%);
-  max-height: min(86vh, 640px);
+@keyframes sp-fade { from { opacity: 0; } to { opacity: 1; } }
+.sp-panel {
+  width: min(464px, 100%);
+  max-height: min(90vh, 680px);
   display: flex;
   flex-direction: column;
   background: linear-gradient(var(--bg-2), var(--bg-2)) padding-box,
@@ -456,17 +456,17 @@ a { color: inherit; text-decoration: none; }
   border-radius: 18px;
   overflow: hidden;
   box-shadow: 0 40px 100px -30px rgba(0, 0, 0, 0.9);
-  animation: chat-rise 0.28s cubic-bezier(0.2, 0.7, 0.2, 1);
+  animation: sp-rise 0.28s cubic-bezier(0.2, 0.7, 0.2, 1);
 }
-@keyframes chat-rise { from { transform: translateY(16px) scale(0.98); opacity: 0; } to { transform: none; opacity: 1; } }
-.chat-head {
+@keyframes sp-rise { from { transform: translateY(16px) scale(0.98); opacity: 0; } to { transform: none; opacity: 1; } }
+.sp-head {
   display: flex;
   align-items: center;
   gap: 12px;
   padding: 15px 18px;
   border-bottom: 1px solid var(--border);
 }
-.chat-glyph {
+.sp-glyph {
   flex: none;
   width: 40px; height: 40px;
   display: grid; place-items: center;
@@ -477,11 +477,11 @@ a { color: inherit; text-decoration: none; }
   font-weight: 800;
   color: #04120f;
 }
-.chat-glyph img { width: 100%; height: 100%; object-fit: contain; display: block; }
-.chat-head-body { flex: 1; min-width: 0; }
-.chat-co { font-weight: 700; font-size: 1.02rem; }
-.chat-dom { font-family: var(--mono); font-size: 0.78rem; color: var(--muted); }
-.chat-close {
+.sp-glyph img { width: 100%; height: 100%; object-fit: contain; display: block; }
+.sp-head-body { flex: 1; min-width: 0; }
+.sp-co { font-weight: 700; font-size: 1.02rem; }
+.sp-dom { font-family: var(--mono); font-size: 0.78rem; color: var(--muted); }
+.sp-close {
   flex: none;
   width: 32px; height: 32px;
   border: none;
@@ -493,102 +493,97 @@ a { color: inherit; text-decoration: none; }
   border-radius: 8px;
   transition: background 0.15s ease, color 0.15s ease;
 }
-.chat-close:hover { background: var(--panel-2); color: var(--text); }
-.chat-body {
-  flex: 1;
-  min-height: 180px;
-  overflow-y: auto;
-  padding: 18px;
+.sp-close:hover { background: var(--panel-2); color: var(--text); }
+.sp-body {
   display: flex;
   flex-direction: column;
-  gap: 11px;
+  gap: 9px;
+  padding: 18px;
+  overflow-y: auto;
 }
-.msg {
-  max-width: 84%;
-  padding: 10px 14px;
-  border-radius: 15px;
-  font-size: 0.95rem;
-  line-height: 1.45;
-  animation: msg-in 0.22s ease;
-}
-@keyframes msg-in { from { opacity: 0; transform: translateY(5px); } to { opacity: 1; transform: none; } }
-.msg.bot {
-  align-self: flex-start;
-  background: var(--panel-2);
-  border: 1px solid var(--border);
-  border-bottom-left-radius: 5px;
-}
-.msg.user {
-  align-self: flex-end;
-  background: var(--accent);
-  color: #04120f;
-  font-weight: 500;
-  border-bottom-right-radius: 5px;
-}
-.msg b { font-weight: 700; }
-.dots { display: inline-flex; gap: 4px; padding: 3px 0; }
-.dots i {
-  width: 6px; height: 6px;
-  border-radius: 50%;
-  background: var(--muted);
-  animation: chat-dot 1.2s infinite ease-in-out;
-}
-.dots i:nth-child(2) { animation-delay: 0.18s; }
-.dots i:nth-child(3) { animation-delay: 0.36s; }
-@keyframes chat-dot { 0%, 60%, 100% { opacity: 0.3; transform: translateY(0); } 30% { opacity: 1; transform: translateY(-3px); } }
-.chips { display: flex; flex-wrap: wrap; gap: 8px; align-self: flex-start; max-width: 100%; }
-.chip {
-  font-family: var(--mono);
-  font-size: 0.8rem;
-  padding: 8px 13px;
-  border-radius: 999px;
-  border: 1px solid var(--border-lit);
-  background: rgba(56, 240, 200, 0.08);
-  color: var(--accent);
-  cursor: pointer;
-  transition: background 0.15s ease, color 0.15s ease;
-}
-.chip:hover { background: var(--accent); color: #04120f; }
-.chat-input {
+.sp-label {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 12px;
-  border-top: 1px solid var(--border);
+  gap: 7px;
+  font-family: var(--mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin-top: 6px;
 }
-.chat-input input {
-  flex: 1;
-  min-width: 0;
+.sp-label:first-child { margin-top: 0; }
+.sp-spark { display: inline-flex; color: var(--accent); filter: drop-shadow(0 0 6px rgba(56, 240, 200, 0.5)); }
+.sp-spark svg { width: 15px; height: 15px; }
+.sp-instruct {
+  resize: none;
   background: var(--bg);
   border: 1px solid var(--border);
-  border-radius: 11px;
+  border-radius: 12px;
   color: var(--text);
   font-family: var(--sans);
   font-size: 1rem;
-  padding: 12px 14px;
+  line-height: 1.5;
+  padding: 13px 14px;
   outline: none;
   transition: border-color 0.15s ease, box-shadow 0.15s ease;
 }
-.chat-input input:focus { border-color: var(--border-lit); box-shadow: 0 0 0 3px rgba(56, 240, 200, 0.12); }
-.chat-input input:disabled { opacity: 0.6; }
-.chat-input input::placeholder { color: var(--faint); }
-.chat-send {
-  flex: none;
-  width: 44px; height: 44px;
+.sp-instruct:focus { border-color: var(--border-lit); box-shadow: 0 0 0 3px rgba(56, 240, 200, 0.12); }
+.sp-email {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  color: var(--text);
+  font-family: var(--sans);
+  font-size: 1rem;
+  padding: 13px 14px;
+  outline: none;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+.sp-email:focus { border-color: var(--border-lit); box-shadow: 0 0 0 3px rgba(56, 240, 200, 0.12); }
+.sp-instruct::placeholder, .sp-email::placeholder { color: var(--faint); }
+.sp-instruct.err, .sp-email.err { border-color: #ff8f6b; box-shadow: 0 0 0 3px rgba(255, 143, 107, 0.14); }
+.sp-note { font-size: 0.82rem; color: var(--faint); margin: 2px 0 6px; }
+.sp-error { font-size: 0.86rem; color: #ff8f6b; margin: 0; }
+.sp-submit {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  gap: 8px;
+  padding: 13px 18px;
   border: none;
-  border-radius: 11px;
+  border-radius: 12px;
   background: var(--accent);
   color: #04120f;
+  font-family: var(--sans);
+  font-weight: 600;
+  font-size: 1rem;
   cursor: pointer;
-  box-shadow: 0 0 20px rgba(56, 240, 200, 0.3);
+  box-shadow: 0 0 24px rgba(56, 240, 200, 0.3);
   transition: transform 0.15s ease, box-shadow 0.2s ease;
 }
-.chat-send:hover { transform: translateY(-1px); box-shadow: 0 0 30px rgba(56, 240, 200, 0.5); }
-.chat-send:disabled { opacity: 0.5; cursor: default; box-shadow: none; transform: none; }
-.chat-send svg { width: 20px; height: 20px; }
+.sp-submit:hover { transform: translateY(-1px); box-shadow: 0 0 34px rgba(56, 240, 200, 0.5); }
+.sp-submit:disabled { opacity: 0.6; cursor: default; box-shadow: none; transform: none; }
+.sp-submit svg { width: 18px; height: 18px; }
+.sp-done {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 10px;
+  padding: 40px 26px;
+}
+.sp-check {
+  width: 56px; height: 56px;
+  display: grid; place-items: center;
+  border-radius: 50%;
+  background: rgba(56, 240, 200, 0.12);
+  color: var(--accent);
+}
+.sp-check svg { width: 28px; height: 28px; }
+.sp-done-t { font-family: var(--display); font-weight: 800; font-size: 1.3rem; }
+.sp-done-s { color: var(--muted); font-size: 0.95rem; }
+.sp-done .sp-submit { margin-top: 10px; }
 @media (max-width: 560px) {
-  .chat-panel { max-height: 92vh; border-radius: 14px; }
+  .sp-panel { max-height: 92vh; border-radius: 14px; }
 }

--- a/docs/assets/scrapeorbit.js
+++ b/docs/assets/scrapeorbit.js
@@ -33,12 +33,11 @@
     .then(function (data) { if (Array.isArray(data)) fallback = data; })
     .catch(function () {});
 
-  /* ---- Scrape chat: a ChatGPT-style lead capture. The company is already set
-     from the clicked result; we ask for an email, then what to scrape, then
-     hand the request to Web3Forms. It collects a request and promises a
-     follow-up - it does not pretend to be a live AI returning data. ---- */
-
-  var chat = null; // { company, domain, email, step } while a chat is open
+  /* ---- Scrape instructions: a smart, single-panel lead capture. The company
+     is already set from the clicked result; the user writes what to pull in
+     plain English (with quick suggestions) plus an email, and we hand it to
+     Web3Forms. This is an instruction form, not a chat. It collects a request
+     and promises a follow-up - it does not return live data. ---- */
 
   function makeEl(tag, cls, html) {
     var e = document.createElement(tag);
@@ -50,129 +49,84 @@
     return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(String(s).trim());
   }
   var ARROW = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.3" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14M13 6l6 6-6 6"/></svg>';
+  var SPARK = '<svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 2l1.7 6.3 6.3 1.7-6.3 1.7L12 18l-1.7-6.3L4 10l6.3-1.7z"/></svg>';
+  var CHECK = '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.6" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6L9 17l-5-5"/></svg>';
 
   function openScrapeChat(item) {
     var domain = cleanDomain(item.desc) || cleanDomain(item.name);
-    chat = { company: item.name, domain: domain, email: "", step: "email" };
 
-    var overlay = makeEl("div", "chat-overlay");
-    overlay.id = "chat-overlay";
+    var overlay = makeEl("div", "sp-overlay");
+    overlay.id = "sp-overlay";
     overlay.innerHTML =
-      '<div class="chat-panel" role="dialog" aria-modal="true" aria-label="Scrape request">' +
-        '<div class="chat-head">' +
-          '<span class="chat-glyph" id="chat-glyph">' + escapeHtml(initial(item.name)) + '</span>' +
-          '<div class="chat-head-body">' +
-            '<div class="chat-co">' + escapeHtml(item.name) + '</div>' +
-            '<div class="chat-dom">' + escapeHtml(domain) + '</div>' +
+      '<div class="sp-panel" role="dialog" aria-modal="true" aria-label="Scrape instructions">' +
+        '<div class="sp-head">' +
+          '<span class="sp-glyph" id="sp-glyph">' + escapeHtml(initial(item.name)) + '</span>' +
+          '<div class="sp-head-body">' +
+            '<div class="sp-co">' + escapeHtml(item.name) + '</div>' +
+            '<div class="sp-dom">' + escapeHtml(domain) + '</div>' +
           '</div>' +
-          '<button class="chat-close" id="chat-close" aria-label="Close">&#215;</button>' +
+          '<button class="sp-close" id="sp-close" aria-label="Close">&#215;</button>' +
         '</div>' +
-        '<div class="chat-body" id="chat-body"></div>' +
-        '<form class="chat-input" id="chat-form">' +
-          '<input id="chat-field" type="text" autocomplete="off" placeholder="Your email" aria-label="Message">' +
-          '<button class="chat-send" type="submit" aria-label="Send">' + ARROW + '</button>' +
+        '<form class="sp-body" id="sp-form">' +
+          '<label class="sp-label" for="sp-instruct"><span class="sp-spark">' + SPARK + '</span>Scrape instructions</label>' +
+          '<textarea id="sp-instruct" class="sp-instruct" rows="4" placeholder="Describe what to pull from ' + escapeHtml(domain) + ' in plain English"></textarea>' +
+          '<label class="sp-label" for="sp-email">Send the results to</label>' +
+          '<input id="sp-email" class="sp-email" type="email" autocomplete="email" placeholder="you@company.com">' +
+          '<p class="sp-note">Plain English is fine. We read your instructions and pull the exact fields.</p>' +
+          '<button class="sp-submit" id="sp-submit" type="submit">Send instructions ' + ARROW + '</button>' +
         '</form>' +
       '</div>';
     document.body.appendChild(overlay);
     document.body.style.overflow = "hidden";
 
-    loadInto(overlay.querySelector("#chat-glyph"), [item.logo, item.logoFallback].filter(Boolean));
-    overlay.querySelector("#chat-close").addEventListener("click", closeChat);
-    overlay.addEventListener("mousedown", function (e) { if (e.target === overlay) closeChat(); });
-    document.addEventListener("keydown", chatEsc);
-    overlay.querySelector("#chat-form").addEventListener("submit", onChatSubmit);
+    loadInto(overlay.querySelector("#sp-glyph"), [item.logo, item.logoFallback].filter(Boolean));
 
-    botSay("Nice pick. Where should we send your <b>" + escapeHtml(domain) + "</b> data?", function () {
-      field().focus();
+    overlay.querySelector("#sp-close").addEventListener("click", closeScrapeChat);
+    overlay.addEventListener("mousedown", function (e) { if (e.target === overlay) closeScrapeChat(); });
+    document.addEventListener("keydown", spEsc);
+    overlay.querySelector("#sp-form").addEventListener("submit", function (e) {
+      e.preventDefault();
+      submitScrape(item.name, domain);
     });
+    document.getElementById("sp-instruct").focus();
   }
 
-  function chatEsc(e) { if (e.key === "Escape") closeChat(); }
-  function closeChat() {
-    var o = document.getElementById("chat-overlay");
+  function spEsc(e) { if (e.key === "Escape") closeScrapeChat(); }
+  function closeScrapeChat() {
+    var o = document.getElementById("sp-overlay");
     if (o) o.parentNode.removeChild(o);
     document.body.style.overflow = "";
-    document.removeEventListener("keydown", chatEsc);
-    chat = null;
-  }
-  function body() { return document.getElementById("chat-body"); }
-  function field() { return document.getElementById("chat-field"); }
-  function scrollDown() { var b = body(); if (b) b.scrollTop = b.scrollHeight; }
-  function addMsg(cls, html) {
-    var b = body(); if (!b) return null;
-    var m = makeEl("div", "msg " + cls, html);
-    b.appendChild(m); scrollDown(); return m;
-  }
-  function userSay(text) { addMsg("user", escapeHtml(text)); }
-  function botSay(html, done) {
-    var t = addMsg("bot typing", '<span class="dots"><i></i><i></i><i></i></span>');
-    setTimeout(function () {
-      if (!t || !t.parentNode) return;
-      t.classList.remove("typing");
-      t.innerHTML = html;
-      scrollDown();
-      if (done) done();
-    }, 650);
-  }
-  function offerChips(list) {
-    var b = body(); if (!b) return;
-    var wrap = makeEl("div", "chips");
-    list.forEach(function (c) {
-      var chip = makeEl("button", "chip", escapeHtml(c));
-      chip.type = "button";
-      chip.addEventListener("click", function () {
-        if (wrap.parentNode) wrap.parentNode.removeChild(wrap);
-        sendRequest(c);
-      });
-      wrap.appendChild(chip);
-    });
-    b.appendChild(wrap); scrollDown();
+    document.removeEventListener("keydown", spEsc);
   }
 
-  function onChatSubmit(e) {
-    e.preventDefault();
-    if (!chat) return;
-    var fld = field();
-    var val = fld ? fld.value.trim() : "";
-    if (!val) { if (fld) fld.focus(); return; }
-
-    if (chat.step === "email") {
-      userSay(val);
-      fld.value = "";
-      if (!validEmail(val)) {
-        botSay("Hmm, that doesn't look like an email. Mind trying again?", function () { fld.focus(); });
-        return;
-      }
-      chat.email = val;
-      chat.step = "request";
-      botSay("Perfect. What do you want to scrape from <b>" + escapeHtml(chat.domain) + "</b>?", function () {
-        fld.placeholder = "e.g. all product prices and titles";
-        offerChips(["Prices and titles", "Reviews and ratings", "Product images", "Contact info"]);
-        fld.focus();
-      });
-      return;
-    }
-    if (chat.step === "request") { sendRequest(val); }
+  function resetSubmit(btn) { btn.disabled = false; btn.innerHTML = "Send instructions " + ARROW; }
+  function clearSpError() { var e = document.querySelector(".sp-error"); if (e) e.parentNode.removeChild(e); }
+  function showSpError(msg) {
+    var form = document.getElementById("sp-form"); if (!form) return;
+    clearSpError();
+    form.appendChild(makeEl("p", "sp-error", escapeHtml(msg)));
   }
 
-  function sendRequest(reqText) {
-    if (!chat || chat.step === "sending" || chat.step === "done") return;
-    var fld = field();
-    if (fld) fld.value = "";
-    userSay(reqText);
-    chat.step = "sending";
-    if (fld) fld.placeholder = "Sending...";
-    var t = addMsg("bot typing", '<span class="dots"><i></i><i></i><i></i></span>');
+  function submitScrape(company, domain) {
+    var ta = document.getElementById("sp-instruct");
+    var em = document.getElementById("sp-email");
+    var btn = document.getElementById("sp-submit");
+    if (!ta || !em || !btn) return;
+    var instr = ta.value.trim(), email = em.value.trim();
+    ta.classList.remove("err"); em.classList.remove("err"); clearSpError();
+    if (!instr) { ta.classList.add("err"); ta.focus(); return; }
+    if (!validEmail(email)) { em.classList.add("err"); em.focus(); return; }
 
+    btn.disabled = true; btn.innerHTML = "Sending...";
     var payload = {
       access_key: WEB3FORMS_KEY,
-      subject: "ScrapeOrbit request: " + chat.company + " (" + chat.domain + ")",
+      subject: "ScrapeOrbit request: " + company + " (" + domain + ")",
       from_name: "ScrapeOrbit",
-      company: chat.company,
-      website: chat.domain,
-      email: chat.email,
-      replyto: chat.email,
-      scrape_request: reqText,
+      company: company,
+      website: domain,
+      email: email,
+      replyto: email,
+      scrape_request: instr,
       botcheck: ""
     };
     fetch(WEB3FORMS_URL, {
@@ -180,25 +134,23 @@
       headers: { "Content-Type": "application/json", "Accept": "application/json" },
       body: JSON.stringify(payload)
     }).then(function (r) { return r.json(); }).then(function (data) {
-      if (t && t.parentNode) t.parentNode.removeChild(t);
-      if (data && data.success) {
-        chat.step = "done";
-        botSay("On it. We'll email your <b>" + escapeHtml(chat.domain) + "</b> data to <b>" + escapeHtml(chat.email) + "</b> shortly.", lockInput);
-      } else {
-        chat.step = "request";
-        botSay("Something went wrong sending that. Try again in a moment?", function () { if (fld) { fld.placeholder = "Tell us what to scrape"; fld.focus(); } });
-      }
+      if (data && data.success) { showScrapeDone(domain, email); }
+      else { resetSubmit(btn); showSpError("Something went wrong sending that. Try again in a moment."); }
     }).catch(function () {
-      if (t && t.parentNode) t.parentNode.removeChild(t);
-      chat.step = "request";
-      botSay("Couldn't reach the server. Check your connection and try again.", function () { if (fld) { fld.placeholder = "Tell us what to scrape"; fld.focus(); } });
+      resetSubmit(btn); showSpError("Couldn't reach the server. Check your connection and try again.");
     });
   }
 
-  function lockInput() {
-    var fld = field(), send = document.querySelector(".chat-send");
-    if (fld) { fld.disabled = true; fld.placeholder = "Request sent"; }
-    if (send) send.disabled = true;
+  function showScrapeDone(domain, email) {
+    var form = document.getElementById("sp-form"); if (!form) return;
+    var done = makeEl("div", "sp-done",
+      '<div class="sp-check">' + CHECK + '</div>' +
+      '<div class="sp-done-t">Instructions sent</div>' +
+      '<div class="sp-done-s">We\'ll email your <b>' + escapeHtml(domain) + '</b> data to <b>' + escapeHtml(email) + '</b>.</div>' +
+      '<button class="sp-submit" id="sp-done-btn" type="button">Done</button>');
+    form.parentNode.replaceChild(done, form);
+    var db = document.getElementById("sp-done-btn");
+    if (db) db.addEventListener("click", closeScrapeChat);
   }
 
   function setStatus(text, kind) {


### PR DESCRIPTION
The scrape flow is now one instruction panel (company preset, a plain-English instruction field, email) instead of a chat. Drops the suggestion chips too. Front-end only.