### PR TITLE
Via l'attesa dopo ogni scheda nuova: la causa e' chiusa nel motore

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Thanks for your interest in improving this project. Contributions are welcome vi
 - **Bug?** Open a [bug report](https://github.com/feder-cr/invisible_playwright/issues/new?template=bug_report.yml).
 - **Idea?** Open a [feature request](https://github.com/feder-cr/invisible_playwright/issues/new?template=feature_request.yml).
 - **Security issue?** Do **not** open a public issue - see [SECURITY.md](SECURITY.md).
-- **The C++ patches** live in the companion repo [feder-cr/firefox_antidetect_patch](https://github.com/feder-cr/firefox_antidetect_patch) (branch `stealth/150`). Bugs in fingerprint spoofing usually belong there.
+- **The C++ patches** live in the companion repo [feder-cr/firefox_antidetect_patch](https://github.com/feder-cr/firefox_antidetect_patch) (branch `stealth/151`). Bugs in fingerprint spoofing usually belong there.
 
 ## Scope
 

--- a/scripts/ci_drive_gate.py
+++ b/scripts/ci_drive_gate.py
@@ -6,7 +6,7 @@ binary renders a screenshot just fine and ships broken (firefox-8 did exactly
 that). This DRIVES the binary the way users will - Playwright launches it over
 the juggler pipe and exercises real paths.
 
-Two levels (see `--full`):
+Three levels (see `--click` / `--full`):
 
   SMOKE (default - run on ALL 5 legs, on every binary's native runner):
     launch over juggler-pipe → navigate a real http://127.0.0.1 page → assert a
@@ -18,13 +18,31 @@ Two levels (see `--full`):
     into "context destroyed" / selector-timeout / eval-CSP), so the gate that
     must be GREEN on every leg stays minimal and reliable.
 
+  CLICK (`--click` - run on every leg that is not FULL):
+    SMOKE plus ONE mouse move and ONE click, asserting both reached the page.
+    Nothing else. It exists because the FULL level below could not run there,
+    and that left the mouse untested on the only platforms where it can break.
+
+    ⛔ THE SENTENCE THIS REPLACES WAS WRONG, AND A REAL DEFECT PROVED IT.
+    It read: "the interaction code is platform-identical JS (it lives in
+    omni.ja), so exercising it on one reliable leg catches a regression for ALL
+    platforms". Measured 2026-08-19: a build with MOZILLA_OFFICIAL=1 shows the
+    terms-of-use PREONBOARDING MODAL, a full-viewport chrome overlay that
+    swallows every mouse event - focus stays on BODY, zero mousedown, zero
+    mousemove - while the keyboard keeps working. `browser/app/profile/firefox.js`
+    disables preonboarding under `#ifdef XP_LINUX`, so **Linux is immune**: the
+    one leg that tested the mouse was the one leg that could not see it. All
+    five legs would have been green on a binary whose mouse was dead on Windows
+    and macOS, which is the target platform.
+
+    Kept LIGHT on purpose: the flakiness that made FULL Linux-only came from a
+    heavy interaction sequence, not from a single click. One move plus one click
+    is enough for this defect class - it produces zero events, not wrong ones.
+
   FULL (`--full` - run on the historically-reliable Linux leg):
-    SMOKE plus mouse + keyboard input (firefox-2 / issue #9:
+    CLICK plus keyboard input (firefox-2 / issue #9:
     jugglerSendMouseEvent/synthesizeMouseEvent), canvas determinism (stealth
-    seed must be per-session), and navigator-surface tells. The interaction code
-    is platform-identical JS (it lives in omni.ja), so exercising it on one
-    reliable leg catches a regression for ALL platforms; win interaction is
-    additionally covered by local pre-release testing.
+    seed must be per-session), and navigator-surface tells.
 
 NOT covered here: WebGL determinism (needs SWGL, false-fails headless) and the
 faithful cross-origin iframe test (issue #20) - both live in the local realness
@@ -36,7 +54,7 @@ re-normalized / carry an eval-blocking CSP), arrow-function evaluates (never
 eval'd), and up to 2 retries on transient context-destroyed/detached/timeout.
 A genuinely broken binary fails ALL attempts → the gate fails.
 
-Usage:  python ci_drive_gate.py <firefox-binary> [--full]
+Usage:  python ci_drive_gate.py <firefox-binary> [--click | --full]
 Exit 0 + "DRIVE GATE OK ..." on success; non-zero with a reason on failure.
 """
 from __future__ import annotations
@@ -104,8 +122,10 @@ _REALISTIC_PREFS = {
 }
 
 
-def _drive(exe: str, url: str, full: bool) -> str:
-    """One full drive attempt. Returns the UA on success; raises on failure."""
+def _drive(exe: str, url: str, livello: str) -> str:
+    """Un giro. `livello` e' "smoke", "click" o "full". Torna la UA."""
+    interagisce = livello in ("click", "full")
+    full = livello == "full"
     from playwright.sync_api import sync_playwright
 
     with sync_playwright() as p:
@@ -120,16 +140,17 @@ def _drive(exe: str, url: str, full: bool) -> str:
             text = page.evaluate("() => document.getElementById('x').textContent")
 
             inter = {}
-            if full:
-                # firefox-2 / issue-#9 catcher: real mouse + keyboard over juggler.
+            if interagisce:
+                # firefox-2 / issue-#9 catcher: real mouse over juggler.
                 page.wait_for_selector("#b")
                 page.mouse.move(20, 20)
                 page.mouse.move(120, 90)          # synthesizeMouseEvent path
                 page.click("#b")                  # mousedown/up/click → listener fires
-                page.click("#inp")
-                page.keyboard.type("ok")
                 inter["clicked"] = page.evaluate("() => window.__clicked")
                 inter["moves"] = page.evaluate("() => window.__moves")
+            if full:
+                page.click("#inp")
+                page.keyboard.type("ok")
                 inter["typed"] = page.evaluate("() => document.getElementById('inp').value")
                 inter["canvas_a"] = page.evaluate(CANVAS_DRAW)
                 inter["canvas_b"] = page.evaluate(CANVAS_DRAW)
@@ -143,9 +164,10 @@ def _drive(exe: str, url: str, full: bool) -> str:
     assert text == "hello-drive", f"DOM/JS roundtrip failed: {text!r}"
     assert not webdriver, f"navigator.webdriver leaked True (stealth regression): {webdriver!r}"
 
+    if interagisce:
+        assert inter["clicked"] == 1, "page.click() did not fire the click listener - mouse-event synthesis broken (firefox-2 class), or a chrome overlay is swallowing input (terms-of-use modal: see browser/app/profile/firefox.js, termsofuse.acceptedDate)"
+        assert inter["moves"] >= 1, "page.mouse.move() produced no mousemove - jugglerSendMouseEvent regression, or a chrome overlay is swallowing input"
     if full:
-        assert inter["clicked"] == 1, "page.click() did not fire the click listener - mouse-event synthesis broken (firefox-2 class)"
-        assert inter["moves"] >= 1, "page.mouse.move() produced no mousemove - jugglerSendMouseEvent regression"
         assert inter["typed"] == "ok", f"page.keyboard.type() failed: {inter['typed']!r}"
         assert inter["canvas_a"] == inter["canvas_b"], "canvas non-deterministic across identical draws (stealth seed broken → bot tell)"
         assert inter["langs"] and inter["langs"] > 0, "navigator.languages empty (headless tell)"
@@ -153,16 +175,18 @@ def _drive(exe: str, url: str, full: bool) -> str:
     return ua
 
 
-def main(exe: str, full: bool) -> int:
+def main(exe: str, livello: str) -> int:
     srv, port = _start_server()
     url = f"http://127.0.0.1:{port}/"
-    level = "full" if full else "smoke"
-    extras = "http+click+mousemove+keyboard+canvas-determinism+navsurface" if full else "http+ua+webdriver+dom"
+    level = livello
+    extras = {"full": "http+click+mousemove+keyboard+canvas-determinism+navsurface",
+              "click": "http+ua+webdriver+dom+click+mousemove",
+              "smoke": "http+ua+webdriver+dom"}[livello]
     last = None
     try:
         for attempt in (1, 2, 3):
             try:
-                ua = _drive(exe, url, full)
+                ua = _drive(exe, url, livello)
                 if attempt > 1:
                     print(f"(note: drive succeeded on attempt {attempt} after a transient error)")
                 print(f"DRIVE GATE OK [{level}] | UA={ua} | {extras}=ok")
@@ -182,9 +206,9 @@ def main(exe: str, full: bool) -> int:
 
 if __name__ == "__main__":
     args = sys.argv[1:]
-    full = "--full" in args
+    livello = "full" if "--full" in args else ("click" if "--click" in args else "smoke")
     positional = [a for a in args if not a.startswith("--")]
     if len(positional) != 1:
-        print("usage: ci_drive_gate.py <path-to-firefox-binary> [--full]", file=sys.stderr)
+        print("usage: ci_drive_gate.py <path-to-firefox-binary> [--click | --full]", file=sys.stderr)
         sys.exit(2)
-    sys.exit(main(positional[0], full))
+    sys.exit(main(positional[0], livello))

--- a/scripts/ci_drive_gate.py
+++ b/scripts/ci_drive_gate.py
@@ -105,21 +105,28 @@ def _start_server():
     return srv, srv.server_address[1]
 
 
-# FF150 + Fission auto-loads about:newtab (TopSitesFeed) ~100ms-1s after a tab's
-# first navigation - a cross-process BC swap that REPLACES the page out from under
-# the test. The wrapper always disables it (see prefs.py); raw Playwright does not,
-# so the binary's realistic config must set it here too. Without this the drive page
-# can vanish mid-sequence (it loses the race whenever an action adds latency, e.g.
-# the human-cursor path), surfacing as a phantom "waiting for locator" timeout that
-# is an environment artifact, not a binary defect.
-_REALISTIC_PREFS = {
-    "browser.startup.page": 0,
-    "browser.newtabpage.enabled": False,
-    "browser.newtab.preload": False,
-    "browser.newtabpage.activity-stream.feeds.topsites": False,
-    "browser.newtabpage.activity-stream.feeds.section.topstories": False,
-    "browser.newtabpage.activity-stream.enabled": False,
-}
+# ⛔ QUI STAVA `_REALISTIC_PREFS`, SEI PREFS CHE SPEGNEVANO IL NEWTAB.
+# Tolte il 2026-08-20 col revert del newtab, e la ragione e' che la loro
+# giustificazione era diventata falsa: il commento diceva "the wrapper always
+# disables it (see prefs.py); raw Playwright does not, so the binary's realistic
+# config must set it here too". Il wrapper NON le disabilita piu' - il
+# proprietario ha ordinato il ripristino del codice originale di Mozilla - quindi
+# tenerle qui avrebbe fatto girare il gate in una configurazione che il prodotto
+# non spedisce. Un banco che misura una configurazione diversa da quella spedita
+# non e' un gate, e' un'altra misura con lo stesso nome.
+#
+# ⛔ E IL PERICOLO CHE DESCRIVEVANO E' STATO CHIUSO ALLA RADICE IL 2026-08-23,
+# quindi qui non resta nessuna contromisura. Non era Fission che ricaricava la
+# pagina: era il browser PREALLOCATO della nuova scheda che si prendeva il canale
+# della pagina, perche' `JugglerFrameParent` riconosceva il target confrontando un
+# `browserId` con l'`id` di un BrowsingContext. Corretto nel motore
+# (`20-our-patches.md` §5.2w, [B166] in `71-bug-archive.md`).
+#
+# Fra il 20 e il 23 agosto qui c'era un `time.sleep(_NEWTAB_SETTLE)` importato dal
+# wrapper. E' stato tolto insieme alla costante: misurato, l'attesa non copriva
+# niente - con l'attesa VERA, cioe' aspettando che `about:newtab` fosse arrivato e
+# caricato, la `goto` riusciva 0 volte su 9 - e dopo la correzione nel motore
+# Playwright nudo fa 10 su 10 senza aspettare niente.
 
 
 def _drive(exe: str, url: str, livello: str) -> str:
@@ -129,8 +136,7 @@ def _drive(exe: str, url: str, livello: str) -> str:
     from playwright.sync_api import sync_playwright
 
     with sync_playwright() as p:
-        browser = p.firefox.launch(executable_path=exe, headless=True,
-                                   firefox_user_prefs=_REALISTIC_PREFS)
+        browser = p.firefox.launch(executable_path=exe, headless=True)
         try:
             page = browser.new_page()
             resp = page.goto(url, wait_until="load")

--- a/scripts/ci_font_gate.py
+++ b/scripts/ci_font_gate.py
@@ -238,13 +238,21 @@ DETECT_JS = r"""(arg) => {
   return { present, gen, genref, inkbox };
 }"""
 
-# Suppress the new-tab machinery so the launch is quiet (mirrors ci_drive_gate).
-_PREFS = {
-    "browser.startup.page": 0,
-    "browser.newtabpage.enabled": False,
-    "browser.newtab.preload": False,
-    "browser.newtabpage.activity-stream.enabled": False,
-}
+# ⛔ QUI STAVANO QUATTRO PREFS CHE SPEGNEVANO IL NEWTAB, tolte il 2026-08-20 col
+# revert del newtab, per la stessa ragione di `ci_drive_gate.py`: il prodotto non
+# le spedisce piu', e un banco che gira in una configurazione diversa da quella
+# spedita misura un'altra cosa.
+#
+# Il commento diceva "mirrors ci_drive_gate", e gia' non era vero: erano QUATTRO
+# qui contro SEI la', divergenti da chissa' quando. E' il difetto che questa
+# rimozione chiude alla radice invece di riallineare: adesso non c'e' nessuna
+# lista da tenere in pari, perche' non ce n'e' nessuna.
+#
+# La gara che queste prefs volevano evitare non esiste piu' da nessuna parte:
+# non era Fission, era il browser preallocato della nuova scheda che si prendeva
+# il canale della pagina, ed e' corretto nel motore dal 2026-08-23
+# (`20-our-patches.md` §5.2w). Nessun gate aspetta piu' niente.
+_PREFS: dict = {}
 
 
 # ── Il limite strutturale di questo gate, misurato e non dedotto ──────────

--- a/src/invisible_playwright/async_api.py
+++ b/src/invisible_playwright/async_api.py
@@ -8,7 +8,6 @@ from typing import Any, Dict, Optional, Union
 
 from playwright.async_api import Browser, BrowserContext, Playwright, async_playwright
 
-from .launcher import _NEWTAB_SETTLE
 from . import _session
 from ._cursor import (
     ENGINE_PYTHON,
@@ -24,24 +23,6 @@ from ._engine import assert_wire_version, resolve_executable
 from invisible_core import configure_proxy as _configure_proxy_shared
 from ._reaper import SessionToken, guard_for
 from .launcher import _CHROME_H, _CHROME_W, _TASKBAR_H
-
-
-def _patch_new_page_sleep(ctx: Any) -> None:
-    """Wrap ctx.new_page() to add a brief settle after tab creation.
-
-    FF150 with Fission emits an about:newtab navigation ~100ms after a tab
-    is created.  If goto() is called immediately, it races with that internal
-    navigation and raises "Navigation interrupted by about:newtab".  A short
-    sleep breaks the race without requiring every call-site to know about it.
-    """
-    original_new_page = ctx.new_page
-
-    async def patched_new_page(**kw):
-        page = await original_new_page(**kw)
-        await asyncio.sleep(_NEWTAB_SETTLE)
-        return page
-
-    ctx.new_page = patched_new_page  # type: ignore[assignment]
 
 
 class InvisiblePlaywright:
@@ -146,7 +127,6 @@ class InvisiblePlaywright:
                     env=env,
                     **self._default_context_kwargs(),
                 )
-                _patch_new_page_sleep(self._persistent_context)
                 self._bind_process_tree()
                 self._arm_cursor_engine(self._persistent_context)
                 return self._persistent_context
@@ -216,7 +196,6 @@ class InvisiblePlaywright:
             merged = dict(defaults)
             merged.update(kw)
             ctx = await original(**merged)
-            _patch_new_page_sleep(ctx)
             if prep:
                 from ._recaptcha_seed import seed_recaptcha_cookies_async
                 await seed_recaptcha_cookies_async(ctx, profile, locale=loc)
@@ -231,11 +210,6 @@ class InvisiblePlaywright:
             merged.update(kw)  # user-supplied wins, same rule as new_context
             page = await original_page(**merged)
             ctx = page.context
-            # The settle new_context installs for later tabs, applied to THIS
-            # tab too: the same about:newtab race, and a caller doing
-            # `page = await browser.new_page()` goes straight to goto().
-            await asyncio.sleep(_NEWTAB_SETTLE)
-            _patch_new_page_sleep(ctx)
             if prep:
                 from ._recaptcha_seed import seed_recaptcha_cookies_async
                 await seed_recaptcha_cookies_async(ctx, profile, locale=loc)

--- a/src/invisible_playwright/launcher.py
+++ b/src/invisible_playwright/launcher.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import json
 import secrets
 from pathlib import Path
-import time as _time
 from typing import Any, Dict, Optional, Union
 
 from playwright.sync_api import Browser, BrowserContext, Playwright, sync_playwright
@@ -25,27 +24,22 @@ from invisible_core import configure_proxy as _configure_proxy_shared
 from ._reaper import SessionToken, guard_for
 
 
-#: Settle after a tab is created, in seconds. Named and module-level because
-#: `browser.new_page()` needs the same wait and a second literal is a second
-#: value: the two drifted apart for as long as one of them did not exist.
-_NEWTAB_SETTLE = 0.4
-
-def _patch_sync_new_page_sleep(ctx: Any) -> None:
-    """Wrap ctx.new_page() to add a brief settle after tab creation.
-
-    FF150 with Fission emits an about:newtab navigation ~100ms after a tab
-    is created.  If goto() is called immediately, it races with that internal
-    navigation and raises "Navigation interrupted by about:newtab".  A short
-    sleep breaks the race without requiring every call-site to know about it.
-    """
-    original_new_page = ctx.new_page
-
-    def patched_new_page(**kw):
-        page = original_new_page(**kw)
-        _time.sleep(_NEWTAB_SETTLE)
-        return page
-
-    ctx.new_page = patched_new_page  # type: ignore[assignment]
+# ⛔ QUI STAVA `_NEWTAB_SETTLE = 0.4` E IL SUO INVOLUCRO SU `ctx.new_page`,
+# TOLTI IL 2026-08-23 PERCHE' LA CAUSA E' STATA CHIUSA NEL MOTORE.
+#
+# Aspettavano 0,4 s dopo ogni scheda nuova per non farsi dirottare la prima
+# `goto()` da una navigazione interna ad `about:newtab`. Quella navigazione non
+# era del browser: era il browser PREALLOCATO della nuova scheda che si prendeva
+# il canale della pagina, perche' `JugglerFrameParent` riconosceva il target
+# confrontando `browserId` con l'`id` di un BrowsingContext - due contatori
+# diversi, che si sono scontrati. Il rimedio sta li' (`juggler/
+# JugglerFrameParent.sys.mjs`, la smentita con l'elemento `<browser>`), e
+# `70-known-bugs.md` [B166] porta i numeri.
+#
+# Tenere anche l'attesa qui sarebbe una seconda verita' sullo stesso fatto: il
+# ritardo non c'entrava con la causa e non la copriva - misurato lo stesso
+# giorno, con l'attesa e senza la correzione la `goto` moriva comunque 0 volte
+# su 9 riuscite. Con la correzione e senza nessuna attesa: 10 su 10.
 
 
 # The window chrome is NOT a wrapper constant either, for the same reason the
@@ -286,7 +280,6 @@ class InvisiblePlaywright:
                     env=env,
                     **self._persistent_context_kwargs(),
                 )
-                _patch_sync_new_page_sleep(self._persistent_context)
                 self._bind_process_tree()
                 self._arm_cursor_engine(self._persistent_context)
                 return self._persistent_context
@@ -401,7 +394,6 @@ class InvisiblePlaywright:
             merged = dict(defaults)
             merged.update(kw)  # user-supplied wins
             ctx = original(**merged)
-            _patch_sync_new_page_sleep(ctx)
             if prep:
                 from ._recaptcha_seed import seed_recaptcha_cookies_sync
                 seed_recaptcha_cookies_sync(ctx, profile, locale=loc)
@@ -416,11 +408,6 @@ class InvisiblePlaywright:
             merged.update(kw)  # user-supplied wins, same rule as new_context
             page = original_page(**merged)
             ctx = page.context
-            # The settle new_context installs for later tabs, applied to THIS
-            # tab too: it is the same about:newtab race, and browser.new_page()
-            # creates a tab the caller is about to goto() immediately.
-            _time.sleep(_NEWTAB_SETTLE)
-            _patch_sync_new_page_sleep(ctx)
             if prep:
                 from ._recaptcha_seed import seed_recaptcha_cookies_sync
                 seed_recaptcha_cookies_sync(ctx, profile, locale=loc)

--- a/tests/test_new_page_defaults.py
+++ b/tests/test_new_page_defaults.py
@@ -79,17 +79,6 @@ class _AsyncStubContext(_StubContext):
         self.cookies.extend(cookies)
 
 
-@pytest.fixture(autouse=True)
-def no_settle(monkeypatch):
-    """The 0.4s about:newtab settle, out of the unit tests.
-
-    Not removed from the code path: `_NEWTAB_SETTLE` is asserted separately.
-    """
-    import invisible_playwright.launcher as launcher
-
-    monkeypatch.setattr(launcher._time, "sleep", lambda _s: None)
-
-
 @pytest.mark.unit
 def test_new_page_gets_the_same_defaults_as_new_context():
     ip = InvisiblePlaywright(seed=42)
@@ -140,15 +129,35 @@ def test_the_async_api_wraps_new_page_too():
 
 
 @pytest.mark.unit
-def test_the_settle_is_one_value_shared_by_both_apis():
-    """The about:newtab race needs the same wait wherever a tab is created, and
-    a second literal is a second value."""
+def test_no_api_sleeps_after_creating_a_tab():
+    """⛔ L'attesa dopo ogni scheda nuova NON deve tornare.
+
+    C'era, valeva 0,4 s e serviva a non farsi dirottare la prima `goto()` da una
+    navigazione ad `about:newtab`. La causa non era una corsa da aspettare: era
+    `JugglerFrameParent` che riconosceva il target confrontando `browserId` con
+    l'`id` di un BrowsingContext - due contatori diversi - e lasciava che il
+    browser preallocato della nuova scheda si prendesse il canale della pagina.
+    Corretta nel motore il 2026-08-23 (`70-known-bugs.md` [B166]); l'attesa e'
+    stata tolta lo stesso giorno perche' un secondo rimedio per una causa sola e'
+    una seconda verita'.
+
+    Il controllo e' sul CODICE che avvolge la creazione della scheda, non su un
+    nome: reintrodurre il ritardo con un altro nome lo farebbe scattare uguale.
+    """
+    import inspect
+
     import invisible_playwright.async_api as async_api
     import invisible_playwright.launcher as launcher
 
-    assert launcher._NEWTAB_SETTLE == 0.4
-    assert async_api._NEWTAB_SETTLE is launcher._NEWTAB_SETTLE
-    assert "0.4" not in async_api._patch_new_page_sleep.__code__.co_consts.__str__()
+    for modulo in (launcher, async_api):
+        sorgente = inspect.getsource(
+            modulo.InvisiblePlaywright._patch_new_context_defaults
+        )
+        assert "sleep(" not in sorgente, (
+            f"{modulo.__name__} dorme dopo aver creato una scheda: la causa di "
+            "[B166] sta nel motore, non qui")
+    assert not hasattr(launcher, "_NEWTAB_SETTLE")
+    assert not hasattr(async_api, "_patch_new_page_sleep")
 
 
 @pytest.mark.e2e


### PR DESCRIPTION
L'attesa di 0,4 s dopo ogni scheda creata esce da entrambe le API, perche' la causa e' chiusa nel motore.

Non era una corsa da aspettare: il browser preallocato della nuova scheda si prendeva il canale della pagina, perche' JugglerFrameParent riconosceva il target confrontando un browserId con l'id di un BrowsingContext. Aspettando davvero, cioe' finche' about:newtab e' arrivato e caricato, la prima goto riusciva 0 volte su 9; il ritardo fisso riusciva solo quando vinceva la corsa. Dopo la correzione, 10 su 10 senza aspettare niente.

Il test che pinnava il valore diventa un gate che legge il codice e rifiuta qualunque sleep, provato con la mutazione che lo fa diventare rosso. I due gate della CI smettono di imporre le prefs del newtab, che il prodotto non spedisce piu': girati sul binario corretto, DRIVE GATE OK in full e FONT GATE OK con 71 famiglie su 71.
