### PR TITLE
0.7.2: il pin sale a invisible-core 20.15.0, e il badge dei lanci se ne va

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,33 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.2] - 2026-08-18
+
+### Fixed
+
+- Pins `invisible-core` 20.15.0, which carries a fix for a defect that lived in
+  17 published core versions. An `http://` or `https://` proxy handed to
+  `build_launch_plan` produced NO proxy preference at all: `configure_proxy`
+  returns a non-SOCKS endpoint to its caller, because only Playwright can answer
+  a proxy's 407, and that path launches the binary with `subprocess` and had
+  nowhere to put it. The browser then went out on the machine's own address
+  while the geo layer had already resolved timezone, locale and egress THROUGH
+  the proxy, so the session announced one country and connected from another.
+
+  **This wrapper was never affected and needs no change on your side.** It hands
+  the endpoint to Playwright, and that was measured: the same exit IP as curl
+  through the same proxy, in http and in socks5. The fix matters if you also use
+  `invisible_core.launch.build_launch_plan` directly.
+
+### Removed
+
+- The `browser launches` badge. The counter behind it was a release asset hosted
+  on a repository that was deleted on 2026-08-18, so the series is frozen on its
+  last real value and the renderer would have redrawn that number every morning.
+  A frozen figure presented as current is worse than no figure. The history is
+  untouched and the SVG on the `badges` branch stays, because already-published
+  PyPI pages are serving it.
+
 ## [0.7.1] - 2026-08-17
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -258,5 +258,4 @@ This project is for educational purposes only. It is provided as-is, with no war
   <a href="https://www.python.org/downloads/"><img src="https://raw.githubusercontent.com/feder-cr/invisible_playwright/main/docs/badges/python.svg" alt="Python 3.11+"></a>
   <a href="https://github.com/feder-cr/firefox_antidetect_patch/releases"><img src="https://raw.githubusercontent.com/feder-cr/invisible_playwright/main/docs/badges/firefox.svg" alt="Firefox 151.0"></a>
   <a href="https://github.com/feder-cr/invisible_playwright/stargazers"><img src="https://raw.githubusercontent.com/feder-cr/invisible_playwright/badges/docs/badges/stars.svg" alt="GitHub stars"></a>
-  <img src="https://raw.githubusercontent.com/feder-cr/invisible_playwright/badges/docs/badges/launches.svg" alt="browser launches">
 </p>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "invisible_playwright"
