### PR TITLE
0.7.1: the two gates that approved without looking

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "invisible_playwright"
-version = "0.7.0"
+version = "0.7.1"
 description = "Playwright wrapper for a patched Firefox with deterministic stealth profile."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
The font gate compared the visible families against a list that had stayed at 68 while the manifest declares 71, and that drift did not produce a red: it produced a green. The probe asks about the list and nothing else, so a family removed from it stops being searched, the count adds up on its own and the gate approves while blind to it. Measured on the real binary. A test now compares that list with what the core declares, and that test previously existed only in the docs.

And the enumerateDevices test has two limits instead of one, because with a single threshold a merely slow resolution was reported as a hang: the product's verdict written over the machine's. The hang wall stays absolute because a hang is infinite; slowness is measured against the machine.

The pin points at the core of firefox-20, already on the index.