### PR TITLE
Le due voci piu' vecchie del changelog puntavano a tag mai esistiti

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -401,8 +401,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Linux x86_64 and Windows x86_64 binary support.
 
 [0.4.3]: https://github.com/feder-cr/invisible_playwright/releases/tag/v0.4.3
-[0.1.1]: https://github.com/feder-cr/invisible_playwright/compare/v0.1.0...v0.1.1
-[0.1.0]: https://github.com/feder-cr/invisible_playwright/releases/tag/v0.1.0
+> Le due voci piu' vecchie puntano a COMMIT e non a tag: 0.1.0 e 0.1.1
+> precedono l'arrivo su PyPI (l'indice parte da 0.3.5) e non hanno mai
+> avuto un tag. Crearne uno oggi non e' innocuo: `publish.yml` si innesca
+> su `v*`, e per una versione che l'indice non serve `already-published`
+> non corto-circuita, quindi un tag nuovo puo' far partire un tentativo di
+> pubblicazione. Il commit e' la stessa informazione senza quel rischio.
+
+[0.1.1]: https://github.com/feder-cr/invisible_playwright/compare/7a983e99c53fa1ec1a443651a4dd9de42258dc61...589c848e07a67c459969a2ddfb79851f48b10eff
+[0.1.0]: https://github.com/feder-cr/invisible_playwright/commit/7a983e99c53fa1ec1a443651a4dd9de42258dc61
 [0.4.4]: https://github.com/feder-cr/invisible_playwright/releases/tag/v0.4.4
 [0.4.5]: https://github.com/feder-cr/invisible_playwright/releases/tag/v0.4.5
 [0.4.6]: https://github.com/feder-cr/invisible_playwright/releases/tag/v0.4.6


### PR DESCRIPTION
`[0.1.1]` e `[0.1.0]` in fondo al file rimandavano a `compare/v0.1.0...v0.1.1` e `releases/tag/v0.1.0`. **Nessuno dei due tag esiste**: quelle versioni precedono l'arrivo su PyPI, dove l'indice parte da 0.3.5, e il riempimento dei tag mancanti fatto a suo tempo era guidato dall'indice, quindi non poteva raggiungerle. Due 404 in fondo a un file che i lettori aprono per capire cosa e' cambiato.

La prova di dove vivevano c'era: `git log -S` sul pyproject da `7a983e9` per 0.1.0 ("feat: initial public release") e `589c848` per 0.1.1.

## Perche' non ho creato i tag

Era possibile e il progetto lo ha gia' fatto per altre versioni. Non l'ho fatto per un rischio concreto: `publish.yml` si innesca sui tag `v*`, e per una versione che l'indice non serve `already-published` non corto-circuita. Un tag nuovo su 0.1.0 puo' far partire un tentativo di pubblicarla.

I link puntano ai commit, che sono la stessa informazione senza inneschi, ed entrambi rispondono 200. Accanto c'e' una riga che spiega perche' quei due sono diversi da tutti gli altri, cosi' il prossimo che li vede non li "sistema" trasformandoli in tag.

## Nota su cosa NON c'e' in questa PR

Nasce da una precedente, la #85, che ho chiuso perche' la diagnosi era sbagliata: avevo letto come guasto la GIF di apertura che dava 404, mentre era stata **rimossa apposta** con #83 e #84. Quel rimedio l'avrebbe resuscitata. Qui resta solo la parte indipendente e ancora valida.