### PR TITLE
Il font gate scrive le prefs nel profilo: sul protocollo il motore le rifiuta

### DIFF
--- a/scripts/ci_font_gate.py
+++ b/scripts/ci_font_gate.py
@@ -28,7 +28,11 @@ Exit 0 + "FONT GATE OK ..." on success; non-zero + the diff on failure.
 """
 from __future__ import annotations
 
+import json
+import shutil
 import sys
+import tempfile
+from pathlib import Path
 
 # The canonical Windows-11 family set the bundle exposes. Verified byte-for-byte
 # identical on Windows/DWrite and Linux/fontconfig; macOS/CoreText must match it
@@ -300,15 +304,37 @@ def main(exe: str) -> int:
 
     prefs = dict(_PREFS)
     prefs["zoom.stealth.fonts.generics"] = GENERICS_DECL
+
+    # ⛔ Le prefs si scrivono nel PROFILO, non si mandano sul protocollo.
+    # Fino a firefox-20 questo era `launch(firefox_user_prefs=prefs)`, che
+    # Playwright consegna al browser dentro `Browser.enable` - cioe' DOPO
+    # l'avvio. Da firefox-21 il motore lo RIFIUTA invece di applicarle tardi:
+    #
+    #     Browser.enable no longer applies preferences. They are written into
+    #     the profile before startup...
+    #
+    # ed e' il rifiuto giusto. Applicarle dopo l'avvio significa che il primo
+    # lancio inizializza gfx e font coi default e il secondo con le prefs
+    # attive: due percorsi diversi, che sono la causa di [B150]. E ignorarle
+    # sarebbe peggio - un browser senza le prefs che il chiamante crede di aver
+    # impostato, e nessun errore.
+    #
+    # Un `user.js` nel profilo viene letto all'AVVIO, quindi la mappa dei
+    # generici c'e' gia' quando gfx si inizializza: un percorso solo.
+    profilo = Path(tempfile.mkdtemp(prefix="ci-font-gate-"))
+    (profilo / "user.js").write_bytes(
+        ("".join("user_pref(%s, %s);\n" % (json.dumps(k), json.dumps(v))
+                 for k, v in sorted(prefs.items()))).encode("utf-8"))
     with sync_playwright() as p:
-        browser = p.firefox.launch(executable_path=exe, headless=True,
-                                   firefox_user_prefs=prefs)
+        ctx = p.firefox.launch_persistent_context(
+            str(profilo), executable_path=exe, headless=True)
         try:
-            page = browser.new_page()
+            page = ctx.new_page()
             page.goto("about:blank")
             r = page.evaluate(DETECT_JS, arg)
         finally:
-            browser.close()
+            ctx.close()
+            shutil.rmtree(profilo, ignore_errors=True)
 
     detected = {f for f, v in r["present"].items() if v}
     expected = set(EXPECTED)

--- a/src/invisible_playwright/launcher.py
+++ b/src/invisible_playwright/launcher.py
@@ -277,21 +277,42 @@ class InvisiblePlaywright:
                 # That is FALSE on the Juggler path, and the false belief is what
                 # made the first-launch/second-launch asymmetry look impossible.
                 # Verified 2026-08-14 in the bundled driver: writePreferences(),
-                # the function that creates user.js, lives in
-                # server/bidi/third_party/firefoxPrefs.ts and is called only by
-                # BidiFirefox.prepareUserDataDir; the BASE prepareUserDataDir is
-                # empty and the Juggler Firefox type does not override it. The
-                # prefs travel over the protocol instead: Browser.enable applies
+                # the function that creates user.js, lived in
+                # server/bidi/third_party/firefoxPrefs.ts and was called only by
+                # BidiFirefox.prepareUserDataDir; the BASE prepareUserDataDir was
+                # empty and the Juggler Firefox type did not override it. The
+                # prefs travelled over the protocol instead: Browser.enable applied
                 # them with Services.prefs.setBoolPref / setStringPref /
                 # setIntPref - USER-branch setters - after
-                # `await this._startCompletePromise`, so Firefox persists them
+                # `await this._startCompletePromise`, so Firefox persisted them
                 # into prefs.js. Measured: 39 zoom.stealth prefs in prefs.js after
                 # the first launch, and no user.js on disk at all.
                 #
-                # Consequence: launch 1 initialises gfx/fonts with the
+                # Consequence: launch 1 initialised gfx/fonts with the
                 # DEFAULTS, launch 2+ with the stealth prefs already active. Two
                 # different code paths, and every gate in this project starts from
                 # a fresh profile - which is how the relaunch hang lived unseen.
+                #
+                # ⛔ TUTTO IL PARAGRAFO SOPRA E' AL PASSATO DA firefox-21, e va
+                # letto come storia. Il fork del driver ora SCRIVE le prefs in
+                # `user.js` dentro il profilo e passa `-profile`, e manda
+                # `Browser.enable` SENZA il campo userPrefs; il motore, dal canto
+                # suo, RIFIUTA quel campo invece di applicarlo tardi:
+                #
+                #     Browser.enable no longer applies preferences. They are
+                #     written into the profile before startup.
+                #
+                # Quindi l'asimmetria primo-lancio/secondo-lancio non esiste piu':
+                # le prefs ci sono gia' quando gfx e i font si inizializzano, un
+                # percorso solo. `firefox_user_prefs=` qui sotto resta il modo di
+                # consegnarle - cambia solo chi le scrive, e dove.
+                #
+                # E la conseguenza per CHI NON usa questo fork: uno script che
+                # lancia il binario con Playwright UPSTREAM e passa
+                # `firefox_user_prefs` ora si becca quel rifiuto. E' successo a
+                # `scripts/ci_font_gate.py` sul primo firefox-21, e li' il rimedio
+                # e' scrivere un `user.js` nel profilo e usare un contesto
+                # persistente - non rimettere il campo nella richiesta.
                 # Cause and fix: `70-known-bugs.md` [B150]. The fix is a pref
                 # applied by invisible_core to every session, not code here: a
                 # geometry-scrubbing remedy lived in this file for a few hours and


### PR DESCRIPTION
I tre job `gate` di `firefox-21` cadevano sul FONT GATE con `Browser.enable no longer applies preferences`. Il drive gate era verde su tutte e tre le gambe, quindi il binario si pilota: a rompersi era solo questo script, che passa `firefox_user_prefs` a un Playwright upstream.

Il rifiuto del motore e' voluto: prima quelle prefs arrivavano dopo l'avvio, quindi il primo lancio inizializzava gfx e font coi default e il secondo con le prefs attive - la causa di B150. Il rimedio sta nello script: un `user.js` nel profilo piu' un contesto persistente.

Verificato che la pref arrivi davvero, non solo che il gate passi: dopo il lancio la riga e' ancora in `user.js` e la pref compare in `prefs.js`, che Firefox scrive dai valori vivi. Il gate rifatto contro un binario locale con lo stesso juggler: FONT GATE OK, 71 famiglie su 71, fuga dall'host 0.

La mutazione (non scrivere `user.js`) sopravvive su Windows, come il commento nel file gia' prevedeva - li' i default di Gecko coincidono per caso con la persona dichiarata. La prova discriminante e' su Linux e la da' la CI.

Corretto anche un commento in `launcher.py` che descriveva il meccanismo vecchio come attuale. Il prodotto non e' toccato: il driver vendored toglie `userPrefs` dalla richiesta e scrive le prefs nel profilo.