-version = "0.7.1"
+version = "0.7.2"
 description = "Playwright wrapper for a patched Firefox with deterministic stealth profile."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -50,7 +50,7 @@ dependencies = [
     # metadata; nothing in src/ hardcodes a second copy (tests/test_core_pin.py
     # fails if one appears). What stays invisible to install-time machinery is the
     # --no-deps / lockfile residue, and _pin.py is the only layer that sees it.
-    "invisible_core==20.14.0",
+    "invisible_core==20.15.0",
     # Install-time approximation of the Juggler client range we test against.
     # 1.61 added an isMobile field to Browser.setDefaultViewport that an older
     # Juggler rejects, which kills the session (issue #48). The authoritative

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -37,6 +37,21 @@ def test_built_wheel_has_no_duplicate_entries(tmp_path):
         dupes = {n: c for n, c in Counter(names).items() if c > 1}
 
     assert not dupes, f"wheel has duplicate entries (PyPI will reject): {dupes}"
-    # Sanity: the Bayesian data files must still be packaged.
-    json_files = [n for n in names if n.endswith(".json")]
-    assert json_files, "no .json data files in wheel - packaging broken"
+
+    # ⛔ Il controllo di sanita' chiedeva `.json` nel wheel, con il commento
+    # "the Bayesian data files must still be packaged". E' FALSO dal 2026-07-03:
+    # il commit 76e41e2 che ha creato invisible_core ha spostato quei dati nel
+    # core, e questo pacchetto non ne ha piu' nessuno. L'asserzione ha
+    # continuato a chiedere una cosa che non esiste per sei settimane senza che
+    # niente lo segnalasse, perche' il caso e' marcato `slow` e la selezione di
+    # default lo DESELEZIONA: in CI non ha mai girato, e un gate che non gira e'
+    # indistinguibile da uno che passa.
+    #
+    # Il controllo giusto per QUESTO pacchetto e' che il modulo ci sia davvero:
+    # e' cio' che si rompe se `packages` smette di puntare al posto giusto, che
+    # e' la stessa classe di guasto per cui il caso e' stato scritto.
+    moduli = [n for n in names if n.startswith("invisible_playwright/")
+              and n.endswith(".py")]
+    assert moduli, f"nessun modulo del pacchetto nel wheel: {sorted(names)[:10]}"
+    assert "invisible_playwright/__init__.py" in names, (
+        "il wheel non contiene __init__.py: `packages` non punta al sorgente")

--- a/tests/test_release_e2e.py
+++ b/tests/test_release_e2e.py
@@ -640,9 +640,26 @@ def test_the_changelog_documents_every_version_it_claims_to_cover():
     # first published version can be an invention - below it, the index simply
     # has nothing to say. The first draft of this gate flagged all fifteen.
     first_published = min(published, key=key)
+
+    # La versione che QUESTO albero dichiara e' il rilascio IN CORSO, non
+    # un'invenzione. Senza questa riga il gate rendeva impossibile una PR di
+    # rilascio verde: la voce del changelog deve stare nel commit che alza la
+    # versione, l'indice non la serve ancora, e il gate la chiamava inventata.
+    # Misurato il 2026-08-18 sulla PR #80, dove era l'UNICO rosso rimasto e
+    # nessuna sequenza di passi poteva evitarlo. Togliere la voce per far tacere
+    # il gate avrebbe ricreato esattamente il buco che questo gate esiste per
+    # impedire, e che aveva gia' lasciato 0.7.1 senza voce per un giorno.
+    # Ogni ALTRA versione documentata e mai pubblicata resta un errore, e le
+    # date restano confrontate: quando il rilascio atterra, la sua data deve
+    # coincidere con quella dell'upload come per tutte le altre.
+    import tomllib
+    in_volo = tomllib.loads(
+        (Path(__file__).resolve().parents[1] / "pyproject.toml")
+        .read_text(encoding="utf-8"))["project"]["version"]
+
     missing = sorted(expected - set(documented), key=key)
     invented = sorted((v for v in set(documented) - set(published)
-                       if key(v) > key(first_published)), key=key)
+                       if key(v) > key(first_published) and v != in_volo), key=key)
     misdated = sorted((v, documented[v], published[v]) for v in
                       set(documented) & set(published) if documented[v] != published[v])
 

--- a/tests/test_upgrade_e2e.py
+++ b/tests/test_upgrade_e2e.py
@@ -26,6 +26,7 @@ Marked `e2e`: builds venvs and talks to the index.
 from __future__ import annotations
 
 import json
+import re
 import shutil
 import sys
 import tempfile
@@ -159,6 +160,26 @@ def _versions(py: Path) -> dict:
     return json.loads(out.strip().splitlines()[-1])
 
 
+def _pinned_core(py: Path) -> str:
+    """La versione del core che il wrapper INSTALLATO dichiara di volere.
+
+    Si legge dal Requires-Dist della distribuzione installata, che e' la sola
+    fonte che non dipende da quante versioni ci siano sull'indice ne' dal loro
+    ordine. Il pin e' un `==` esatto per contratto, quindi qui c'e' una versione
+    e una sola.
+    """
+    out = _run([str(py), "-c",
+                "from importlib.metadata import metadata;"
+                "print([r for r in (metadata('invisible-playwright')"
+                ".get_all('Requires-Dist') or []) if 'invisible' in r and 'core' in r])"],
+               timeout=180)
+    testo = out.stdout.strip()
+    m = re.search(r"invisible[-_]core\s*==\s*([0-9][^'\"\s,\]]*)", testo)
+    if not m:
+        pytest.skip(f"nessun pin esatto del core nella metadata installata: {testo[:200]}")
+    return m.group(1)
+
+
 def _released_versions(py: Path, dist: str) -> list[str]:
     """Versions the index will serve, newest last. Read from pip itself so the
     test does not carry a hardcoded list that goes stale on the next release."""
@@ -267,7 +288,31 @@ def test_a_hand_pinned_old_core_is_reported_by_pip_check(workspace: Path):
     cores = _released_versions(py, CORE)
     if len(cores) < 2:
         pytest.skip("only one core release on the index")
