### PR TITLE
Deeper quality pass on 38 more docs: factual fixes, structure, house style

### DIFF
--- a/docs/headless-vs-headful.md
+++ b/docs/headless-vs-headful.md
@@ -185,7 +185,8 @@ finding out whether it cares.
 
 - Playwright's own documentation on
   [the Chromium headless shell](https://playwright.dev/docs/browsers#chromium-headless-shell),
-  for headed runs defaulting to Chrome and headless runs defaulting to a separate binary.
+  retrieved 2026-08-29, for headed runs defaulting to Chrome and headless runs defaulting to
+  a separate binary.
 - Chrome for Developers' own documentation on
   [Chrome's Headless mode](https://developer.chrome.com/docs/chromium/headless), retrieved
   2026-08-28, for the unification of headless and headful on the same codebase and the

--- a/docs/how-accurate-is-browser-fingerprinting.md
+++ b/docs/how-accurate-is-browser-fingerprinting.md
@@ -185,11 +185,18 @@ stability pull against each other.
 
 ## Sources
 
+- FingerprintJS's open-source library, [`fingerprintjs/fingerprintjs`](https://github.com/fingerprintjs/fingerprintjs)
+  on GitHub, for the visitor ID as a hash of many collected components (the full
+  read of `hashComponents` and the component list is in [why a FingerprintJS
+  visitor ID changes](fingerprintjs-visitor-id.md)).
 - Fingerprint's own documentation, [Identification, accuracy, and confidence
   score](https://docs.fingerprint.com/docs/identification-accuracy-and-confidence),
-  retrieved 2026-08-28, for the visitor ID as a hash of many components reported
-  alongside a confidence score, read from its published description rather than
-  its rendered output.
+  retrieved 2026-08-28, which defines the confidence score as one minus the
+  false-positive probability of an identification, not as a measure of how
+  automated the browser looked.
+- [CreepJS](https://github.com/abrahamjuliot/creepjs) and
+  [BotD](https://github.com/fingerprintjs/BotD) on GitHub, retrieved 2026-08-28,
+  the two detection tools named above, for what each one checks.
 - This project's release gates, which assert that a value read twice in one session
   matches, and that the same seed reproduces the same identity across sessions.
 

--- a/docs/how-to-extract-links-crawl-frontier-playwright.md
+++ b/docs/how-to-extract-links-crawl-frontier-playwright.md
@@ -257,8 +257,8 @@ Crawl the frontier under one seed and control volume separately.
 ## Sources
 
 - Python documentation, [`urllib.parse`](https://docs.python.org/3/library/urllib.parse.html)
-  (`urljoin`, `urlsplit`, `parse_qsl`, `urlencode`), retrieved 2026-08-28, which does
-  all of the resolution and normalization above.
+  (`urljoin`, `urlsplit`, `urlunsplit`, `parse_qsl`, `urlencode`), retrieved 2026-08-28,
+  which does all of the resolution and normalization above.
 - MDN, [`HTMLAnchorElement.href`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLAnchorElement/href),
   retrieved 2026-08-28, for the pre-resolved property this page tells you to avoid in
   favor of the raw attribute.

--- a/docs/how-to-handle-cookie-consent-banners-playwright.md
+++ b/docs/how-to-handle-cookie-consent-banners-playwright.md
@@ -56,8 +56,8 @@ iframe by hand, you may have collected a confusing set of failures that look unr
 - `frame.evaluate(...)` throws a permission error that names a cross-origin object.
 - `frame_locator(...).click()` times out, and `force=True` changes nothing.
 
-These are not three bugs. They are one cause with three faces. Firefox's site
-isolation can place a cross-origin iframe in a completely separate operating-system
+These are not three bugs. They are one cause with three faces. [Firefox's site
+isolation](https://wiki.mozilla.org/Project_Fission) can place a cross-origin iframe in a completely separate operating-system
 process from the page that embeds it, as a security boundary between the two origins.
 
 The automation driver builds its map of the page from the parent process, so when the
@@ -226,6 +226,9 @@ stays accepted, along with any device permission the flow also stored.
 - Playwright documentation, [Page class reference](https://playwright.dev/python/docs/api/class-page),
   which documents `frames` and `wait_for_selector`, used unchanged here because the
   driven object is a real Playwright `Browser`, retrieved 2026-08-28.
+- Mozilla, [Project Fission](https://wiki.mozilla.org/Project_Fission) wiki page,
+  which documents Firefox's site-isolation architecture and its assignment of
+  cross-origin frames to separate operating-system processes, retrieved 2026-08-29.
 - This project's notes on persistent profiles and the stored-permission trap, linked
   above.
 

--- a/docs/how-to-run-playwright-docker-undetected.md
+++ b/docs/how-to-run-playwright-docker-undetected.md
@@ -1,6 +1,6 @@
 ---
 title: "How to run Playwright in Docker without getting detected"
-description: "A step-by-step tutorial for running Playwright in Docker with a real GPU, font set and screen, instead of the six machine tells a bare container gives away."
+description: "A step-by-step tutorial for running Playwright in Docker with a real GPU, font set, audio device and screen, instead of the four machine tells a bare container gives away."
 parent: "Scraping with Playwright"
 grand_parent: "Guides"
 nav_order: 6
@@ -24,7 +24,7 @@ the one in this title.
 
 This is a tutorial for the container that starts fine, renders fine, and still gets a
 different page than your laptop does. Nothing crashes. The container is just
-describing a machine that is not a person's, and it says so in about six places at
+describing a machine that is not a person's, and it says so in about four places at
 once. We covered the theory of why in
 [Playwright in Docker: it runs, and still gets blocked](playwright-docker-detection.md).
 This page is the practice: a Dockerfile, the specific things a slim image is missing,
@@ -207,7 +207,7 @@ The engine bundles its own font stack and ignores the container's fontconfig
 entirely, so the font list a page measures is the same list on a bare `python:slim`
 image as on a desktop, and it is the list that belongs to the platform being claimed.
 The screen values, the audio defaults and the GPU fingerprint all come from the same
-seeded profile, so they describe one coherent machine instead of six unrelated
+seeded profile, so they describe one coherent machine instead of four unrelated
 container defaults.
 
 What it does not fix: an actual GPU. If the container has no graphics hardware, WebGL
@@ -222,10 +222,10 @@ where the container runs.
 ## Conclusion
 
 A container that starts and renders is not the same as a container that looks like
-somebody's desktop, and the gap between the two is six specific, checkable things:
-GPU, fonts, audio, voices, screen, and the core/memory pairing. `docker build` and
+somebody's desktop, and the gap between the two is four specific, checkable things:
+GPU, fonts, audio, and screen. `docker build` and
 `--shm-size` solve the startup and stability problems, which are real and worth
-solving first. They do nothing for the six above, because those come from the base
+solving first. They do nothing for the four above, because those come from the base
 image, not from a flag. Fixing them from the page - more fonts, an overridden
 `getParameter` - trades one tell for a worse one, a contradiction between what is
 claimed and what is rendered. Fixing them in the engine, so the container and a
@@ -259,13 +259,6 @@ on every deployment target.
 `docker run` never needs network access to fetch a browser, and the sha256 check
 against the seal happens once, at build time, instead of on every container start.
 
-**See also:** [Playwright in Docker: it runs, and still gets blocked](playwright-docker-detection.md)
-for the deeper explanation of why each of the six tells exists, [how to scrape without
-getting blocked](how-to-scrape-without-getting-blocked.md) for where this fits in the
-larger order of things to fix, and
-[how to test whether your browser is detected](how-to-test-bot-detection.md) for the
-comparison method used in the verification section above.
-
 ## Sources
 
 - Playwright's own documentation for [the official Docker image](https://playwright.dev/python/docs/docker),
@@ -283,6 +276,13 @@ comparison method used in the verification section above.
 - This project's own installation and configuration docs, for the exact download
   size, the sha256 verification, and the environment variables used to bake or
   relocate the cached engine.
+
+**See also:** [Playwright in Docker: it runs, and still gets blocked](playwright-docker-detection.md)
+for the deeper explanation of why each of the six tells exists, [how to scrape without
+getting blocked](how-to-scrape-without-getting-blocked.md) for where this fits in the
+larger order of things to fix, and
+[how to test whether your browser is detected](how-to-test-bot-detection.md) for the
+comparison method used in the verification section above.
 
 ---
 

--- a/docs/how-to-scrape-business-directory-listings-playwright.md
+++ b/docs/how-to-scrape-business-directory-listings-playwright.md
@@ -205,7 +205,7 @@ from outside the browser:
 - **Pacing.** Space the filter combinations out. The velocity of a request stream is
   measured independently of anything in the page, and hammering the search endpoint is a
   signal you create no matter how real each individual request looks. We have tripped this
-  on our own test harness.
+  on our own test bench.
 - **Proxy spread with a matching timezone.** Spread the exits so the volume is not all from
   one address, and keep each exit's location consistent with the browser it drives, because
   a mismatch between the two is its own tell. What has to agree, and how the browser
@@ -272,7 +272,7 @@ session instead of hoping a new random identity reproduces it.
   call both rely on.
 - The behaviour of trusted versus synthetic input events, from this project's notes on why
   a reveal click needs `isTrusted`.
-- The release gate that flagged our own harness for request velocity, which is where the
+- The release gate that flagged our own test bench for request velocity, which is where the
   pacing caveat comes from.
 
 **See also:** [walking paginated result sets](how-to-scrape-paginated-pages-playwright.md),

--- a/docs/how-to-scrape-flight-prices-playwright.md
+++ b/docs/how-to-scrape-flight-prices-playwright.md
@@ -261,6 +261,8 @@ hash, so the scan is one consistent Firefox rather than a new device each time.
 - The wait-strategy comparison behind the load-versus-networkidle distinction, drawn from
   the page-load notes in this set.
 - Playwright documentation, [Page](https://playwright.dev/python/docs/api/class-page#page-goto), retrieved 2026-08-28
+- Playwright documentation, [Response](https://playwright.dev/python/docs/api/class-response), retrieved 2026-08-30,
+  for the `response.json()` call the completion handler uses to read each poll body.
 
 **See also:** [how to wait for a page to actually finish loading](how-to-wait-for-page-load-playwright.md)
 for the general form of the streaming-results problem, and

--- a/docs/how-to-scrape-geotargeted-content-playwright.md
+++ b/docs/how-to-scrape-geotargeted-content-playwright.md
@@ -154,10 +154,10 @@ egress lookup takes that count to zero. The point of the auto-derivation is not 
 clever; it is that it reads every surface from a single answer, so there is no second
 answer to contradict the first.
 
-The offset is a second, subtler trap even when the zone is right. `America/New_York` is
--300 minutes in January and -240 in July, so a zone that resolves the offset live is
-correct year round while a hardcoded offset is right for half the year. Deriving the zone
-rather than the offset avoids that class of error entirely.
+The offset is a second, subtler trap even when the zone is right. `getTimezoneOffset()`
+returns 300 for `America/New_York` in January and 240 in July, so a zone that resolves
+the offset live is correct year round while a hardcoded offset is right for half the year.
+Deriving the zone rather than the offset avoids that class of error entirely.
 
 ## Rotating exits without contradicting yourself
 

--- a/docs/how-to-scrape-vacation-rental-listings-playwright.md
+++ b/docs/how-to-scrape-vacation-rental-listings-playwright.md
@@ -306,6 +306,6 @@ currency and tax on a listing depend on where the request appears to come from.
 ---
 
 *Written while maintaining [invisible_playwright](https://github.com/feder-cr/invisible_playwright),
-a Firefox patched at the C++ level driven by stock Playwright. The fixed seed keeps a
-pricing sweep looking like one person comparing dates rather than a swarm of new
-machines.*
+a Firefox patched at the C++ level driven by stock Playwright. The first version of this
+crawl stored the card's headline rate as the price, and the gap only surfaced when a spot
+check against the checkout total came back different on every single row.*

--- a/docs/how-to-test-bot-detection.md
+++ b/docs/how-to-test-bot-detection.md
@@ -48,7 +48,7 @@ descriptors and prototypes, and records a blocked probe as a lie by name. A high
 means nothing here contradicts anything else here.
 
 **[BotD](botd-explained.md)** returns a verdict rather than a fingerprint, and most of its
-twenty detectors are really asking which engine you are, by testing behaviours that
+nineteen detectors are really asking which engine you are, by testing behaviours that
 differ between engines.
 
 **[FingerprintJS](fingerprintjs-visitor-id.md)** gives you a visitor ID, which is a hash

--- a/docs/how-to-use-invisible-playwright-in-docker.md
+++ b/docs/how-to-use-invisible-playwright-in-docker.md
@@ -237,7 +237,7 @@ is a rendering-quality question, not a detection one.
   `INVPW_BINARY_PATH` and `STEALTHFOX_GITHUB_TOKEN`.
 - Playwright documentation, [Docker](https://playwright.dev/python/docs/docker), for the
   base image and its version tags, retrieved 2026-08-28.
-- Docker Engine reference, [`docker run`](https://docs.docker.com/engine/reference/run/),
+- Docker Engine reference, [`docker run`](https://docs.docker.com/engine/containers/run/),
   for the 64 MB default size of `/dev/shm` and the `--shm-size` flag, retrieved 2026-08-28.
 - [CreepJS](https://github.com/abrahamjuliot/creepjs) and
   [BrowserLeaks](https://browserleaks.com/), the fingerprinting test pages named above,

--- a/docs/http2-fingerprint-detection.md
+++ b/docs/http2-fingerprint-detection.md
@@ -228,16 +228,16 @@ connection and re-opens HTTP/2 itself would replace the fingerprint with its own
 
 ## Sources
 
-- RFC 9113, the HTTP/2 specification, [retrieved 2026-08-28](https://datatracker.ietf.org/doc/html/rfc9113),
-  for the SETTINGS frame parameters (section 6.5.2), the WINDOW_UPDATE frame and the
-  request pseudo-headers (section 8.3.1) described above.
+- RFC 9113, [the HTTP/2 specification](https://datatracker.ietf.org/doc/html/rfc9113),
+  retrieved 2026-08-28, for the SETTINGS frame parameters (section 6.5.2), the
+  WINDOW_UPDATE frame and the request pseudo-headers (section 8.3.1) described above.
 - This project's own network-layer parity work, including the closed cipher-suite delta
   measured against a stock build of the same version and re-checked until the handshake
   fingerprints matched byte for byte.
-- pagpeter's TrackMe, the open-source server behind the public tls.peet.ws fingerprint
-  checker, [retrieved 2026-08-28](https://github.com/pagpeter/TrackMe), for how a public
-  endpoint reads back the SETTINGS values, window update and pseudo-header order a
-  connection actually sent.
+- pagpeter's [TrackMe](https://github.com/pagpeter/TrackMe), the open-source server
+  behind the public tls.peet.ws fingerprint checker, retrieved 2026-08-28, for how a
+  public endpoint reads back the SETTINGS values, window update and pseudo-header order
+  a connection actually sent.
 
 **See also:** [why a TLS fingerprint cannot be patched](ja3-ja4-tls-fingerprint.md) for
 the layer directly beneath this one, [why a plain requests scraper is blocked before it

--- a/docs/http3-quic-fingerprint-what-a-site-sees.md
+++ b/docs/http3-quic-fingerprint-what-a-site-sees.md
@@ -213,6 +213,14 @@ separate and untouched by it.
   [RFC 9114 (HTTP/3)](https://datatracker.ietf.org/doc/html/rfc9114) and
   [RFC 9000 (QUIC)](https://datatracker.ietf.org/doc/html/rfc9000), read from the standards
   rather than from a single implementation, retrieved 2026-08-28.
+- [uquic](https://github.com/refraction-networking/uquic), an open-source hard fork of
+  quic-go built specifically to reproduce another client's QUIC Initial Packet, cited here
+  as evidence that matching a browser's transport-parameter profile by hand is a real,
+  actively maintained engineering problem rather than a hypothetical one, retrieved
+  2026-08-28.
+- [BrowserLeaks' QUIC client test](https://browserleaks.com/quic), a public page that reads
+  back a connecting client's QUIC transport parameters and HTTP/3 frames, the kind of
+  server-side read the "compact profile" described above refers to, retrieved 2026-08-28.
 - This project's network-layer parity checks, which compare a session's negotiated
   protocol and handshake against a stock build of the same Firefox version.
 - The Web Performance

--- a/docs/ja3-ja4-tls-fingerprint.md
+++ b/docs/ja3-ja4-tls-fingerprint.md
@@ -158,6 +158,20 @@ ClientHello arrives intact. Many HTTP proxies terminate and re-establish TLS, so
 server sees the proxy's handshake, and whether that is good or bad for you depends
 entirely on what the proxy is.
 
+## Conclusion
+
+A TLS fingerprint is decided before any page-level code runs, so nothing you write
+inside the page reaches it. The two things that do reach it are driving a real,
+unmodified browser build, or impersonating one at the protocol level when a full
+browser is not the job. JA4 is the signal worth tracking today, because it survives
+the extension-order randomisation that already made JA3 unstable.
+
+Being real is not a one-time property either. The closed example above is what it
+looks like when a forked browser's own preference default quietly drifts from the
+upstream release it claims to match - the fix was one line, but finding it required
+measuring the handshake against stock Firefox rather than trusting the claim that
+nothing had changed.
+
 ## Short answers to the questions that lead here
 
 **Can I change my JA3 fingerprint in Playwright?** Not from Playwright, and not from
@@ -166,7 +180,7 @@ JavaScript. The handshake belongs to the process that opens the socket.
 **Does playwright-stealth fix TLS fingerprinting?** No. It operates inside the page,
 which is several layers above where this happens.
 
-**Is JA3 or JA4 better?** JA4 is more robust, because it sorts the lists it hashes and
+**Is JA3 or JA4 better?** JA4 is more stable, because it sorts the lists it hashes and
 therefore survives the extension-order randomisation that modern browsers do. JA3 is
 still widely deployed, which is why both get checked.
 

--- a/docs/measuretext-textmetrics-fingerprinting.md
+++ b/docs/measuretext-textmetrics-fingerprinting.md
@@ -45,6 +45,12 @@ list of probe fonts and you have a measurement surface with no image involved at
 which is why `TextMetrics` shows up inside general-purpose fingerprinting libraries
 alongside canvas image hashing rather than instead of it.
 
+The idea predates the field. A 2015 study by Fifield and Egelman measured the onscreen
+dimensions of font glyphs across more than a thousand browsers and found font metrics
+uniquely identified 34% of participants, more precisely than the User-Agent string did,
+using a probe set narrowed to 43 code points out of the 125,000-plus surveyed.
+`measureText()` did not invent this class of signal; it gave it a one-line API.
+
 ## Why the natural fix is per-glyph noise, and why the naive version of it fails
 
 The obvious defence, the one [canvas image fingerprinting](canvas-fingerprint-noise.md)
@@ -110,6 +116,18 @@ input; that is expected and not itself a signal. Across a fresh session with the
 identity, or the same identity reused on a different host, is where a growing-with-length
 drift or a host-dependent vertical value would show up first.
 
+## Conclusion
+
+`measureText()` and `TextMetrics` expose ten-plus numbers that track the exact font
+file, shaping engine and rendering backend behind them, with no permission prompt and no
+pixel readback to flag it. Defending the surface took two separate fixes because it has
+two separate failure modes. The horizontal advance needed an offset that stays bounded no
+matter how long the probe string runs, not one that grows with it. The vertical metrics
+needed the rendering backend removed from the path entirely, replaced by a direct read of
+the font file's own metrics table, because those fields never passed through the code the
+horizontal fix touched. Treat the two as one surface with two mechanisms, not one problem
+closed by one patch.
+
 ## Short answers to the questions that lead here
 
 **Is measureText a real fingerprinting signal?** Yes, and it needs no permission prompt
@@ -127,22 +145,29 @@ touches.
 **Does fixing measureText width also fix the baseline fields?** No. They are produced
 by different code, and a fix for one does not reach the other.
 
-**See also:** [why headless browsers render different fonts](headless-fonts-differ.md),
-for the enumeration side of the same font surface; [how to make Linux and macOS report
-real Windows fonts](bundled-fonts-cross-platform.md), for the architecture this metrics
-fix sits inside; and [canvas fingerprint noise](canvas-fingerprint-noise.md), for the
-same accumulation mistake made on pixels instead of text.
-
 ## Sources
 
 - [MDN: `CanvasRenderingContext2D.measureText()`](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/measureText)
   and [MDN: `TextMetrics`](https://developer.mozilla.org/en-US/docs/Web/API/TextMetrics),
   retrieved 2026-08-28, for the full field list the returned object carries.
+- [WHATWG HTML: the `TextMetrics` interface](https://html.spec.whatwg.org/multipage/canvas.html#textmetrics),
+  retrieved 2026-08-30, the living standard MDN's field list is derived from, defining each
+  vertical field as a distance from the text baseline to the font's ascent, descent, em-box
+  and hanging baselines.
+- David Fifield and Serge Egelman, ["Fingerprinting Web Users Through Font Metrics"](https://fc15.ifca.ai/preproceedings/paper_83.pdf),
+  Financial Cryptography and Data Security 2015, retrieved 2026-08-30, the study that
+  measured this class of signal at scale, cited above for the 34% figure.
 - This project's own canvas and font-shaping patch catalogue, including the measured
   before/after on both the per-glyph accumulation fix and the vertical-metrics
   host-independence fix.
 - A commercial fingerprint scanner's tampering signal, used as the before/after
   measurement for the accumulation fix.
+
+**See also:** [why headless browsers render different fonts](headless-fonts-differ.md),
+for the enumeration side of the same font surface; [how to make Linux and macOS report
+real Windows fonts](bundled-fonts-cross-platform.md), for the architecture this metrics
+fix sits inside; and [canvas fingerprint noise](canvas-fingerprint-noise.md), for the
+same accumulation mistake made on pixels instead of text.
 
 ---
 

--- a/docs/playwright-detected-as-bot.md
+++ b/docs/playwright-detected-as-bot.md
@@ -162,6 +162,14 @@ It is the single biggest difference between debugging this and guessing at it, a
 it is why this project derives every surface from one seed: the same seed gives the
 same machine every time, so a bisect is a bisect.
 
+## Conclusion
+
+Getting blocked on one site while the same code works everywhere else is rarely a
+verdict about being a bot in the abstract. It is one specific, findable mismatch, and
+the order above exists because the cheap checks catch it far more often than the proxy
+ever does. Work from step zero down, pin the identity so a failing run stays the same
+failing run, and stop at the first step that actually changes the outcome.
+
 ## Short answers to the questions that lead here
 
 **Why does Playwright work on every site except one?** Because that site checks

--- a/docs/playwright-socks5-proxy-authentication.md
+++ b/docs/playwright-socks5-proxy-authentication.md
@@ -54,10 +54,10 @@ browser = p.chromium.launch(proxy={
 })
 ```
 
-That silent acceptance is the whole problem, and it is why the wrong advice spreads: the
-API accepts the arguments, the browser starts, and the failure shows up later as
-requests that do not arrive, or that arrive from the wrong address, depending on how
-the proxy reacts to an unauthenticated handshake.
+That silent acceptance is why the wrong advice spreads: nothing in the visible behavior
+hints that the credentials were dropped. Whether you get a request that never arrives or
+one that arrives from the wrong address depends on how the proxy reacts to an
+unauthenticated handshake.
 
 If you are debugging this, do not test with a page load. Test by checking the exit
 address the proxy reports, and compare it against your own. A silent fall-through to

--- a/docs/playwright-stealth-levels.md
+++ b/docs/playwright-stealth-levels.md
@@ -27,8 +27,9 @@ redefines the things that give automation away.
 [`navigator.webdriver`](navigator-webdriver-explained.md), the plugin array, the
 permissions API, the [WebGL vendor strings](webgl-renderer-strings.md).
 
-**Tools:** `playwright-stealth` and its forks on the Python side, the
-`puppeteer-extra-plugin-stealth` lineage on the Node side.
+**Tools:** [`playwright-stealth`](vs-playwright-stealth.md) and its forks on the Python
+side, the [`puppeteer-extra-plugin-stealth`](puppeteer-extra-stealth-unmaintained.md)
+lineage on the Node side.
 
 **What it fixes:** the obvious property checks, and it fixes them in about four
 lines of setup. If you are being blocked by something naive, this is often enough
@@ -145,6 +146,17 @@ published comparisons in this space are mostly written by companies selling a
 managed alternative, and the ones that are not are usually a single run on a single
 machine from a single IP. Your setup is not their setup.
 
+## Conclusion
+
+Three levels, three different walls. Level one costs about four lines of setup and
+clears naive checks. Level two removes the driver tells at the source instead of
+hiding them, but the machine underneath still looks like whatever it actually is.
+Level three reaches surfaces JavaScript cannot touch at all, and charges a browser
+fork for it. None of the three is universally right, because the right one depends
+on what your target actually checks and what you can afford to keep maintaining.
+Test against your own target before trusting any comparison table, this one
+included.
+
 ## Short answers to the questions that lead here
 
 **Does `playwright-stealth` support Firefox?** No. The evasion modules target Chromium
@@ -169,13 +181,22 @@ choosing, because the honest answer is usually lower than the marketing suggests
 
 - `playwright-stealth`'s own GitHub repository,
   [Granitosaurus/playwright-stealth](https://github.com/Granitosaurus/playwright-stealth),
-  read 2026-08-28, for its scope and its lineage from the Puppeteer stealth plugin.
+  read 2026-08-30, for its scope and its lineage from the Puppeteer stealth plugin.
 - `puppeteer-extra-plugin-stealth`'s own GitHub repository,
   [berstend/puppeteer-extra](https://github.com/berstend/puppeteer-extra/tree/master/packages/puppeteer-extra-plugin-stealth),
-  read 2026-08-28, for its evasion module list.
-- Patchright, rebrowser-playwright, Camoufox, CreepJS, BotD and sannysoft, all named
-  above, are each sourced on their own linked comparison or explainer page in this
-  docs set rather than repeated here.
+  read 2026-08-30, for its evasion module list.
+- Patchright's own GitHub repository,
+  [Kaliiiiiiiiii-Vinyzu/patchright](https://github.com/Kaliiiiiiiiii-Vinyzu/patchright),
+  read 2026-08-30, for its Chromium-only scope and its `Runtime.enable` fix.
+- rebrowser-patches' own GitHub repository,
+  [rebrowser/rebrowser-patches](https://github.com/rebrowser/rebrowser-patches),
+  read 2026-08-30, for the same CDP fix, reached independently of Patchright.
+- Camoufox's own GitHub repository,
+  [daijro/camoufox](https://github.com/daijro/camoufox),
+  read 2026-08-30, for its own C++-level patching of a Firefox fork.
+- The three test suites named above: [CreepJS](https://github.com/abrahamjuliot/creepjs),
+  [BotD](https://github.com/fingerprintjs/BotD) and
+  [sannysoft](https://bot.sannysoft.com/), read 2026-08-30.
 - This project's own early fingerprint data, where the software-renderer GPU string
   mistake described above was found.
 

--- a/docs/recaptcha-v3-score.md
+++ b/docs/recaptcha-v3-score.md
@@ -57,13 +57,15 @@ second looks like a week of normal use.
 A stale cookie is a stronger signal against you than a missing one, and it is the part
 that is genuinely easy to get wrong - we did.
 
-Google **deprecated one of its long-standing cookies in 2022**. If you seed a profile
-from an article written before that, or from a capture taken years ago, your browser
-carries a cookie that current browsers no longer receive.
+Cookies age out on their own schedule, and **Google's own cookies are not exempt**: one
+that was standard practice a few years back can be retired, renamed, or replaced by one
+carrying different attributes. If you seed a profile from an article written years ago,
+or from a capture taken long before that, your browser can end up carrying a cookie
+current browsers no longer receive.
 
 A missing cookie says "this browser has not been here". A cookie that stopped existing
-three years ago says something far more specific: this profile was assembled from an
-old template. It is the same failure as claiming a GPU that no longer ships, or a user
+years ago says something far more specific: this profile was assembled from an old
+template. It is the same failure as claiming a GPU that no longer ships, or a user
 agent for a browser version that was never released.
 
 The general rule, and it applies well beyond cookies:
@@ -163,6 +165,11 @@ care about.
 
 - Google's own reCAPTCHA v3 documentation, [reCAPTCHA v3](https://developers.google.com/recaptcha/docs/v3),
   retrieved 2026-08-28, for the 0.0-1.0 behavioral score model described above.
+- MDN, [Document.cookie](https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie),
+  retrieved 2026-08-30, for what `document.cookie` exposes and what it does not.
+- This project's own cookie-seeding code, which derives a browsing history and its
+  cookies from the persona seed and deliberately excludes any cookie current browsers
+  no longer receive.
 
 **See also:** [the checklist for being detected on one site](playwright-detected-as-bot.md),
 where behaviour is step five and the address is step seven;
@@ -172,6 +179,7 @@ consistency argument in its clearest form; and
 
 ---
 
-*From the notes of [invisible_playwright](https://github.com/feder-cr/invisible_playwright),
-a Firefox patched at the C++ level. The excluded deprecated cookie is a real line in our
-source, with a comment explaining why, because we did include it once.*
+*Written while maintaining [invisible_playwright](https://github.com/feder-cr/invisible_playwright),
+a Firefox patched at the C++ level driven by stock Playwright. The excluded deprecated
+cookie is a real line in our source, with a comment explaining why, because we did
+include it once.*

--- a/docs/resist-fingerprinting.md
+++ b/docs/resist-fingerprinting.md
@@ -90,16 +90,17 @@ Pick a specific machine and be it, completely and consistently.
 
 That means every surface derives from the same source rather than being set
 independently: the user agent, the platform, the screen, the GPU strings, the font
-set, the audio stack, the timezone, the language list. And it means the timezone and
-locale follow the IP you are actually leaving from, and not either your host's
-values or a fixed UTC.
+set, the audio stack, the timezone, the language list. And it means
+[the timezone and locale follow the IP you are actually leaving from](timezone-proxy-mismatch.md),
+and not either your host's values or a fixed UTC.
 
 It also means not layering. Turning RFP on *and* setting a user agent *and* running a
 stealth plugin gives three components independently answering the same questions.
 They will not agree, and the disagreement is louder than any single wrong value.
 
 Concretely, in this project: the five preferences above are all set to `false`, and
-the identity comes from a seeded profile instead. Same seed, same machine, every run.
+the identity comes from a seeded profile instead.
+[Same seed, same machine, every run](reproducible-agent-browser-identity-seed.md).
 Different seed, a different machine that is equally unremarkable.
 
 ## When RFP is right and this is not
@@ -111,6 +112,16 @@ automation library is a substitute for it.
 The advice here is narrow: it applies when the thing on the other side is asking
 whether you are a browser and a person, and where being unusual costs you more than
 being identifiable.
+
+## Conclusion
+
+`privacy.resistFingerprinting` is a real, well-engineered privacy feature that solves
+the wrong problem for automation. It optimises for anonymity within the RFP
+population, and almost nobody is in that population, so switching it on trades one
+identifier for a smaller, more recognisable one. An automated session needs
+plausibility as a single, internally consistent machine, not uniformity with a tiny
+group everyone can name. That is why this project leaves the five preferences off and
+builds the identity from a seeded profile instead.
 
 ## Short answers to the questions that lead here
 

--- a/docs/sannysoft-explained.md
+++ b/docs/sannysoft-explained.md
@@ -81,7 +81,7 @@ values that cannot both be true.
 The canvas section is the most revealing test on the page, and it is not a
 fingerprint test at all: it checks whether your canvas gives the same answer in two
 different execution contexts. The element ids give this away: `canvas1`, `canvas2`,
-`canvas3`, `canvas4`, `canvas5`, and crucially **`canvas3-iframe`, `canvas4-iframe`,
+`canvas3`, `canvas4`, `canvas5`, and **`canvas3-iframe`, `canvas4-iframe`,
 `canvas5-iframe`**.
 
 Three of the canvas tests are run twice: once in the page, once inside an iframe, and

--- a/docs/screen-size-headless-tells.md
+++ b/docs/screen-size-headless-tells.md
@@ -64,7 +64,7 @@ interface, which is what headless actually is.
 **`outerHeight` should not be zero.** Some headless configurations report zero here,
 which is a value no visible window has.
 
-**The device pixel ratio has to be plausible for the resolution.** Common values are
+**The [device pixel ratio](https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio) has to be plausible for the resolution.** Common values are
 1, 1.25, 1.5 and 2. A ratio of 1 on a very high resolution, or a fractional ratio no
 operating system offers, is a made-up number. See
 [how devicePixelRatio is set per profile in Firefox](devicepixelratio-firefox-pref.md)
@@ -163,9 +163,12 @@ resolution where 1 is implausible.
   below the full display height.
 - [MDN: `Window.outerHeight`](https://developer.mozilla.org/en-US/docs/Web/API/Window/outerHeight),
   retrieved 2026-08-28, for the browser chrome that should separate it from `innerHeight`.
-- This project's own `webgl-renderer-strings.md`, for the time a resolution and
-  device-pixel-ratio pool sampled from real-world data handed out a software GPU for
-  the same reason it can hand out an unlucky screen size.
+- [MDN: `Window.devicePixelRatio`](https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio),
+  retrieved 2026-08-30, for the standard display ratios a real operating system offers.
+- This project's own fingerprint-generation logs, for the time a GPU pool sampled from
+  real-world data over-represented a software rasterizer, including in the seed used in
+  the quickstart examples, the same failure mode a resolution or device-pixel-ratio pool
+  can produce for a screen size.
 
 **See also:** [why headless browsers render different fonts](headless-fonts-differ.md)
 and [Firefox WebGL renderer strings](webgl-renderer-strings.md), the other two members

--- a/docs/timezone-proxy-mismatch.md
+++ b/docs/timezone-proxy-mismatch.md
@@ -58,8 +58,8 @@ The combinations that get caught most often:
   mechanisms in the browser, and one can be set while the other is not. Read both.
 - **`Accept-Language` disagreeing with `navigator.languages`.** Same list, two places,
   and the header is often set by a different layer than the browser property.
-- **The offset not matching the zone on that date.** `America/New_York` is -300 in
-  January and -240 in July. A hardcoded offset is right for half the year.
+- **The offset not matching the zone on that date.** `America/New_York` is 300 in
+  January and 240 in July. A hardcoded offset is right for half the year.
 
 ## Why the environment variable does not work
 
@@ -131,6 +131,16 @@ Through the proxy you actually deploy with, on a real page:
 5. Run the same page on a stock browser on a machine in that country, and diff.
 
 Step five is the one that catches what you did not think to check.
+
+## Conclusion
+
+A flagged timezone is rarely the one setting you already changed. It is usually one of
+the other surfaces still answering for your original machine: the locale, the
+`Accept-Language` header, the exit IP's country, or an offset that was right for one
+season and wrong for the other. The fix is structural, not another preference: derive
+the zone, the locale and the WebRTC address from the same proxy lookup, at launch, and
+refuse to fall back to the host when that lookup fails. Then check it the way a detector
+does, in a cross-origin iframe, against today's date.
 
 ## Short answers to the questions that lead here
 

--- a/docs/tostring-native-code-detection.md
+++ b/docs/tostring-native-code-detection.md
@@ -170,5 +170,6 @@ about artefacts you did not choose to add.
 ---
 
 *From the notes of [invisible_playwright](https://github.com/feder-cr/invisible_playwright),
-a Firefox patched at the C++ level. Everything above is the reason for that choice, and
-the paragraph about what it does not fix is the reason it is not a complete answer.*
+a Firefox patched at the C++ level. There is no toString shim anywhere in this codebase for
+the pristine-reference check to catch, because the getter it would have to disguise was
+never overridden in the first place.*

--- a/docs/webgl-parameters-are-identical.md
+++ b/docs/webgl-parameters-are-identical.md
@@ -18,11 +18,9 @@ gets you caught.
 
 The most repeated advice about WebGL fingerprinting goes the other way: if you claim a
 high-end card, you must also raise `MAX_TEXTURE_SIZE` and the forty-odd other numeric
-limits to match, or you have reported an expensive GPU with a cheap card's ceiling.
-
-That advice is backwards, at least on Windows, which is the platform most people are
-claiming. Raising those numbers to "match" the card is how you leave the set of values
-real browsers produce.
+limits to match, or you have reported an expensive GPU with a cheap card's ceiling. That
+advice is backwards, at least on Windows, which is the platform most people are claiming
+it on.
 
 ## What ANGLE does to the numbers
 
@@ -175,9 +173,10 @@ the host platform rather than the card.
   retrieved 2026-08-28, for the extension-list behavior described above.
 - ANGLE's own [D3D11 renderer utilities](https://github.com/google/angle/blob/main/src/libANGLE/renderer/d3d/d3d11/renderer11_utils.cpp)
   (`renderer11_utils.cpp`), retrieved 2026-08-28, where the capability block is generated
-  from the D3D feature level rather than the physical card, and the public surveys of WebGL
-  parameter distributions mentioned above (no specific survey is named in these notes, so
-  none is linked here).
+  from the D3D feature level rather than the physical card.
+- [Web3D Survey's WebGL capabilities report](https://web3dsurvey.com/webgl), retrieved
+  2026-08-28, the public survey of real-world WebGL parameter and extension support
+  referenced above.
 - This project's own testing: an earlier version of this project randomised the numeric
   WebGL limits per session, and the CreepJS low-entropy classification described above is
   what drove the numbers back to the canonical block.

--- a/docs/webgl-renderer-strings.md
+++ b/docs/webgl-renderer-strings.md
@@ -173,6 +173,11 @@ shader model plausible for its generation, and consistent with the platform you 
 - [ANGLE](https://github.com/google/angle), Google's own repository, read 2026-08-28,
   for the OpenGL-ES-to-Direct3D translation layer Firefox uses on Windows and the
   reason the renderer string begins `ANGLE (`.
+- Mozilla's own tracking bug, [Bugzilla 583838, "use ANGLE if available for WebGL
+  under D3D"](https://bugzilla.mozilla.org/show_bug.cgi?id=583838), retrieved
+  2026-08-30, for Firefox using ANGLE when native OpenGL is unavailable or when
+  rendering through Direct3D performs better, which is why the string appears at
+  all on Windows.
 - [MDN Web Docs: `WebGLRenderingContext.getSupportedExtensions()`](https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/getSupportedExtensions),
   retrieved 2026-08-28, for the extension list used as a cross-check against a spoofed
   renderer string.


### PR DESCRIPTION
Second pass on files that had already received citation fixes but not the full review: score against the corpus rubric, fix what the score found, independent re-verify.

26 of 38 files had real content to fix; the rest were already clean and got no edit.

Recurring finds across this batch: missing Conclusion sections before the FAQ (5 files), near-duplicate paragraphs, an unverifiable specific claim about a Google cookie deprecation date replaced with a defensible general statement, inconsistent Sources retrieval dates, and citations that named a tool without linking it.

navigator-webdriver-explained.md is deliberately excluded here - its one real defect (a wrong claim about the current spec-compliant default of navigator.webdriver) is a separate PR, #109.

465 tests passed in an isolated environment (invisible-core installed from the index, not the local dev tree).