### PR TITLE
Il controllo sul registro andava rosso su un rilascio riuscito

### DIFF
--- a/tests/test_release_e2e.py
+++ b/tests/test_release_e2e.py
@@ -544,7 +544,30 @@ def test_the_published_version_has_a_github_release():
         recorded = {e["version"]: e for e in
                     json.loads(ledger_path.read_text(encoding="utf-8"))["released"]}
 
-    unrecorded = [v for v in live if recorded and v not in recorded]
+    # ⛔ LA VERSIONE CHE QUESTO ALBERO DICHIARA E' ESENTE, e solo lei.
+    #
+    # Il registro non puo' arrivare su main insieme alla pubblicazione: publish.yml
+    # pubblica su PyPI e POI prova a spingere PUBLISHED.json, ma main e' protetto e
+    # la spinta diretta viene rifiutata sempre, per costruzione. La voce finisce su
+    # un ramo ledger/<versione> la cui PR resta bloccata da sola ([B136]), quindi
+    # fra la pubblicazione e il merge a mano l'indice ha la versione e il registro
+    # no. Senza questa riga il caso e' ROSSO su un rilascio andato a buon fine, ed
+    # e' la QUARTA occorrenza della stessa forma trovata il 2026-08-18: un
+    # controllo scritto guardando lo stato a regime che diventa rosso esattamente
+    # quando serve.
+    #
+    # L'esenzione non apre un buco permanente, e la ragione e' che si richiude da
+    # sola. Se quel ramo del registro non viene mai unito, al rilascio successivo
+    # la versione rimasta indietro non e' piu' quella dichiarata dall'albero:
+    # ricade in unrecorded e il caso torna rosso. E' lo stesso modello che il
+    # commento qui sopra descrive per version_gate - una pubblicazione fuori dal
+    # cancello resta invisibile fino al rilascio dopo, che la rifiuta.
+    import tomllib
+    in_volo = tomllib.loads(
+        (Path(__file__).resolve().parents[1] / "pyproject.toml")
+        .read_text(encoding="utf-8"))["project"]["version"]
+
+    unrecorded = [v for v in live if recorded and v not in recorded and v != in_volo]
     thin = {v: [k for k in ("published_at", "requires_dist", "wheel_filename",
                             "sdist_filename", "wheel", "sdist")
                 if k not in recorded[v]]


### PR DESCRIPTION
Quarta occorrenza della stessa forma trovata stanotte, e questa non l'ho cercata: e' uscita da un audit che ha letto 363 controlli chiedendo a ognuno se puo' essere verde mentre un rilascio e' a meta'.

## Il difetto

Il sotto-controllo sul registro dentro `test_the_published_version_has_a_github_release` confronta `PUBLISHED.json`, letto dall'albero, con le versioni che l'indice serve. Ma il registro non puo' arrivare su `main` insieme alla pubblicazione: `publish.yml` pubblica su PyPI e poi prova a spingere `PUBLISHED.json`, `main` e' protetto e la spinta diretta viene rifiutata sempre per costruzione, quindi la voce finisce su un ramo `ledger/<versione>` la cui PR resta bloccata da sola per il difetto B136 gia' aperto.

Fra la pubblicazione e il merge a mano, l'indice ha la versione e il registro no.

## Non e' teorico, e' misurato adesso

Con 0.7.2 sull'indice e non ancora nel registro:

| | |
|---|---|
| il caso **senza** questo rimedio | ROSSO: `on the index and NOT in PUBLISHED.json: ['0.7.2']` |
| il caso **con** questo rimedio | verde |

Senza la correzione, quel controllo sarebbe diventato rosso su un rilascio andato a buon fine, e domani qualcuno avrebbe cercato un guasto nel prodotto.

## L'esenzione, e perche' non apre un buco

Esente e' **solo** la versione che l'albero dichiara nel suo `pyproject`. Se il ramo del registro non viene mai unito, al rilascio successivo la versione rimasta indietro non e' piu' quella dichiarata: ricade in `unrecorded` e il caso torna rosso. E' lo stesso modello che il commento accanto descrive gia' per `version_gate`, dove una pubblicazione fuori dal cancello resta invisibile fino al rilascio dopo, che la rifiuta.

Nello stesso file, poche righe sotto, c'era gia' l'esenzione scritta un'ora prima per il gate del changelog: la stessa cura, sul controllo accanto, mai applicata.

## Prova con input noto-cattivo

Tolta `0.7.0` dal registro, cioe' una versione **non** in volo: il caso diventa rosso. Rimessa: verde. L'esenzione non rende cieco il controllo su tutto il resto.