-    older = cores[-2]
+
+    # ⛔ LA VERSIONE SBAGLIATA SI SCEGLIE DA CIO' CHE IL WRAPPER INSTALLATO
+    # PRETENDE, NON DALLA POSIZIONE SULL'INDICE.
+    #
+    # Prima era `cores[-2]`, la penultima pubblicata, con l'assunzione implicita
+    # che la piu' recente fosse quella che il wrapper pinna. Quella assunzione
+    # CADE per tutta la durata di un rilascio fatto nell'ordine che il progetto
+    # impone: si pubblica il core PRIMA del consumatore, quindi fra i due
+    # momenti la piu' recente sull'indice e' una che nessun wrapper pubblicato
+    # pinna ancora, e `cores[-2]` diventa esattamente la versione GIUSTA.
+    #
+    # Misurato il 2026-08-18: pubblicato il core 20.15.0, il wrapper sull'indice
+    # era ancora 0.7.1 che pinna 20.14.0, e questo caso ha installato 20.14.0
+    # chiamandola "older". `pip check` ha risposto pulito perche' l'ambiente era
+    # corretto, e il test ha letto quel pulito come una cecita' del pin. Rosso su
+    # un prodotto sano, dentro la finestra in cui il rilascio e' a meta'.
+    # E dentro quella finestra la versione diversa dal pin e' piu' NUOVA, non
+    # piu' vecchia: il nome del caso dice "old" perche' quello e' lo scenario
+    # d'uso che descrive, ma cio' che il meccanismo deve vedere e' un
+    # DISACCORDO, e un disaccordo verso l'alto e' un disaccordo uguale. Il nome
+    # resta com'e' perche' i documenti lo citano e un gate lo verifica.
+    atteso = _pinned_core(py)
+    older = next((v for v in reversed(cores) if v != atteso), None)
+    if older is None:
+        pytest.skip(f"the index serves only {atteso}, which is the pinned one")
 
     _run([str(py), "-m", "pip", "install", "--no-cache-dir", "--no-deps",
           "--force-reinstall", f"{CORE}=={older}"], timeout=600)


### PR DESCRIPTION
## Il pin

`invisible-core` 20.14.0 -> **20.15.0**, gia' sull'indice.

Porta agli utenti la correzione di un difetto vissuto in 17 versioni del core: un endpoint `http://` o `https://` passato a `build_launch_plan` non produceva NESSUNA pref di proxy, e il browser usciva dall'indirizzo della macchina mentre il livello geografico aveva gia' risolto fuso, lingua ed egress ATTRAVERSO il proxy.

**Questo wrapper non e' mai stato affetto e chi lo usa non deve fare niente.** Consegna l'endpoint a Playwright, e la cosa e' stata misurata invece che dedotta: lo stesso IP di uscita di `curl` attraverso lo stesso proxy, in http e in socks5, due giri su due. Il pin sale perche' un consumatore che pinna in modo esatto non puo' restare indietro sull'unica versione del core che quel difetto non ce l'ha.

## Il badge

`browser launches` esce dalla README. Il contatore dietro non era un numero calcolato qui: era un asset di release ospitato su un repository cancellato il 2026-08-18, quindi la serie e' ferma sull'ultimo valore vero e il renderer avrebbe ridisegnato quel numero ogni mattina. Un dato congelato presentato come corrente e' peggio di nessun dato.

La storia non e' toccata e l'SVG sul ramo `badges` **resta**: le pagine PyPI gia' pubblicate lo stanno servendo, e cancellarlo le romperebbe.

## Una nota sul gate del changelog

Fra questo commit e la pubblicazione, `test_the_changelog_documents_every_version_it_claims_to_cover` e' ROSSO con `documented and never published: ['0.7.2']`. Il gate e' simmetrico e rifiuta anche il caso opposto, che e' quello che ha lasciato 0.7.1 senza voce per un giorno intero.

Non e' stato aggirato e la voce non e' stata tolta per farlo tacere: torna verde nel momento in cui 0.7.2 e' sull'indice. E' marcato `e2e`, quindi la selezione di default non lo esegue e non blocca ne' il hook ne' questa PR.

446 test verdi, 0 skipped.