### PR TITLE
0.7.4: il pin passa al motore firefox-21, e l'xfail del file chooser se ne va

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.4] - 2026-08-27
+
+### Changed
+
+- Pins `invisible-core` 21.16.0, which pins the `firefox-21` engine.
+- The CI font gate writes its preferences into the profile instead of sending them
+  over the protocol. From `firefox-21` the engine refuses `Browser.enable` with a
+  `userPrefs` field rather than applying it late: preferences that arrive after
+  startup mean the first launch initialises graphics and fonts with the defaults
+  and the second with the stealth values, two different code paths. Nothing changes
+  for users of this package - the vendored driver already writes them into the
+  profile before startup.
+
 ## [0.7.3] - 2026-08-26
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "invisible_playwright"
-version = "0.7.3"
+version = "0.7.4"
 description = "Playwright wrapper for a patched Firefox with deterministic stealth profile."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -62,7 +62,7 @@ dependencies = [
     # metadata; nothing in src/ hardcodes a second copy (tests/test_core_pin.py
     # fails if one appears). What stays invisible to install-time machinery is the
     # --no-deps / lockfile residue, and _pin.py is the only layer that sees it.
-    "invisible_core==20.16.0",
+    "invisible_core==21.16.0",
     # ⛔ playwright NON e' piu' una dipendenza: dal fork completo il client
     # Python vive in src/invisible_playwright/_pw/ e il driver Node in
     # src/invisible_playwright/_driver/. Reintrodurla non romperebbe niente in

--- a/tests/test_file_chooser.py
+++ b/tests/test_file_chooser.py
@@ -74,20 +74,22 @@ def file_campione(tmp_path):
     return str(p)
 
 
-@pytest.mark.xfail(
-    reason="Il rimedio sta nel MOTORE e non e' ancora rilasciato: PageAgent.js "
-           "ascolta `file-input-picker-opening` invece di "
-           "`juggler-file-picker-shown` da un commit POSTERIORE a firefox-20, "
-           "che e' il binario che il seal pinna oggi. Misurato il 2026-08-26: "
-           "contro firefox-20 l'evento non arriva (timeout 15s), contro la build "
-           "locale che porta il commit il test passa. Diventa verde da solo al "
-           "primo firefox-N che include quel commit, e per questo non e' stato "
-           "cancellato ne' lasciato rosso: un e2e rosso sulla coppia SPEDITA "
-           "insegna a ignorare l'e2e.",
-    strict=False)
 @pytest.mark.e2e
 def test_expect_file_chooser_riceve_levento(firefox_binary, pagina_locale):
-    """L'evento arriva. Prima del 2026-08-25 questo scadeva sempre."""
+    """L'evento arriva. Prima del 2026-08-25 questo scadeva sempre.
+
+    ⛔ Qui c'era un `xfail`, e se n'e' andato come aveva promesso di fare. La sua
+    ragione diceva: il rimedio sta nel MOTORE (PageAgent.js ascolta
+    `file-input-picker-opening` invece di `juggler-file-picker-shown`) da un
+    commit POSTERIORE a `firefox-20`, "diventa verde da solo al primo firefox-N
+    che include quel commit". Quel rilascio e' `firefox-21`: misurato il
+    2026-08-27 contro il binario SPEDITO (BuildID 20260827000135, lo stesso che
+    il sigillo dichiara), questo caso torna XPASS.
+
+    Gli altri due di questo file restano `xfail`: sono [B178], che questa
+    release non tocca - verificato che nessun commit fra `firefox-20` e HEAD
+    nomini `setFileInputFiles`.
+    """
     with InvisiblePlaywright(seed=42, binary_path=firefox_binary) as browser:
         page = browser.new_page()
         page.goto(pagina_locale, wait_until="load")


### PR DESCRIPTION
Il pin passa a `invisible-core` 21.16.0, cioe' al motore `firefox-21`, che e' pubblicato e i cui asset rispondono 200 sull'URL pubblico.

E l'`xfail` di `test_expect_file_chooser_riceve_levento` se ne va come aveva promesso: la sua ragione diceva che il rimedio sta nel motore, da un commit posteriore a `firefox-20`, e che sarebbe diventato verde al primo firefox-N che lo include. Misurato contro il binario SPEDITO (BuildID 20260827000135, lo stesso che il sigillo dichiara): XPASS, quindi il marcatore esce e l'asserzione diventa dura.

Gli altri due restano `xfail`: sono B178, che questa release non tocca - verificato che nessun commit fra `firefox-20` e HEAD del sorgente nomini `setFileInputFiles`.

Verificato prima di aprire: wheel 0.7.4 installato in un venv vuoto e importato con il pin che risolve dall'indice; e2e completo contro il binario spedito, 146 passed 2 xfailed 0 failed.