### PR TITLE
Link the course catalogs guide from four related pages

### DIFF
--- a/docs/how-to-scrape-autocomplete-typeahead-playwright.md
+++ b/docs/how-to-scrape-autocomplete-typeahead-playwright.md
@@ -166,6 +166,9 @@ one mechanism the whole widget is built around and comes back empty. Do the per-
 character version and you get both the data and, because the cadence is right, a
 session that keeps its shape across a long run of lookups.
 
+Catalog search boxes behave the same way and hide a four-level tree behind them: see
+[how to scrape course catalogs with Playwright](how-to-scrape-course-catalogs-playwright.md).
+
 ## Short answers to the questions that lead here
 
 **Why does fill() leave the autocomplete dropdown empty?** Because `fill()` sets the

--- a/docs/how-to-scrape-html-tables-playwright.md
+++ b/docs/how-to-scrape-html-tables-playwright.md
@@ -222,6 +222,9 @@ Python before you navigate, never after, because a handle held across a page tur
 already dead and the failure is silent when it is not loud. Get those two right and a
 forty-page table comes back whole and a failing run replays exactly.
 
+When the table is a schedule rather than a grid, the row is not the visible line: see
+[how to scrape course catalogs with Playwright](how-to-scrape-course-catalogs-playwright.md).
+
 ## Short answers to the questions that lead here
 
 **What is the fastest way to scrape a table with Playwright?** `locator.evaluate_all` over

--- a/docs/how-to-scrape-job-postings-playwright.md
+++ b/docs/how-to-scrape-job-postings-playwright.md
@@ -234,6 +234,9 @@ returning visitor and not a new random machine every morning, and pace it so the
 itself does not give you away. The structured markup gives you clean data; the stable real
 browser keeps the endpoint willing to hand it over across a long, repetitive sweep.
 
+The same listing-versus-record problem shows up in academic catalogs, where the row is
+the section: [how to scrape course catalogs with Playwright](how-to-scrape-course-catalogs-playwright.md).
+
 ## Short answers to the questions that lead here
 
 **Why does the URL not change when I filter a job board?** Because the filters live in

--- a/docs/how-to-scrape-paginated-pages-playwright.md
+++ b/docs/how-to-scrape-paginated-pages-playwright.md
@@ -204,6 +204,9 @@ to finish before you read the next page. When the page number is in the URL, pre
 browser, pass a fixed seed so a forty-page crawl is one visitor reading forty pages rather
 than forty visitors reading one each.
 
+A catalog is the same pagination problem with a tree under it: see
+[how to scrape course catalogs with Playwright](how-to-scrape-course-catalogs-playwright.md).
+
 ## Short answers to the questions that lead here
 
 **Why does my Playwright pagination loop crash with "Execution context was destroyed"?**


### PR DESCRIPTION
The new guide had six outbound links and zero inbound, making it the only orphan among 324 pages (README and index aside, which are correctly not linked from articles).

One contextual sentence added to each of four related pages. All four were checked first and none holds a first-page position, so no ranking page was edited.