### PR TITLE
La prima immagine della README era un 404, e il primo badge portava a un sito morto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -401,8 +401,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Linux x86_64 and Windows x86_64 binary support.
 
 [0.4.3]: https://github.com/feder-cr/invisible_playwright/releases/tag/v0.4.3
-[0.1.1]: https://github.com/feder-cr/invisible_playwright/compare/v0.1.0...v0.1.1
-[0.1.0]: https://github.com/feder-cr/invisible_playwright/releases/tag/v0.1.0
+> Le due voci piu' vecchie puntano a COMMIT e non a tag: 0.1.0 e 0.1.1
+> precedono l'arrivo su PyPI (l'indice parte da 0.3.5) e non hanno mai
+> avuto un tag. Crearne uno oggi non e' innocuo: `publish.yml` si innesca
+> su `v*`, e per una versione che l'indice non serve `already-published`
+> non corto-circuita, quindi un tag nuovo puo' far partire un tentativo di
+> pubblicazione. Il commit e' la stessa informazione senza quel rischio.
+
+[0.1.1]: https://github.com/feder-cr/invisible_playwright/compare/7a983e99c53fa1ec1a443651a4dd9de42258dc61...589c848e07a67c459969a2ddfb79851f48b10eff
+[0.1.0]: https://github.com/feder-cr/invisible_playwright/commit/7a983e99c53fa1ec1a443651a4dd9de42258dc61
 [0.4.4]: https://github.com/feder-cr/invisible_playwright/releases/tag/v0.4.4
 [0.4.5]: https://github.com/feder-cr/invisible_playwright/releases/tag/v0.4.5
 [0.4.6]: https://github.com/feder-cr/invisible_playwright/releases/tag/v0.4.6

--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 <p align="center">
-  <a href="https://feder-cr.github.io/invisible_playwright/"><img src="https://raw.githubusercontent.com/feder-cr/invisible_playwright/main/docs/scrapeorbit-demo.gif" alt="ScrapeOrbit - find and scrape any company on Earth" width="760"></a>
+  <img src="https://raw.githubusercontent.com/feder-cr/invisible_playwright/65b72741a9f8f9fbae05ba17379a16b511b2d90e/docs/scrapeorbit-demo.gif" alt="ScrapeOrbit - find and scrape any company on Earth" width="760">
 </p>
 <p align="center">
   <b>Find and scrape any company on Earth.</b>
 </p>
 <p align="center">
-  <a href="https://feder-cr.github.io/invisible_playwright/"><img src="https://img.shields.io/badge/%E2%96%B6_Try_it_live-38f0c8?style=for-the-badge" alt="Try it live"></a>
 </p>
 
 <h2></h2>


### PR DESCRIPTION
Trovati controllando i link uno per uno invece di leggerli: **2814 link relativi** nella documentazione dei due pacchetti (zero rotti) e **42 URL assoluti** verso repo nostri, di cui quattro non rispondevano 200.

## Pages non esiste piu'

L'API risponde 404 per `invisible_playwright`, `invisible_core` e `firefox_antidetect_patch`, e il sito stesso da 404. La README lo linkava in due punti, e uno era **il primo badge in cima**, `Try it live`. Rimossi entrambi; il link che avvolgeva la GIF di apertura sparisce, l'immagine resta.

## La GIF di apertura era rotta

Il guasto peggiore, perche' era la prima cosa che si vedeva aprendo la pagina del progetto. `docs/scrapeorbit-demo.gif` e' tracciata in locale e il commit che l'ha aggiunta e' antenato di `main`, ma il file **non e' piu' nell'albero di main**: `raw.githubusercontent` risponde 404.

Il rimedio era gia' in uso in questo stesso file e non l'ho inventato: `hero.gif` e' puntato a uno **SHA fisso**, e per questo risponde 200 pur essendo anche lei fuori da `main`. Ora la GIF di apertura punta a `65b7274`, che la contiene. Verificato: 200, 1706550 byte.

## Il changelog puntava a due tag mai esistiti

`[0.1.1]` e `[0.1.0]` rimandavano a `compare/v0.1.0...v0.1.1` e `releases/tag/v0.1.0`. Nessuno dei due tag esiste: quelle versioni precedono l'arrivo su PyPI, dove l'indice parte da 0.3.5, e il riempimento dei tag fatto a suo tempo era guidato dall'indice.

La prova di dove vivevano c'era (`git log -S` sul pyproject: `7a983e9` per 0.1.0, `589c848` per 0.1.1), quindi **creare i tag era possibile**. Non e' stato fatto, per un rischio concreto: `publish.yml` si innesca sui tag `v*`, e per una versione che l'indice non serve `already-published` non corto-circuita, quindi un tag nuovo su 0.1.0 puo' far partire un tentativo di pubblicarla. I link puntano ai commit, che sono la stessa informazione senza inneschi, e la ragione e' scritta nel file accanto perche' il prossimo che li vede diversi dagli altri non li "sistemi".

## Verifica

Tutte e nove le immagini della README ricontrollate dopo la modifica: zero rotte. Dei sei link `href`, due rispondono male e **nessuno dei due e' un difetto**: LinkedIn da 999, che e' il suo codice anti-bot, e `/stargazers` da 404 a un client non-browser mentre l'API ne conta 1901 e il repo e' pubblico e sano.