### PR TITLE
Drop the empty-state search hint

### DIFF
--- a/docs/assets/scrapeorbit.js
+++ b/docs/assets/scrapeorbit.js
@@ -298,7 +298,7 @@
     if (timer) clearTimeout(timer);
     if (q.length < 2) {
       results.innerHTML = "";
-      setStatus("Start typing to search the live index.");
+      setStatus("");
       return;
     }
     timer = setTimeout(function () { runSearch(q); }, 240);

--- a/docs/index.html
+++ b/docs/index.html
@@ -53,7 +53,7 @@
               <svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"></path><path d="M13 6l6 6-6 6"></path></svg>
             </button>
           </div>
-          <p class="search-hint" id="status" aria-live="polite">Start typing to search the live index.</p>
+          <p class="search-hint" id="status" aria-live="polite"></p>
         </form>
 
         <div class="results" id="results" role="listbox" aria-label="Search results"></div>


### PR DESCRIPTION
Removes the "Start typing to search the live index." hint under the search bar. The status line still shows scanning and result counts.