### PR TITLE
6 more docs: hCaptcha's missing pages, 2 verbatim errors, TOTP 2FA

### DIFF
--- a/docs/automating-email-otp-verification-login-playwright.md
+++ b/docs/automating-email-otp-verification-login-playwright.md
@@ -260,7 +260,10 @@ inbox and credentials that are actually yours.
 - This project's own notes on session and fingerprint consistency, linked throughout,
   for why the request and the redemption belong in one identity.
 
-**See also:** [Why automating login is riskier than reusing a session](automating-login-vs-session-reuse.md)
+**See also:** [Automating TOTP-Based 2FA Login with Playwright](automating-totp-2fa-login-playwright.md)
+for the other common second-login-step mechanism, a locally computed authenticator
+code with no inbox and no polling involved at all, [Why automating login is riskier
+than reusing a session](automating-login-vs-session-reuse.md)
 for the fingerprint-consistency argument this page depends on,
 [how to scrape data behind a login with Playwright](how-to-scrape-behind-login-playwright.md)
 for the end-to-end session-reuse pattern this flow feeds into, and

--- a/docs/automating-totp-2fa-login-playwright.md
+++ b/docs/automating-totp-2fa-login-playwright.md
@@ -1,0 +1,271 @@
+---
+title: "Automating TOTP-Based 2FA Login with Playwright"
+description: "Generate a time-based one-time code with pyotp from the same shared secret an authenticator app would scan as a QR code, and feed it straight into the login form. No inbox, no polling, no IMAP - for testing your own application's 2FA flow."
+parent: "Scraping with Playwright"
+grand_parent: "Guides"
+nav_order: 147
+---
+
+
+# Automating TOTP-Based 2FA Login with Playwright
+
+This page is about a specific, ordinary testing need: your own application, or an
+account you control, has authenticator-app two-factor authentication turned on,
+and a test or a script needs to complete the login end to end without a human
+opening Google Authenticator or Authy on a phone. The mechanism is cryptographic,
+not network-based: a time-based one-time password (TOTP) is computed on the spot
+from a shared secret you already hold, the same secret an authenticator app would
+have scanned as a QR code the day 2FA was set up. Nothing here assumes or requires
+access to an account that is not yours, and the whole point of writing this down
+is to keep the automation scoped to accounts you actually control.
+
+## This is not the email-OTP page, on purpose
+
+If you came here from [automating an email OTP or magic-link
+login](automating-email-otp-verification-login-playwright.md), the two pages solve
+the same category of problem, "get past a second login step," with genuinely
+different mechanics, and it is worth being explicit about which one your situation
+actually needs.
+
+| | Email OTP / magic link | TOTP authenticator |
+|---|---|---|
+| Where the code comes from | The site generates and emails it *after* you trigger the send | You generate it yourself, locally, from a secret you already hold |
+| What you need on hand | IMAP credentials, or a test-inbox API | Nothing but the shared secret and a library |
+| Timing model | Poll a real mailbox against a deadline; codes can take seconds to arrive and can expire in minutes | Instant; no network call, no waiting, no inbox at all |
+| Failure mode | Mailbox rate limits, expired links, stale messages from old runs | Clock drift between your machine and the server, a mismatched digit/period setting |
+
+The email-OTP page spends most of its length on `imaplib`, timestamps, and polling
+loops, because the hard part there is coordinating with a mailbox on the network.
+None of that exists here. If your two-factor step involves opening a mail client,
+you want that page. If it involves an authenticator app and a 6-digit code that
+refreshes every 30 seconds, you want this one.
+
+## The shape of the flow
+
+```python
+import pyotp
+from invisible_playwright import InvisiblePlaywright
+
+SEED = 42
+TOTP_SECRET = "JBSWY3DPEHPK3PXP"   # the same secret your authenticator app holds
+
+with InvisiblePlaywright(seed=SEED) as browser:
+    page = browser.new_page()
+    page.goto("https://example.com/login")
+    page.fill("#email", "you@example.com")
+    page.fill("#password", "your-password")
+    page.click("#sign-in")
+
+    page.wait_for_selector("#totp-code")          # the 2FA step actually appeared
+    code = pyotp.TOTP(TOTP_SECRET).now()
+    page.fill("#totp-code", code)
+    page.click("#verify")
+    page.wait_for_url("https://example.com/account")
+```
+
+There is no step 2 that waits on anything external. `pyotp.TOTP(TOTP_SECRET).now()`
+returns a code synchronously, in microseconds, because it is a computation, not a
+request.
+
+## Where the secret comes from
+
+The shared secret is not something you invent; it is the same value your own
+application generated when you (or a test account you control) turned on
+authenticator-app 2FA. During that setup flow, most applications show a QR code
+and, next to it, a plain-text fallback string for anyone whose phone camera does
+not work. That fallback string is a base32-encoded secret, and it is exactly what
+an authenticator app decodes out of the QR code before storing it. Google's own
+specification for the format authenticator apps read, the `otpauth://` URI scheme,
+states it directly: the QR code encodes a URI whose `secret` parameter is "an
+arbitrary key value encoded in Base32," and that URI is "what get[s] converted
+into QR codes during the setup process for authenticator applications." Capture
+that string once, during your own account's enrollment, store it the way you would
+store any other test credential, and `pyotp.TOTP(secret)` consumes it identically
+to how a phone's authenticator app would.
+
+```python
+import pyotp
+
+# provisioning_uri() is what you would render as a QR code for a human;
+# reading the same secret directly is what a script needs instead.
+secret = pyotp.random_base32()
+uri = pyotp.totp.TOTP(secret).provisioning_uri(name="you@example.com", issuer_name="Example App")
+print(uri)     # otpauth://totp/Example%20App:you%40example.com?secret=...&issuer=Example%20App
+```
+
+Do not try to re-derive the secret from a screenshot of the QR code on every test
+run. Capture it once, during setup, the same way you would capture a password.
+
+## Generating the code
+
+[PyOTP's own documentation](https://pyotp.readthedocs.io/en/stable/) describes the
+library plainly: it generates and verifies one-time passwords for two-factor and
+multi-factor authentication. The call that matters is one line:
+
+```python
+import pyotp
+
+totp = pyotp.TOTP(secret)
+code = totp.now()      # e.g. "492039"
+```
+
+`.now()` computes the code for the current 30-second window and returns it as a
+string. There is no client-server round trip anywhere in this call; the entire
+value is derived from the secret and the current time.
+
+### The algorithm, briefly
+
+TOTP is defined in [RFC 6238](https://datatracker.ietf.org/doc/html/rfc6238) as a
+time-based variant of HOTP (RFC 4226), the counter-based one-time-password
+algorithm. The RFC states the relationship directly: `TOTP = HOTP(K, T)`, where
+`T` is a moving factor computed as `(Current Unix time - T0) / X`, with `X` the
+time step, 30 seconds by default, and `T0` the Unix epoch. In plain terms: instead
+of HOTP's incrementing counter, TOTP uses "which 30-second slice of time is it
+right now" as the counter, and HMACs that against the shared secret the same way
+HOTP always has. Both your script and the server computing the same thing from the
+same secret and the same clock arrive at the same 6-digit code, which is the whole
+mechanism 2FA setup relies on, and the whole reason no network call is involved on
+either generation or verification.
+
+### Matching digits, algorithm and period to what the site actually issued
+
+`pyotp.TOTP()` defaults to 6 digits, SHA1, and a 30-second period, which matches
+the overwhelming majority of sites' authenticator-app implementations. If your
+target application's enrollment page shows different values, in an advanced setup
+screen or in the raw `otpauth://` URI, pass them explicitly:
+
+```python
+totp = pyotp.TOTP(secret, digits=8, digest=hashlib.sha256, interval=60)
+```
+
+A code generated with the wrong digit count, algorithm or interval will not match
+what the server expects, and this looks identical to "the automation is broken"
+from the outside. Read the parameters out of the actual `otpauth://` URI your
+application issued rather than assuming the defaults.
+
+## Clock drift and reuse, the two real failure modes
+
+Two practical issues account for nearly every TOTP automation failure that is not
+a plain wrong secret.
+
+**Clock drift.** TOTP's whole security model rests on both sides agreeing what
+time it is. If the machine running your script and the server verifying the code
+disagree by more than roughly one time step, the code you generate is for the
+wrong window and gets rejected as invalid even though the secret is correct.
+`pyotp.TOTP.verify()` accepts a `valid_window` argument specifically for this: it
+checks the current window plus a configurable number of windows on either side,
+which is the standard tolerance most real verifiers apply server-side too. If
+you are generating and submitting the code yourself rather than verifying it, the
+practical fix is keeping the machine running the automation on synced NTP time,
+not widening a window you do not control on the server end.
+
+**Code reuse inside the same window.** Some applications reject submitting the
+same TOTP code twice, even if it is still numerically valid, as a replay defense.
+If a test suite runs the login flow twice in quick succession and happens to land
+in the same 30-second window both times, the second attempt can fail for a reason
+that has nothing to do with the code being wrong. This is intermittent by nature,
+tied to wall-clock timing rather than your code, and the fix is either spacing
+runs apart or, if the site's session allows it, not re-authenticating a fresh TOTP
+challenge more than once per window in automated test loops.
+
+## Storing the secret safely
+
+The shared secret is a long-lived credential, not a one-time value; anyone who has
+it can generate valid codes for as long as 2FA stays configured with it. Treat it
+the way you would treat a password: an environment variable or a secrets manager
+in CI, never a literal string committed to a repository. This is the same
+housekeeping any other test credential needs, and it is worth stating because a
+TOTP secret is easy to underestimate: unlike a password, it never gets rotated by
+a failed-login lockout, so a leaked one stays valid indefinitely.
+
+## Conclusion
+
+TOTP-based 2FA automates in two lines once you have the secret: `pyotp.TOTP(secret).now()`
+to compute the current code, and a `page.fill()` into whatever field the login
+form shows for it. The mechanism is entirely local and cryptographic, RFC
+6238's HMAC-over-time-step algorithm, with no inbox, no IMAP connection, and no
+polling loop anywhere in it, which is the whole difference from [the email-OTP
+flow](automating-email-otp-verification-login-playwright.md) this page is most
+often confused with. The parts worth being careful about are capturing the secret
+once during your own account's real enrollment rather than trying to re-scan a QR
+code every run, matching the digit count, algorithm and period the site actually
+issued, and keeping the automation's clock in sync so the code you compute lands
+in the same window the server checks against.
+
+## Short answers to the questions that lead here
+
+**How do I automate a login protected by an authenticator app?** Get the shared
+secret from your own account's 2FA enrollment (the base32 string next to the QR
+code), then call `pyotp.TOTP(secret).now()` to generate the current code and fill
+it into the login form, in the same script, right after triggering the login.
+
+**Is this the same as automating an email OTP login?** No. [Email OTP](automating-email-otp-verification-login-playwright.md)
+requires triggering a send and polling a real mailbox over IMAP until the code
+arrives. TOTP requires no network call at all: you already hold the secret, and
+the code is computed instantly and locally from it and the current time.
+
+**Where do I get the TOTP secret in the first place?** From your own account's 2FA
+setup screen, the same base32 string an authenticator app decodes out of the QR
+code. Capture it once during enrollment and store it like any other credential;
+do not try to re-derive it from a screenshot on every run.
+
+**Why does the generated code get rejected even though the secret is right?**
+Almost always clock drift between the machine generating the code and the server
+verifying it, or a mismatch in digits, hash algorithm or time-step length against
+what the site actually issued. Check both before assuming the secret itself is
+wrong.
+
+**Can I run the login twice in a row with the same code?** Some applications
+reject reusing a TOTP code inside the same 30-second window as a replay defense,
+independent of whether the code is still numerically valid. Space repeated
+automated logins apart if you see intermittent rejections tied to timing.
+
+**Is this a way to get into an account that is not mine?** No. It only works
+against an account whose 2FA you set up yourself and whose secret you hold. The
+technique automates a flow you already have legitimate access to, the same
+category as reusing a saved session or automating an email OTP for your own
+inbox; it does not solve, guess or bypass anything, and it is worthless against a
+secret you were never given.
+
+## Sources
+
+- [PyOTP's own documentation](https://pyotp.readthedocs.io/en/stable/) and its
+  [GitHub repository](https://github.com/pyauth/pyotp), for the `TOTP` class,
+  `.now()`, `.verify()` and `valid_window`, and `provisioning_uri()`, retrieved
+  2026-08-30.
+- [RFC 6238](https://datatracker.ietf.org/doc/html/rfc6238), "TOTP: Time-Based
+  One-Time Password Algorithm," for the `TOTP = HOTP(K, T)` definition and the
+  `T = (Current Unix time - T0) / X` moving-factor formula, retrieved 2026-08-30.
+- [RFC 4226](https://datatracker.ietf.org/doc/html/rfc4226), the HOTP algorithm
+  TOTP extends with a time-derived counter in place of an incrementing one.
+- Google's [Key Uri Format](https://github.com/google/google-authenticator/wiki/Key-Uri-Format)
+  specification, for the `otpauth://` URI scheme, the base32 `secret` parameter,
+  and its role as what actually gets encoded into a 2FA setup QR code, retrieved
+  2026-08-30.
+- Checkly's own [How to Bypass Time-Based 2FA Login Flows With
+  Playwright](https://www.checklyhq.com/docs/learn/playwright/bypass-totp/),
+  verified live this session, for a real, independent walkthrough of the same
+  generate-then-fill pattern (using the JavaScript `otpauth` library against a
+  personal GitHub account's own TOTP secret, explicitly scoped to an account the
+  reader already controls).
+- Playwrightsolutions.com's [Playwright Login Test With Two Factor Authentication
+  (2FA) Enabled (TOTP)](https://playwrightsolutions.com/playwright-login-test-with-2-factor-authentication-2fa-enabled/),
+  verified live this session, for another independent practitioner writeup of the
+  same mechanism.
+
+**See also:** [Automating an Email OTP / Verification-Link Login with
+Playwright](automating-email-otp-verification-login-playwright.md) for the
+network-polling variant of "get past a second login step" this page deliberately
+does not overlap with, [why automating login is riskier than reusing a
+session](automating-login-vs-session-reuse.md) for the fingerprint-consistency
+argument that applies to any login automation, and [how to scrape data behind a
+login with Playwright](how-to-scrape-behind-login-playwright.md) for the
+session-reuse pattern this flow feeds into once the 2FA step is past.
+
+---
+
+*From the notes of [invisible_playwright](https://github.com/feder-cr/invisible_playwright),
+a Firefox patched at the C++ level. Generating a code from a secret you already
+hold is arithmetic, not automation trickery; the browser's realness has nothing to
+do with whether the math is correct, and the whole flow is worthless without a
+secret that was legitimately yours to begin with.*

--- a/docs/does-playwright-trigger-hcaptcha.md
+++ b/docs/does-playwright-trigger-hcaptcha.md
@@ -1,0 +1,186 @@
+---
+title: "Does Playwright Trigger hCaptcha More Often?"
+description: "Why Playwright sessions escalate to hCaptcha's visual challenge more often. How hCaptcha's invisible pass reads fingerprint, IP, and session inputs, and which of those a browser engine can actually move."
+parent: "Testing and Troubleshooting"
+grand_parent: "Guides"
+nav_order: 26
+---
+
+
+# Does Playwright Trigger hCaptcha More Often?
+
+Often, yes. hCaptcha runs an invisible risk pass before it ever shows anything, and a
+default Playwright session gives that pass more reasons to escalate than a browser a
+person has actually been using does. That is not a single "this is Playwright" flag
+either. It is the same shape of problem covered on
+[the reCAPTCHA version of this page](does-playwright-trigger-recaptcha.md): several
+inputs, most of them not published, several of them pushed the wrong way at once by a
+fresh automated context.
+
+[hCaptcha, Explained](hcaptcha-explained.md) covers the two-stage mechanism in full,
+the invisible pass and the visual puzzle it falls back to. This page is about what tips
+that first stage toward showing you the second one, and which parts of that a
+patched, engine-level browser can actually change.
+
+## What the invisible pass is deciding
+
+hCaptcha's own documentation frames the decision at category level only: a challenge
+appears based on "computed confidence in the visitor's humanity, the site difficulty
+setting, and other security factors," and hCaptcha's Pro-tier docs describe the
+underlying evaluation as drawn from "thousands of factors," aimed at keeping visible
+challenges under roughly 0.1% of real visitors. Neither document names the specific
+signals or their weights, and this page does not claim to know them either, the same
+honesty this corpus applies to [Arkose's undisclosed "225+ risk signals"](arkose-labs-funcaptcha-explained.md#what-arkoses-own-materials-say-and-where-they-stop).
+
+What is confirmed, from hCaptcha's own API surface, is that the server-side
+`siteverify` call accepts an optional `remoteip` parameter that hCaptcha's own docs say
+improves the check's accuracy, which is a direct acknowledgment that the requesting
+address is one of the inputs, alongside whatever the client-side script itself collects.
+
+## The inputs that plausibly feed the score
+
+Reasoning from what a browser-based risk pass generally reads, and from hCaptcha's own
+partial disclosures, the same broad families that drive
+[reCAPTCHA's score](does-playwright-trigger-recaptcha.md#the-inputs-that-feed-the-score)
+apply here too:
+
+- **Fingerprint and engine consistency.** Whether the browser's claimed identity agrees
+  with how it actually behaves, an inconsistency this corpus has documented in general
+  through [`navigator.webdriver`](does-playwright-set-navigator-webdriver.md) and other
+  automation tells that a stock automated launch leaves in place.
+- **IP reputation.** Confirmed as an input via the `remoteip` parameter above. A
+  datacenter address or one already flagged by other traffic raises suspicion regardless
+  of what the browser reports.
+- **Session and cookie history.** A brand-new context with nothing behind it looks
+  different from a browser that has actually been used, the same "a fresh profile has no
+  past" argument [made in full on the reCAPTCHA v3 score page](recaptcha-v3-score.md).
+- **Interaction pattern.** How the page got its click or its keystrokes, before the
+  challenge ever renders, is part of what "other security factors" plausibly covers,
+  though hCaptcha's own docs do not spell this out explicitly.
+
+One nuance worth being precise about: hCaptcha's own marketing draws a contrast with
+"traditional fingerprints," describing its passive modes as working "without
+fingerprinting" and framing device fingerprints as becoming obsolete as a detection
+tool. Read that as a positioning claim about where hCaptcha says it is putting its
+effort, not as proof that browser-level consistency checks play no role at all in the
+undisclosed "thousands of factors." hCaptcha does not publish enough for either reading
+to be stated as settled fact, and this page does not pretend otherwise.
+
+## Which input the browser layer actually moves
+
+Of those families, the browser engine itself can only speak to one: whether the
+JavaScript-visible surface of the browser is internally consistent and behaves like a
+genuine instance of the engine it claims to be. Stock Playwright driving stock Firefox
+or Chromium leaves a scattering of small disagreements here, an automation property
+like `navigator.webdriver`, a headless context missing a real GPU, a font set or codec
+list that does not match the claimed platform. Each one is a plausible, if unconfirmed,
+contributor to whatever "other security factors" hCaptcha's decision actually weighs.
+
+IP reputation, session history and interaction pattern are not properties of the
+browser engine at all. No amount of patching below the JavaScript layer manufactures a
+browsing history, warms a cold IP, or paces a click for you.
+
+## What invisible_playwright does, and a two-line example
+
+invisible_playwright is a Firefox patched at the C++ level and driven by stock
+Playwright. Its contribution to this specific problem is the fingerprint-and-engine
+input: instead of a scattering of disagreements, it presents one coherent real Firefox,
+with GPU, audio, fonts, screen and roughly 400 fields derived together from a single
+seed so they agree with each other and with a genuine desktop build.
+
+Switching from plain Playwright is two lines, and every Playwright method works
+unchanged because the returned object is a real Playwright
+[`Browser`](https://playwright.dev/python/docs/api/class-browser):
+
+```python
+from invisible_playwright import InvisiblePlaywright
+
+# seed=42 makes the identity reproducible: same GPU, fonts, canvas hash every run
+with InvisiblePlaywright(seed=42, proxy={
+    "server": "socks5://gate.example.com:1080",
+    "username": "user",
+    "password": "pass",
+}) as browser:
+    page = browser.new_page()
+    page.goto("https://example.com/signup")
+    page.click("#submit")   # pointer arcs to the button on a Bezier curve
+```
+
+The reproducible seed matters for debugging this specific problem: if a run escalates
+to hCaptcha's visual challenge, replay the exact same identity and change one variable,
+the proxy, the timing, the target page, at a time, rather than guessing whether the
+site's own thresholds moved or the browser did.
+
+What this buys you is a smaller fingerprint-and-consistency contribution to whatever the
+invisible pass weighs. It does not touch the address you connect from, the history that
+session does or does not carry, or the rhythm of your own clicks, and it does not
+"solve" hCaptcha's pass/fail decision. There is no such thing, and this project does not
+claim to have found one.
+
+## The inputs the browser cannot move
+
+These stay yours to bring, and no browser-engine patch substitutes for them:
+
+- **IP reputation.** A perfect fingerprint on a listed or overused address is still on a
+  bad address. Rule out the exit first; see
+  [how ASN and IP reputation feed bot detection](asn-and-ip-reputation-in-bot-detection.md).
+- **Session age.** A cookieless, day-zero context reads as fresh every single time.
+  Warming a session or reusing storage state moves this, and it is not the browser's job.
+- **Behavior and timing.** Mechanical pacing scores against you no matter how real the
+  browser looks underneath it.
+
+If the fingerprint is coherent and the visible puzzle still shows up, the cause is one
+of these three, not the engine.
+
+## Short answers to the questions that lead here
+
+**Does Playwright itself get flagged by hCaptcha?** Not as a single named flag. hCaptcha
+does not publish its criteria, but a default Playwright session tends to combine an
+inconsistent browser fingerprint with a fresh, historyless session, both plausible
+contributors to whatever pushes the invisible pass toward escalating.
+
+**Will a stealth browser stop hCaptcha's visual challenge from appearing?** It can lower
+the fingerprint-and-engine-consistency contribution. It does nothing for the IP address,
+the session's age, or your own timing, so on its own it will not stop every challenge.
+
+**Can any browser guarantee I never see the puzzle?** No. hCaptcha's decision draws on
+undisclosed inputs the browser does not fully control, and even if it did, this project
+does not sell or claim a captcha-solving outcome for the puzzle itself.
+
+**Is it the IP or the browser?** Test it directly: visit the same page by hand from the
+same machine and network. If the manual visit also escalates, look at the exit first,
+using [the detection checklist](playwright-detected-as-bot.md) to work the split in
+order.
+
+**Does hCaptcha's "no fingerprinting" claim mean the browser doesn't matter?** Not
+necessarily. It is hCaptcha's own positioning against traditional device fingerprints,
+not a disclosure of the full input list behind its "thousands of factors." Treat it as a
+marketing claim to weigh, not as proof the browser layer is irrelevant.
+
+## Sources
+
+- hCaptcha, [Frequently Asked Questions](https://docs.hcaptcha.com/faq), retrieved
+  2026-08-30, for the "computed confidence... site difficulty... other security
+  factors" framing of the challenge decision.
+- hCaptcha, [Pro Features](https://docs.hcaptcha.com/pro), retrieved 2026-08-30, for the
+  "thousands of factors" and "less than 0.1%" description of the passive evaluation.
+- hCaptcha, [Developer Guide](https://docs.hcaptcha.com/), retrieved 2026-08-30, for the
+  `remoteip` parameter on the `siteverify` endpoint.
+- hCaptcha, [homepage](https://www.hcaptcha.com/), retrieved 2026-08-30, for the
+  "without fingerprinting" and traditional-fingerprints-are-obsolete positioning quoted
+  and weighed above.
+- This project's fingerprint generation, which derives roughly 400 fields from one seed
+  so they agree with each other rather than contradicting.
+
+**See also:** [hCaptcha, Explained](hcaptcha-explained.md) for the full two-stage
+mechanism this page assumes; [Does Playwright Trigger reCAPTCHA More Often?](does-playwright-trigger-recaptcha.md)
+for the structurally identical argument on Google's product; [how a browser trust score
+is assembled](browser-trust-score-explained.md); and
+[the checklist for being detected on one site](playwright-detected-as-bot.md).
+
+---
+
+*Written while maintaining [invisible_playwright](https://github.com/feder-cr/invisible_playwright),
+a Firefox patched at the C++ level driven by stock Playwright. It moves the
+fingerprint-and-engine input into hCaptcha's invisible pass; the clean exit, the session
+history and the timing are still yours to bring.*

--- a/docs/guides-detectors-explained.md
+++ b/docs/guides-detectors-explained.md
@@ -43,6 +43,8 @@ whether a browser is telling the truth about what it claims to be.
 - [Vercel Bot Protection (BotID), Explained](vercel-bot-protection-botid-explained.md) - a client-side challenge plus an optional Kasada-powered Deep Analysis tier, including real false-positive reports.
 - [GeeTest v4 (Slide/Click Captcha), Explained](geetest-v4-explained.md) - drag, tap-in-order or match-three, encrypted client-side and verified server-side.
 - [Honeypot Fields and Hidden Links: How Sites Trap Scrapers](honeypot-fields-explained.md) - a field or link a real visitor never sees, that a script reading raw DOM will trigger.
+- [hCaptcha, Explained](hcaptcha-explained.md) - an invisible risk pass first, a visual puzzle only when unsure, and a data-labeling business underneath.
+- [hCaptcha Enterprise vs Standard](hcaptcha-enterprise-vs-standard.md) - the same mechanism, plus custom difficulty tuning, dedicated risk models and an SLA instead of the free tier's labeled-data economy.
 
 ## What a fingerprint is and how accurate it is
 

--- a/docs/guides-scraping-with-playwright.md
+++ b/docs/guides-scraping-with-playwright.md
@@ -195,3 +195,4 @@ for the model that orders the rest, then pick the task you have.
 - [How to Handle a PDF That Opens in a New Tab with Playwright](how-to-handle-pdf-opens-new-tab-playwright.md) - Catch the new page with `context.expect_page()`, then pull the real bytes instead of screenshotting the viewer.
 - [Does Playwright Support Firefox Extensions?](does-playwright-support-firefox-extensions.md) - The documented extension API is Chromium-only; loading an .xpi into Firefox means a persistent profile, not a launch flag.
 - [Automating an Email OTP / Verification-Link Login with Playwright](automating-email-otp-verification-login-playwright.md) - Poll your own inbox over IMAP mid-login and feed the code back into the same session that requested it.
+- [Automating TOTP-Based 2FA Login with Playwright](automating-totp-2fa-login-playwright.md) - Generate a time-based code with pyotp from the same shared secret an authenticator app would scan; no inbox, no polling.

--- a/docs/guides-testing-troubleshooting.md
+++ b/docs/guides-testing-troubleshooting.md
@@ -33,6 +33,9 @@ telling the difference before you ship a fix, not after.
 - [Content-Security-Policy Blocks Playwright's Injected Scripts](content-security-policy-blocks-playwright-scripts.md) - A page's CSP can refuse `addInitScript`; what `bypassCSP` fixes and what it changes about the test.
 - [Playwright "Executable Doesn't Exist" After Install](playwright-executable-doesnt-exist.md) - The most common first-run error, and its Docker, CI and serverless variants.
 - [Playwright "Page Crashed" Error](playwright-page-crashed-error.md) - An OOM-killed content process versus an actual engine bug, and how to tell them apart.
+- [Does Playwright Trigger hCaptcha More Often?](does-playwright-trigger-hcaptcha.md) - How hCaptcha's invisible pass reads fingerprint, IP and session inputs, and which of those an engine can actually move.
+- [Playwright Firefox: SEC_ERROR_UNKNOWN_ISSUER](playwright-firefox-sec-error-unknown-issuer.md) - Firefox's own NSS certificate-trust error, not a Chromium string; why curl works in a container and Firefox still fails.
+- [Playwright ERR_BLOCKED_BY_CLIENT via page.route](playwright-err-blocked-by-client-page-route.md) - Request blocking with `page.route()` reproduces the exact string a real ad-blocker extension produces.
 
 ## When you get blocked or detected
 

--- a/docs/hcaptcha-enterprise-vs-standard.md
+++ b/docs/hcaptcha-enterprise-vs-standard.md
@@ -1,0 +1,198 @@
+---
+title: "hCaptcha Enterprise vs Standard"
+description: "hCaptcha Enterprise is not a harder version of the free widget, it is the same invisible-pass-plus-puzzle mechanism with custom difficulty tuning, dedicated risk models, an SLA, and a cash relationship instead of the free tier's labeled-data economy. What changes, from hCaptcha's own docs."
+parent: "Detectors, Explained"
+grand_parent: "Guides"
+nav_order: 43
+---
+
+
+# hCaptcha Enterprise vs Standard
+
+This page assumes you already know how hCaptcha's two-stage mechanism works, the
+invisible risk pass and the visual puzzle it escalates to when that pass is unsure.
+[That is covered in full on its own page](hcaptcha-explained.md), and this one does not
+repeat it. What follows is specifically what changes between the free Basic tier, the
+mid-tier Pro plan, and Enterprise: what each adds, what it costs, and which parts stay,
+underneath, the same mechanism.
+
+The short version: Enterprise is not a stricter widget. It is the same
+checkbox-or-invisible, escalate-to-a-puzzle model, given a visible risk score, custom
+challenge content, difficulty controls a free integration never sees, and a support
+contract, sold as a metered or negotiated product rather than embedded for free in
+exchange for the puzzle answers themselves.
+
+## Three tiers, not two
+
+hCaptcha's own pricing and plans pages describe three tiers, not a simple free/paid
+split. **Basic** is free, with an allowance hCaptcha's own plans page states as "10,000
+requests/month," and hCaptcha's own FAQ describes Basic ("Publisher") accounts as
+choosing among four fixed difficulty modes: "Easy, Medium, Difficult, and Auto." **Pro**
+is a paid, self-serve tier priced, per hCaptcha's own pricing page, at "$99/month"
+billed annually or "$139/month" billed monthly, including 100,000 evaluations a month
+with overage at "$0.99/1K" beyond that, with a two-week free trial. **Enterprise** is
+custom-priced and sold through a sales contact rather than a checkout page.
+
+## What Pro adds over Basic
+
+Pro's own documentation describes its centerpiece as "99.9% Passive" mode, the default
+for new Pro sitekeys, an evaluation "derived from thousands of factors" aimed at showing
+a visible challenge to "less than 0.1% of users" while still, per hCaptcha's own
+framing, "increasing the costs of an attack in virtually all cases." hCaptcha's own
+plans page lists Pro as also adding bot risk scores and threat signatures, custom
+widget themes, more detailed analytics than Basic, and room for a small team, up to five
+members, to share sitekeys and dashboards.
+
+None of this exists on Basic. A Basic integration is limited to the four fixed
+difficulty levels named above and does not get the passive-mode risk evaluation, the
+score, or the analytics.
+
+## What Enterprise adds on top of Pro
+
+This is the part that is a genuine capability gap rather than a bigger number on the
+same feature, and hCaptcha's own plans page names it directly: **private learning**,
+described as training detection models on an Enterprise customer's own traffic patterns
+rather than a shared, general model, plus **custom challenges** and **challenge content
+control**, meaning an Enterprise account can bring its own images or questions instead
+of using hCaptcha's default challenge pool. hCaptcha's plans page also lists **human
+threat detection**, **difficulty tuning**, called out specifically as including the
+ability to "raise and lower challenge difficulty based on time of day," and, on the
+program-management side, multi-user dashboards with SAML SSO, advanced analytics and
+reporting APIs, and Enterprise-level SLAs.
+
+hCaptcha's own FAQ separately describes Enterprise as unlocking two difficulty modes
+Pro and Basic do not have at all, "Passive" alongside "99.9% Passive," plus
+"sophisticated custom threat models" and "detailed bot scores" beyond what Pro's flat
+risk score exposes.
+
+Put together, the shape of the gap is: Pro turns on a shared risk model and a passive
+mode; Enterprise turns on a model trained specifically on that customer's own traffic,
+gives that customer direct control over what the puzzle even looks like, and adds the
+operational scaffolding (SLA, SSO, reporting) an organization actually deploying this at
+scale asks for. None of it is a stricter version of the puzzle itself, it is control
+over when and how the puzzle appears, and how well the risk model fits one customer's
+own traffic rather than the general population hCaptcha sees.
+
+| | Basic (free) | Pro | Enterprise |
+|---|---|---|---|
+| Price | $0 | $99-139/mo, 100K evals incl. | Custom |
+| Difficulty control | 4 fixed modes (Easy/Medium/Difficult/Auto) | Adds 99.9% Passive | Adds Passive, plus time-of-day tuning |
+| Risk score visible to you | No | Yes (bot risk scores, threat signatures) | Yes, plus custom threat models |
+| Model trained on | Shared, general | Shared, general | Your own traffic ("private learning") |
+| Challenge content | hCaptcha's default pool | hCaptcha's default pool | Customer-supplied images/questions |
+| Team/SSO/SLA | No | Up to 5 users | Multi-user dashboards, SAML SSO, SLA |
+
+## The relationship changes too, not just the feature list
+
+This is the differentiator that is easy to miss if you only read the feature tables,
+and it is stated plainly in a blog post from HUMAN Protocol, the labor marketplace
+hCaptcha's compensation model runs through: "hCaptcha also compensates integrators for
+the work their users do as they verify their humanity," framing that work as
+"annotation" feeding machine-learning training. The same post draws the Enterprise line
+explicitly: "Enterprise integrators of the hCaptcha security service like Cloudflare pay
+IM [Intuition Machines] for more features, rather than being compensated."
+
+Read plainly, a free-tier integration sits inside a labeled-data economy: visitors solve
+puzzles, the site owner is compensated for that work, and hCaptcha's own labeling
+product resells the resulting annotations to machine-learning customers, described on
+[the hCaptcha explainer page](hcaptcha-explained.md#the-part-that-pays-for-the-free-tier-labeled-data)
+in full. An Enterprise integration is a direct commercial customer instead, paying
+Intuition Machines in money for the extra tier of product, rather than the arrangement
+running the other direction. That is a genuinely different relationship, not a
+messaging choice, and it is the closest hCaptcha equivalent to
+[the free-vs-metered split covered on the reCAPTCHA Enterprise page](recaptcha-enterprise-vs-v3.md#pricing-the-free-tier-is-smaller-than-v3s-used-to-feel),
+even though the mechanisms behind the two vendors' free tiers are not the same thing.
+
+## What this means for anything actually being scored
+
+Nothing about Enterprise's extra machinery changes what a browser engine can honestly
+answer versus what it cannot, because every tier sits on the same underlying widget and
+`siteverify` mechanism described on [the hCaptcha explainer page](hcaptcha-explained.md):
+an invisible pass first, a visual puzzle only if that pass is unsure, and a server-side
+token check either way. [The reasoning that applies to a Playwright session against the
+free tier](does-playwright-trigger-hcaptcha.md) applies without modification against
+Enterprise's version of the same pass: a real, engine-level browser answers the
+JavaScript-visible fingerprint surface honestly, which narrows one input among several
+undisclosed ones, and does nothing for the address you connect from or the history a
+session does or does not carry. Private learning specifically cannot be addressed by
+engine realness at all, because a model trained on one Enterprise customer's own traffic
+patterns is a property of that customer's deployment and its accumulated data, not of
+any single browser session run against it.
+
+`invisible_playwright` does not include a private-learning workaround, a custom-challenge
+bypass, or any feature that changes a hCaptcha risk score or a puzzle escalation
+decision, on Basic, Pro, or Enterprise. What honest engine behavior affects here is
+exactly what it affects on the free tier and no more: it keeps the fingerprint-and-engine
+portion of the assessment from contradicting itself.
+
+## Short answers to the questions that lead here
+
+**Is hCaptcha Enterprise just a harder version of the free widget?** No. All three
+tiers run the same invisible-pass-then-puzzle mechanism. Enterprise adds a risk model
+trained on the customer's own traffic, control over the puzzle's content, time-of-day
+difficulty tuning, and operational features (SSO, SLA, reporting) the free and Pro tiers
+do not have.
+
+**What is the actual difference between Pro and Enterprise?** Pro turns on a shared,
+general risk model and a passive (low-friction) mode. Enterprise adds a model trained
+specifically on that customer's traffic ("private learning"), custom challenge content,
+an extra "Passive" difficulty tier, and enterprise support and reporting.
+
+**Does Enterprise cost money the way Pro does?** Yes, but it is negotiated rather than a
+published metered rate; Pro is a published $99-139/month tier with per-evaluation
+overage, while Enterprise pricing is not published and requires contacting hCaptcha
+directly.
+
+**Is the free tier really "paid for" by the puzzle answers?** According to hCaptcha's
+own labeling product and a HUMAN Protocol blog post describing the compensation model,
+yes in substance: free-tier site owners are compensated for the annotation work their
+visitors do, and hCaptcha's own labeling business resells that annotation category to
+machine-learning customers. hCaptcha's own privacy FAQ denies selling individually
+targeted ads or personal data specifically, which is a narrower claim than a denial that
+labeled answers are monetized.
+
+**Do Enterprise customers participate in that same labeling economy?** Per the same
+HUMAN Protocol post, no: "Enterprise integrators of the hCaptcha security service like
+Cloudflare pay IM for more features, rather than being compensated," describing a direct
+cash relationship instead.
+
+**Does a real browser engine answer Enterprise's assessment any differently than
+Basic's?** No. All three tiers share the same underlying mechanism, and the reasoning
+that already applies to a Playwright session against Basic or Pro applies to
+Enterprise's version of the same pass unchanged. Private learning, being trained on a
+specific customer's own traffic history, is outside what any single browser session can
+affect at all.
+
+**See also:** [hCaptcha, Explained](hcaptcha-explained.md) for the underlying mechanism
+this page builds on, and [Does Playwright Trigger hCaptcha More Often?](does-playwright-trigger-hcaptcha.md)
+for what a Playwright session specifically does to that mechanism regardless of tier.
+
+## Sources
+
+- hCaptcha, [Pricing](https://www.hcaptcha.com/pricing), retrieved 2026-08-30, for the
+  Basic/Pro/Enterprise price points and the Pro evaluation allowance and overage rate.
+- hCaptcha, [Plans](https://www.hcaptcha.com/plans), retrieved 2026-08-30, for the
+  feature-by-tier breakdown (free-tier request allowance, Pro's risk scores and threat
+  signatures, Enterprise's private learning, custom challenges, challenge content
+  control, time-of-day difficulty tuning, multi-user dashboards, SAML SSO, and SLAs).
+- hCaptcha, [Pro Features](https://docs.hcaptcha.com/pro), retrieved 2026-08-30, for the
+  "99.9% Passive" mode description, its "thousands of factors" and "less than 0.1%"
+  framing, and the Pro pricing and trial terms.
+- hCaptcha, [Frequently Asked Questions](https://docs.hcaptcha.com/faq), retrieved
+  2026-08-30, for the four Basic-tier difficulty modes and the Enterprise-only "Passive"
+  mode plus "sophisticated custom threat models" and "detailed bot scores" framing.
+- HUMAN Protocol, ["How does hCaptcha fit into HUMAN Protocol?"](https://humanprotocol.org/blog/how-does-hcaptcha-fit-into-human-protocol),
+  retrieved 2026-08-30, for the integrator-compensation model on the free tier and the
+  explicit statement that Enterprise customers like Cloudflare pay Intuition Machines
+  directly rather than being compensated.
+- hCaptcha, [Data Labeling](https://www.hcaptcha.com/labeling), retrieved 2026-08-30, for
+  the annotation-service pitch that the free-tier economy above feeds into.
+
+---
+
+*From the notes of [invisible_playwright](https://github.com/feder-cr/invisible_playwright),
+a Firefox patched at the C++ level driven by stock Playwright. Enterprise's extra
+machinery is risk-model customization, challenge content control, and a paid support
+contract on top of a mechanism this project already writes about on the main hCaptcha
+page; nothing here should be read as a claim that engine realness moves a private
+learning model trained on someone else's traffic, which this project has no access to.*

--- a/docs/hcaptcha-explained.md
+++ b/docs/hcaptcha-explained.md
@@ -1,0 +1,244 @@
+---
+title: "hCaptcha, Explained"
+description: "hCaptcha runs an invisible risk pass first and only falls back to a visual image-classification puzzle when that pass is unsure. It also doubles as a data-labeling business: puzzle answers train other companies' machine learning models. Read from hCaptcha's own docs."
+parent: "Detectors, Explained"
+grand_parent: "Guides"
+nav_order: 42
+---
+
+
+# hCaptcha, Explained
+
+hCaptcha is a real captcha, not a background score wearing a captcha's name. Most of the
+time a visitor never sees it: an invisible pass runs first and only escalates to a
+visible puzzle when that pass is unsure. When it escalates, the puzzle is an actual
+image-classification task, select every image matching a label, the same family of
+thing reCAPTCHA v2 and GeeTest ask for.
+
+Be clear about what this page is before reading further, because that distinction
+matters more here than on most pages in this corpus. This page explains the mechanism,
+read from hCaptcha's own documentation and independent, checkable sources. It is not
+instructions for solving the puzzle automatically, and `invisible_playwright` includes
+no puzzle-solving or captcha-solving capability, for hCaptcha or any other vendor. That
+boundary is stated once here, plainly, and repeated at the end of this page.
+
+## What hCaptcha is
+
+hCaptcha is a product of Intuition Machines, Inc., described in its own materials as
+"the world's most widely used independent CAPTCHA service," positioned against Google's
+reCAPTCHA on privacy and reach: "Unlike reCAPTCHA, we work in every country," with a
+claimed "Zero-PII architecture" and compliance with GDPR, CCPA, LGPD and PIPL. Its
+homepage describes current scale as "hundreds of millions of people around the world"
+and "the largest independent service of its kind," without a specific volume figure.
+
+An independent reference work places its introduction in 2018. The most concrete public
+data point on adoption is independently reported rather than hCaptcha's own: Cloudflare's
+April 2020 switch away from reCAPTCHA, citing Google's advertising business, reCAPTCHA
+being blocked in China alongside every other Google service, and a newly announced
+reCAPTCHA price that would have cost Cloudflare, in its own account, millions of dollars
+a year to keep using for free.
+
+## The two-stage model: an invisible pass, then maybe a puzzle
+
+hCaptcha's own developer documentation describes the flow in two stages. First, "the
+user starts an hCaptcha evaluation: they click the checkbox or submit button, or you
+trigger it programmatically" through `hcaptcha.execute(widgetID)`. Second, once that
+evaluation finishes, "the hCaptcha script inserted a unique token into your form data,"
+which the integrating site's own backend then has to check.
+
+The part that matters for automation is what happens between those two steps. A widget
+configured with `data-size="invisible"` renders nothing, and per hCaptcha's own
+documentation, "the widget will be rendered in the background and only presented when a
+challenge is required." Whether a challenge is required is a per-session decision:
+"the user will only be presented with a hCaptcha challenge if that user meets challenge
+criteria." hCaptcha's FAQ names the inputs to that decision only at the category level:
+"computed confidence in the visitor's humanity, the site difficulty setting, and other
+security factors." Neither document lists the specific signals or weights behind that
+confidence figure, and no page in this corpus claims to know them.
+
+The clearest description of the invisible pass's intent comes from hCaptcha's own
+Pro-tier documentation, describing its highest-friction-reduction mode: an evaluation
+"derived from thousands of factors," built to "minimize challenges to real people to
+less than 0.1% of users, while still increasing the costs of an attack in virtually all
+cases." That shape, thousands of undisclosed factors feeding one pass/challenge
+decision, matches the risk engines covered elsewhere in this corpus for
+[Turnstile](cloudflare-turnstile-explained.md) and
+[Arkose Labs](arkose-labs-funcaptcha-explained.md): broad category claims, no published
+field list. One input is visible in the API itself: the server-side verification call
+accepts an optional `remoteip` parameter, recommended "for accuracy," about as direct a
+confirmation as a vendor gets that the requesting address feeds the decision too.
+
+## The puzzle, when it appears
+
+When the invisible pass escalates, a Basic (free, "Publisher") account has four fixed
+difficulty modes to pick from: "Easy, Medium, Difficult, and Auto." hCaptcha's own FAQ
+states a completed challenge takes "about the same as a traditional captcha: 3-10
+seconds depending on the difficulty mode," the same rough time budget as a reCAPTCHA v2
+checkbox-and-grid flow.
+
+hCaptcha's own documentation does not spell out the puzzle's visual format in technical
+detail. An independent, encyclopedic reference describes it as asking a visitor to
+"select all images matching a generated query, called a label," which matches how
+hCaptcha's own data-labeling materials describe the underlying task category: bounding
+boxes, polygons, landmarks and attribute categorization on images and video. The puzzle
+a visitor solves and the annotation task a machine-learning customer pays for are, per
+that framing, the same category of work, which is the subject of the next section.
+
+## The part that pays for the free tier: labeled data
+
+hCaptcha's business model is unusual among captcha vendors in that the company is
+explicit, in its own public materials, about running a second product built on the same
+challenges visitors solve. hCaptcha's own labeling page pitches a data-annotation service
+directly at "companies working on artificial intelligence and machine learning
+applications," describing the same task types, bounding boxes, polygons, landmarks,
+categorization, that show up in the visual puzzle, and framing the pitch around solving
+"the most labor intensive problem in machine learning: labeling massive amounts of data
+in a timely, affordable, and reliable way."
+
+hCaptcha's own FAQ is specific about what it does not do with the data it collects: "we
+are not in the business of selling individually targeted ads," and it works "to protect
+your personal data and limit collection rather than selling it to others." That is a
+claim about advertising and personal data, narrower than a claim that labeled answers
+are never monetized, and it should be read exactly that narrowly. An independent
+reference states plainly that "hCaptcha makes revenue by selling its datasets to 3rd
+party companies," and a blog post from HUMAN Protocol, the labor marketplace hCaptcha
+is connected to, describes hCaptcha compensating the sites that embed it for "the work
+their users do as they verify their humanity," framing that work as "annotation," a
+"vital part of building and improving machine intelligence." The same post draws a
+clean line on the other side of that arrangement: "Enterprise integrators... like
+Cloudflare pay IM [Intuition Machines] for more features, rather than being
+compensated." Free-tier integrations sit inside a labor-and-payment loop; Enterprise
+integrations pay cash instead.
+
+That split, an ad-and-labeling-funded free tier against a directly paid Enterprise tier,
+is one axis of what actually changes between the two, and it is covered in full,
+alongside the pricing figures and the feature differences that are more than framing,
+on [hCaptcha Enterprise vs Standard](hcaptcha-enterprise-vs-standard.md).
+
+## The server side: what actually proves the puzzle was solved
+
+The puzzle, or the invisible pass, produces a token, and hCaptcha's own documentation is
+direct that the token proves nothing until a server checks it. The check is a
+server-to-server call to `https://api.hcaptcha.com/siteverify`, POSTing the site's secret
+key and the token (an optional `remoteip`, plus a `sitekey` to stop a token being
+replayed under a different site's key, are also accepted). The response is JSON: a
+`success` boolean, a `challenge_ts` timestamp, the `hostname`, `error-codes` on failure,
+and, Enterprise-only, a `score`/`score_reason` pair carrying the risk assessment itself.
+A token "can only be used once and must be verified within a short period of time," a
+default of 120 seconds, the same single-use, time-boxed shape as
+[the Turnstile token](cloudflare-turnstile-explained.md#the-token-and-why-passing-the-widget-is-not-the-finish-line).
+
+## What invisible_playwright does and does not do here
+
+Read this section carefully, because it is the point of this page. `invisible_playwright`
+is a patched Firefox that answers the JavaScript-visible parts of a browser fingerprint
+honestly, canvas and WebGL output, font enumeration, timing consistency, whether the
+engine claiming to be a real browser actually behaves like one. Whatever hCaptcha's
+undisclosed "thousands of factors" include on the fingerprint side, a genuinely real
+engine answers that category the way any other real instance of that engine does, for
+the same reason argued on [the Turnstile page](cloudflare-turnstile-explained.md#where-an-engine-level-browser-actually-helps-and-where-it-does-not)
+and [the GeeTest page](geetest-v4-explained.md#what-invisible_playwright-does-and-does-not-do-here).
+
+That is where the honest boundary sits, and it sits well short of the puzzle. Selecting
+the images that match a label is a human-interaction and image-recognition problem, not
+a fingerprint problem, and no amount of engine-level realness answers it for you.
+`invisible_playwright` does not solve, automate past, or sell a solution to hCaptcha's
+visual challenge, and it never will as a feature of this project. A tool claiming to
+"bypass hCaptcha" is describing a different, separate product category, commercial
+captcha-solving services exist for exactly this reason, not something this project
+does, sells, or intends to build.
+
+## Short answers to the questions that lead here
+
+**Is hCaptcha a real captcha, like GeeTest, or a silent score, like Turnstile?** Both, in
+sequence. An invisible risk pass runs first and handles most sessions with no visible
+step at all; only the sessions it leaves unsure escalate to an actual visual puzzle.
+
+**What does the hCaptcha puzzle actually ask you to do?** Per independent description of
+the format, select every image matching a given label, in the same family as a
+reCAPTCHA v2 image grid, taking roughly 3 to 10 seconds by hCaptcha's own account of
+typical completion time.
+
+**Does hCaptcha publish what its invisible pass checks?** No. hCaptcha's own materials
+describe the decision only at category level, "computed confidence," "thousands of
+factors," an accepted `remoteip` parameter, without publishing the specific signals or
+their weights.
+
+**Is it true that hCaptcha sells the data from the puzzles people solve?** Its own
+labeling product pitches image and video annotation directly to AI and ML companies
+using the same task categories as the visitor-facing puzzle, and an independent
+reference states it sells datasets to third parties; hCaptcha's own privacy FAQ denies
+selling individually targeted ads or personal data specifically, a narrower claim than a
+denial that labeled answers are monetized.
+
+**Does invisible_playwright solve hCaptcha's puzzle for me?** No. That is a
+human-interaction, image-recognition challenge, not a browser-fingerprint check, and this
+project does not include a puzzle-solving or captcha-solving capability of any kind, for
+hCaptcha or any other vendor.
+
+**Does a real, engine-level browser help against hCaptcha at all?** Only against
+whatever portion of the invisible pass reads genuine browser-engine behavior, canvas,
+WebGL, font and timing consistency, the same category argued throughout this corpus. It
+has no effect on the puzzle interaction itself.
+
+**Is hCaptcha the same thing whether I'm on the free tier or Enterprise?** The underlying
+widget and verification mechanism described on this page is shared. What changes across
+tiers, difficulty controls, risk-score visibility, custom challenges, and the
+labeling-versus-cash relationship, is covered on
+[hCaptcha Enterprise vs Standard](hcaptcha-enterprise-vs-standard.md).
+
+## Sources
+
+- hCaptcha, [Developer Guide](https://docs.hcaptcha.com/), retrieved 2026-08-30, for the
+  two-stage widget flow, the `hcaptcha.execute()` trigger, and the `siteverify` endpoint,
+  its parameters, response fields and the single-use/120-second token behavior.
+- hCaptcha, [Invisible Captcha](https://docs.hcaptcha.com/invisible), retrieved
+  2026-08-30, for the `data-size="invisible"` behavior and the challenge-criteria framing.
+- hCaptcha, [Configuration](https://docs.hcaptcha.com/configuration), retrieved
+  2026-08-30, for the documented widget parameters (`data-size`, `data-theme`, the
+  callback hooks) and confirmation that difficulty selection is not a client-side option.
+- hCaptcha, [Pro Features](https://docs.hcaptcha.com/pro), retrieved 2026-08-30, for the
+  "99.9% Passive" mode description and its "thousands of factors" / "less than 0.1%"
+  framing.
+- hCaptcha, [Frequently Asked Questions](https://docs.hcaptcha.com/faq), retrieved
+  2026-08-30, for the challenge-decision factors ("computed confidence... site
+  difficulty... other security factors"), the four Basic-tier difficulty modes, the
+  3-10 second completion-time figure, and the privacy/no-targeted-ads statement.
+- hCaptcha, [Pricing](https://www.hcaptcha.com/pricing) and
+  [Plans](https://www.hcaptcha.com/plans), both retrieved 2026-08-30, for tier
+  positioning referenced briefly here (full comparison on the Enterprise-vs-Standard
+  page).
+- hCaptcha, [homepage](https://www.hcaptcha.com/) and [About](https://www.hcaptcha.com/about),
+  both retrieved 2026-08-30, for the "hundreds of millions of people," "largest
+  independent service," "every country," "Zero-PII architecture" claims, and the
+  company's relationship to Intuition Machines.
+- hCaptcha, [Data Labeling](https://www.hcaptcha.com/labeling), retrieved 2026-08-30, for
+  the annotation-service pitch to AI/ML companies and its overlap with the puzzle.
+- HUMAN Protocol, ["How does hCaptcha fit into HUMAN Protocol?"](https://humanprotocol.org/blog/how-does-hcaptcha-fit-into-human-protocol),
+  retrieved 2026-08-30, for the integrator-compensation model and the explicit statement
+  that Enterprise customers like Cloudflare pay Intuition Machines rather than being paid.
+- HandWiki, [HCaptcha](https://handwiki.org/wiki/HCaptcha), retrieved 2026-08-30, an
+  independent encyclopedic mirror, for the 2018 introduction date, the "select all images
+  matching a generated query, called a label" challenge description, the claim that
+  hCaptcha "makes revenue by selling its datasets to 3rd party companies," and the
+  ~10-million-users-per-month 2019 adoption figure.
+- BleepingComputer, ["Cloudflare drops Google's reCAPTCHA due to privacy concerns"](https://www.bleepingcomputer.com/news/technology/cloudflare-drops-googles-recaptcha-due-to-privacy-concerns/),
+  published 2020-04-13, retrieved 2026-08-30, independent corroboration of Cloudflare's
+  April 2020 move to hCaptcha and its stated reasons (privacy, China accessibility, cost).
+
+**See also:** [Does Playwright Trigger hCaptcha More Often?](does-playwright-trigger-hcaptcha.md)
+for what a Playwright session specifically does to the invisible pass described above;
+[hCaptcha Enterprise vs Standard](hcaptcha-enterprise-vs-standard.md) for the tier
+comparison this page defers to; [GeeTest v4 (Slide/Click Captcha), Explained](geetest-v4-explained.md)
+and [Arkose Labs (FunCaptcha), Explained](arkose-labs-funcaptcha-explained.md) for two
+other vendors whose visible puzzle sits behind a similar undisclosed risk pass; and
+[How Cloudflare Turnstile actually works](cloudflare-turnstile-explained.md) for the
+non-interactive counterpart of the same fingerprint-versus-human-gate split.
+
+---
+
+*From the notes of [invisible_playwright](https://github.com/feder-cr/invisible_playwright),
+a Firefox patched at the C++ level and driven by stock Playwright. This page explains a
+mechanism and a business model, not a workaround: the product does not solve captchas,
+and a claim that any tool defeats hCaptcha's puzzle step is a different promise than
+anything documented here.*

--- a/docs/playwright-err-blocked-by-client-page-route.md
+++ b/docs/playwright-err-blocked-by-client-page-route.md
@@ -1,0 +1,222 @@
+---
+title: "Playwright ERR_BLOCKED_BY_CLIENT via page.route"
+description: "net::ERR_BLOCKED_BY_CLIENT is the exact string a real ad-blocker extension produces, and page.route()-based request blocking can reproduce it byte for byte. What that means for a page's own error handling, and the two-edged detection question it raises."
+parent: "Testing and Troubleshooting"
+grand_parent: "Guides"
+nav_order: 28
+---
+
+
+# Playwright ERR_BLOCKED_BY_CLIENT via page.route
+
+`net::ERR_BLOCKED_BY_CLIENT` means the client itself refused to send a request,
+before it ever reached the network. Chromium's own network error list defines it in
+five words, code -20: "The client chose to block the request." The name is precise:
+not the server, not a network failure, the client's own decision. That client is
+usually a browser extension, and it is exactly the string a real ad blocker
+produces on every ad and tracker request it stops. It is also, less widely known,
+a string `page.route()` can produce on purpose.
+
+## Where the string actually comes from in a page.route() handler
+
+`route.abort()` accepts an optional error code, and Playwright's own API reference
+lists `'blockedbyclient'` among the valid values, alongside `'failed'`,
+`'aborted'`, `'connectionrefused'`, and the rest of the family. Call
+`route.abort('blockedbyclient')` and the aborted request surfaces in Chromium as
+`net::ERR_BLOCKED_BY_CLIENT`, identical to what an installed ad blocker would have
+produced on the same request. Call bare `route.abort()` with no argument and you
+get `'failed'` instead, Chromium's generic `net::ERR_FAILED`, a different string
+for the same underlying abort.
+
+This is not a hypothetical pairing. [`@ghostery/adblocker-playwright`](https://github.com/ghostery/adblocker),
+a real, actively maintained library applying actual EasyList- and
+EasyPrivacy-style filter rules inside a Playwright session, calls
+`route.abort('blockedbyclient')` directly in its request handler. A tool built to
+block ads and trackers through `page.route()` chose the one error code that makes
+its blocking indistinguishable, at the network layer, from a real ad-blocker
+extension. It is worth knowing which code your own blocking logic passes, because
+the string in your logs depends on it.
+
+## Not the same thing as net::ERR_ABORTED
+
+[`net::ERR_ABORTED`](err-aborted-playwright.md), covered separately on this site,
+is a different code (-3, "an operation was aborted") for a different situation: an
+in-flight *navigation* getting cancelled, by a download, a redirect, a second
+`goto()`, or a `route.abort()` call that unintentionally caught the navigation
+request itself rather than a sub-resource. `ERR_BLOCKED_BY_CLIENT` is what shows up
+on a *sub-resource* request, an ad script, a tracking pixel, an image, that your
+own route handler (or a real extension) deliberately refused, while the page
+navigation around it completes normally. If your `page.goto()` itself is failing,
+that is the other page's territory. If a specific request inside an otherwise
+loaded page is failing, and your code or a library is calling `route.abort()` on
+it, this is the right page.
+
+## How the page's own JavaScript sees it
+
+Because `route.abort()` operates in the real network stack rather than mocking
+anything at the JavaScript layer, the page's own code experiences the block exactly
+as it would a real extension's: a `fetch()` call rejects with a generic
+network-error `TypeError` and no further detail, an `XMLHttpRequest` fires its
+`error` event with `status` left at `0`, and an `<img>` or `<script>` tag fires its
+own `error` event and never loads. None of these code paths know or care whether a
+browser extension or a route handler made the decision, which is exactly why a
+library choosing this error code produces genuinely indistinguishable
+JavaScript-visible behavior.
+
+## The two-edged consideration
+
+Ad-blocker use is itself a real, commonly checked signal, not a hypothetical one.
+Independent research into this space, including [Fingerprint's own writeup on
+ad-blocker fingerprinting](https://fingerprint.com/blog/ad-blocker-fingerprinting/),
+documents two broad detection families sites actually use: watching whether known
+ad-network network requests simply never happen, and, described as the more
+reliable and more commonly preferred approach, planting a "bait" or "honeypot" DOM
+element that matches a known filter-list selector and checking whether the element
+got hidden, typically by testing `offsetParent === null` after the page settles.
+That second family exists specifically because pure network-request detection, the
+same source notes, is "problematic" on its own: it requires attempting to load a
+resource and watching how the attempt resolves, which is slow and visible in the
+page's own network panel.
+
+This cuts both ways for a `page.route()`-based blocking setup:
+
+- **At the pure network-failure level, blocking via `route.abort('blockedbyclient')`
+  is not distinguishable from a real ad-blocker extension.** Both produce the exact
+  same error string on the exact same class of request, because that is what the
+  error code is for. A detector that only asks "did this ad request fail" learns
+  nothing about which of the two happened.
+- **At the cosmetic-filtering level, the two are not equivalent.** A real
+  ad-blocker extension commonly does more than stop the network request: it also
+  injects CSS to hide the placeholder element the ad would have filled, which is
+  exactly what the bait-element/`offsetParent` check is built to catch.
+  `page.route()` only intercepts the network layer and never touches the DOM, so a
+  bait element planted to catch cosmetic hiding stays visible, `offsetParent`
+  intact, even while the matching request fails with `ERR_BLOCKED_BY_CLIENT` right
+  next to it. A site checking both signals together could read that mismatch,
+  failed ad requests with no cosmetic hiding to match, as a tell of its own.
+
+None of this is a reason to avoid `route.abort()`; it is a reason to know what
+signal you are actually producing, and that a network-only view of "ad blocked or
+not" is not the whole picture a real detector might be checking.
+
+## What this looks like against the real engine here, Firefox
+
+`net::ERR_BLOCKED_BY_CLIENT` is Chromium's own naming, and `invisible_playwright`
+drives a [patched Firefox](does-playwright-support-firefox-stealth.md), not
+Chromium. Playwright's cross-browser `route.abort('blockedbyclient')` call is
+identical on every engine, and [a real Playwright report](https://github.com/microsoft/playwright/issues/22332)
+confirms Firefox handles it correctly where your script actually reads it:
+`onerror` fires on the affected element the same way it does in Chromium, which is
+notably not true of WebKit for this same pair of error codes. What differs is the
+string underneath. Firefox's own networking layer reports a cancelled request
+through its `nsIRequest`/Necko error family, commonly `NS_BINDING_ABORTED` rather
+than a Chromium-style `net::` code; [a separate real report](https://github.com/microsoft/playwright/issues/20749)
+shows that exact string on a Firefox navigation Playwright cancelled, and Mozilla's
+own bug tracker documents the same string for requests an extension blocked
+outright. Grepping raw browser logs against this project's engine, search for
+`NS_BINDING_ABORTED`; reading Playwright's own `route`/`request` objects,
+`'blockedbyclient'` is what comes back regardless of which engine produced it.
+
+## Diagnostic checklist
+
+1. **Confirm which error code your own code is passing.** `ERR_BLOCKED_BY_CLIENT`
+   specifically means something called `route.abort('blockedbyclient')`, or
+   equivalent, on that request. Bare `route.abort()` produces `ERR_FAILED` instead;
+   if you are seeing the former and did not write it, a dependency is doing it.
+2. **Grep your dependency tree for an ad-blocking library** such as
+   `@ghostery/adblocker-playwright` or a hand-rolled filter list before assuming
+   your own route handler is the source.
+3. **Read `route.request().resourceType()` and the URL on the aborted request**,
+   via `DEBUG=pw:api`, to confirm it is the sub-resource you intended to block and
+   not, for example, a redirect target the handler's glob pattern caught by
+   accident.
+4. **If the failure is on the navigation itself rather than a sub-resource**,
+   you are looking at [`net::ERR_ABORTED`](err-aborted-playwright.md), not this
+   error; the fix there is narrowing the route pattern so it does not catch
+   in-flight navigation traffic.
+5. **If you are testing your own page's ad-blocker-detection logic**, drive the
+   comparison with a real extension loaded in a persistent context alongside your
+   `page.route()` version, and compare both the network log and any DOM-visibility
+   check the page runs, rather than assuming one implies the other.
+
+## What this does and does not fix
+
+`page.route()` is a testing and traffic-shaping tool, the same honest boundary that
+runs through [blocking images to speed up
+scraping](block-images-speed-up-playwright-scraping-page-route.md) and
+[intercepting and mocking requests](intercept-and-mock-requests-page-route-playwright.md)
+on this site. It lets you stub, drop, or rewrite requests on a browser that already
+reads as a genuine Firefox. It does not make your blocking choices invisible to a
+page that inspects its own network failures or its own DOM for the shape a real ad
+blocker leaves behind; that shape is a property of what you chose to block and how,
+not of the engine underneath it.
+
+## Short answers to the questions that lead here
+
+**What does net::ERR_BLOCKED_BY_CLIENT mean?** The client itself refused to send
+the request before it reached the network, most commonly a browser extension like
+an ad blocker, or a `page.route()` handler that called
+`route.abort('blockedbyclient')`.
+
+**Why does my page.route() blocking produce this exact error?** Because you (or a
+library you depend on) passed `'blockedbyclient'` as the error code to
+`route.abort()`. Passing no code at all produces `ERR_FAILED` instead, a different
+string for the same abort.
+
+**Is this the same as net::ERR_ABORTED?** No. `ERR_ABORTED` is a different code for
+a cancelled navigation; `ERR_BLOCKED_BY_CLIENT` is for a sub-resource request the
+client deliberately refused to send while the surrounding page load continues.
+
+**Can a site tell my scraper apart from a real ad-blocker user?** Not from the
+failed network request alone; that signal is identical either way by design. A
+site checking whether a bait element's cosmetic hiding matches the failed requests
+could notice the difference, since `page.route()` never touches the DOM the way a
+real extension's CSS injection does.
+
+**Does invisible_playwright add anything to how page.route() behaves here?** No.
+It is stock Playwright behavior, unchanged; this project's fingerprint and driver
+work sits above the network-interception layer entirely.
+
+## Sources
+
+- Chromium's [`net/base/net_error_list.h`](https://chromium.googlesource.com/chromium/src/+/main/net/base/net_error_list.h),
+  for `ERR_BLOCKED_BY_CLIENT` (-20), `ERR_ABORTED` (-3) and `ERR_FAILED` (-2) and
+  their exact definitions, retrieved 2026-08-30.
+- Playwright's own [`Route.abort()` API reference](https://playwright.dev/python/docs/api/class-route#route-abort),
+  for the full list of valid `error_code` values including `'blockedbyclient'` and
+  the `'failed'` default, retrieved 2026-08-30.
+- [ghostery/adblocker](https://github.com/ghostery/adblocker/blob/master/packages/adblocker-playwright/src/index.ts),
+  the real, maintained Playwright ad-blocking integration whose request handler
+  calls `route.abort('blockedbyclient')` directly, verified in the source this
+  session.
+- [microsoft/playwright#23598](https://github.com/microsoft/playwright/issues/23598),
+  a real, verified report of `net::ERR_BLOCKED_BY_CLIENT` surfacing from a
+  `route.continue()` call in Chromium specifically, confirming the error is not
+  limited to `route.abort()` alone.
+- Fingerprint's own [writeup on ad-blocker
+  fingerprinting](https://fingerprint.com/blog/ad-blocker-fingerprinting/), for the
+  distinction between network-request-based ad-blocker detection and the
+  bait-element/`offsetParent` cosmetic-hiding check sites prefer instead.
+- [microsoft/playwright#22332](https://github.com/microsoft/playwright/issues/22332),
+  confirming Firefox fires `onerror` correctly for both `'blockedbyclient'` and
+  `'aborted'` error codes, unlike WebKit, which does not for the same pair.
+- [microsoft/playwright#20749](https://github.com/microsoft/playwright/issues/20749),
+  a real report showing Firefox's own `NS_BINDING_ABORTED` string on a cancelled
+  navigation, the same error family Firefox uses for a blocked request underneath
+  Playwright's cross-browser `'blockedbyclient'` value.
+
+**See also:** [Block images to speed up scraping (and when not to)](block-images-speed-up-playwright-scraping-page-route.md)
+for the related resource-type blocking case and its own request-waterfall tell,
+[Intercept and mock network requests with page.route](intercept-and-mock-requests-page-route-playwright.md)
+for the full `fulfill`/`abort`/`continue_` picture this page is one caveat of,
+[net::ERR_ABORTED in Playwright](err-aborted-playwright.md) for the navigation-level
+sibling this error is easy to confuse it with, and [the checklist for being
+detected on one site](playwright-detected-as-bot.md) for where request-blocking
+behavior sits among the other signals a site can check.
+
+---
+
+*Written while maintaining [invisible_playwright](https://github.com/feder-cr/invisible_playwright),
+a Firefox patched at the C++ level driven by stock Playwright. The error code is
+upstream Chromium naming; the fact that a route handler and a real extension can
+produce it identically is the part worth knowing before you rely on either.*

--- a/docs/playwright-firefox-sec-error-unknown-issuer.md
+++ b/docs/playwright-firefox-sec-error-unknown-issuer.md
@@ -1,0 +1,209 @@
+---
+title: "Playwright Firefox: SEC_ERROR_UNKNOWN_ISSUER"
+description: "SEC_ERROR_UNKNOWN_ISSUER is Firefox's own NSS certificate-trust error, not a Chromium string. Why curl works inside a Docker container and Firefox still fails, and the MOZILLA_PKIX_ERROR_MITM_DETECTED variant Firefox raises when it recognizes interception."
+parent: "Testing and Troubleshooting"
+grand_parent: "Guides"
+nav_order: 27
+---
+
+
+# Playwright Firefox: SEC_ERROR_UNKNOWN_ISSUER
+
+`SEC_ERROR_UNKNOWN_ISSUER` is what Firefox itself says when a certificate arrives
+during a TLS handshake and Firefox cannot build a chain from it up to a root it
+trusts. Sectigo's own support documentation states it plainly: the error means
+"Firefox is unable to chain up to a trusted Certificate Authority based on
+information provided to Firefox from the web site you're visiting." The chain is
+broken, not necessarily the certificate at the end of it.
+
+If you already know `net::ERR_CERT_AUTHORITY_INVALID` from Chromium, this is the
+same underlying condition described by a different browser's own error stack, and
+the distinction matters for anyone driving Firefox with Playwright.
+
+## Not the same string as ERR_CERT_AUTHORITY_INVALID, and why it matters here
+
+[`ERR_CERT_AUTHORITY_INVALID`](err-cert-authority-invalid-playwright.md), covered
+separately on this site, is Chromium's own network-stack naming: `net::` prefix,
+numeric code -202, defined in Chromium's source tree. `SEC_ERROR_UNKNOWN_ISSUER` is
+not a Playwright string or a wrapper string, and it is not that Chromium string
+ported over. It comes from NSS, the certificate library Firefox has always used,
+surfaced through Firefox's own PSM (Personal Security Manager) error list. Two
+browsers, two independent TLS stacks, two different names for the same category of
+failure: an issuer the browser does not trust.
+
+This is not a cosmetic detail for `invisible_playwright`. The wrapper drives a
+[patched Firefox binary](does-playwright-support-firefox-stealth.md), not a
+Chromium build, so the string a script actually sees on a broken certificate chain
+is `SEC_ERROR_UNKNOWN_ISSUER` (or its MITM-specific sibling below), never the
+Chromium one. Searching your logs for `ERR_CERT_AUTHORITY_INVALID` against this
+project is searching for a string this engine does not produce.
+
+## The realistic causes
+
+**A Docker container missing CA certificates entirely.** Minimal base images, the
+kind most CI and scraping containers start from, frequently ship without the
+`ca-certificates` package installed at all, so nothing in the container's trust
+store validates anything, legitimate or otherwise. The fix at the OS level is
+routine: install `ca-certificates` and run `update-ca-certificates` on
+Debian/Ubuntu-based images, or the CentOS-family equivalent against
+`/etc/pki/ca-trust/source/anchors/`. That step alone often "fixes" `curl` inside
+the same container while Firefox keeps failing, for the reason in the next section.
+
+**A self-signed certificate on the target**, the ordinary local-development and
+staging case: nothing signed it that any browser trusts by default, Firefox
+included, because nothing was meant to.
+
+**A proxy or corporate security product intercepting and re-signing TLS.** A device
+between the browser and the destination that terminates the original connection and
+presents its own certificate produces exactly this error unless its root CA is
+separately installed and trusted. This is functionally identical, from Firefox's
+point of view, to a hostile interception, because the mechanism is the same one
+either way.
+
+**Firefox keeping its own certificate store separate from the operating system's.**
+This is the specific reason "curl works, Firefox doesn't" is the single most common
+shape this bug takes inside a container. Firefox has historically shipped and
+trusted its own NSS-based root store rather than reading the OS bundle the way
+`curl` and most system tools do. Mozilla's own support documentation describes the
+bridge for this: on Windows, macOS and Android, Firefox by default searches the
+operating system's certificate store for third-party roots an administrator or a
+program has added. Linux is conspicuously absent from that list, which lines up
+with two real Playwright bug reports.
+[microsoft/playwright#7611](https://github.com/microsoft/playwright/issues/7611)
+reports that inside the official Playwright Docker image, "curl -v inside of Docker
+works correctly and picks up the custom certificates, but it seems that the
+Browsers don't," with both Chromium and Firefox failing and `SEC_ERROR_UNKNOWN_ISSUER`
+named explicitly. [microsoft/playwright#33596](https://github.com/microsoft/playwright/issues/33596),
+filed against Playwright on Ubuntu, shows the same split for Firefox specifically: a
+certificate created with `mkcert`, `curl` reporting `SSL certificate verify ok`, and
+Firefox throwing `page.goto: SEC_ERROR_UNKNOWN_ISSUER` on the identical host.
+`update-ca-certificates` updates the container's system trust store; it does not
+put that root into Firefox's own NSS database or flip the pref that would make
+Firefox read the system store on Linux. An open feature request,
+[microsoft/playwright#35815](https://github.com/microsoft/playwright/issues/35815),
+tracks the sharper version of this gap: Firefox 137 tightened private-CA handling
+further and now expects a `policies.json` enterprise-roots configuration Playwright
+has no supported way to inject.
+
+## The MOZILLA_PKIX_ERROR_MITM_DETECTED variant
+
+Firefox does not always show plain `SEC_ERROR_UNKNOWN_ISSUER` when something is
+actively intercepting traffic. Since Firefox 67, it can instead show
+`MOZILLA_PKIX_ERROR_MITM_DETECTED`, and the difference is not cosmetic; it reflects
+an actual second check Firefox ran. [Mozilla's own bug
+tracker](https://bugzilla.mozilla.org/show_bug.cgi?id=1529643) documents the
+mechanism: on hitting a certificate error, Firefox fires a background "priming"
+request to a Mozilla-operated detection endpoint and compares the issuer it gets
+back against the issuer on the page that just failed. A match means whatever is
+intercepting the browser's own connections is broad enough to also be intercepting
+that background request, which is a much stronger signal than one bad certificate
+on one site, and Firefox can go on to auto-enable the same
+`security.enterprise_roots.enabled` preference described above if a further pref
+allows it to. In practice this means: a corporate or antivirus TLS-inspection
+product that intercepts everything commonly produces the MITM-specific error, while
+a single misconfigured server, or a self-signed certificate on one test host, stays
+plain `SEC_ERROR_UNKNOWN_ISSUER`. Appuals' own troubleshooting writeup for this
+error lists the usual real-world triggers seen in the wild: security suites doing
+HTTPS scanning or filtering (Avast, Bitdefender, Kaspersky, ESET are the commonly
+named ones), and, more rarely, a VPN or proxy product doing the same thing.
+
+## Diagnostic checklist
+
+1. **Confirm with `curl` or `openssl s_client -connect host:443 -showcerts` from
+   inside the exact same container or environment.** If those validate cleanly
+   while Firefox fails, you have just reproduced the "curl works, Firefox doesn't"
+   shape directly, and the cause is almost always Firefox's separate trust store,
+   not a broken certificate.
+2. **Check whether `ca-certificates` is actually installed and updated in the
+   image**, distinct from whether Firefox picks it up. Both steps are required and
+   neither substitutes for the other.
+3. **Test with the proxy or security product removed from the path entirely.**
+   Clears: the intercepting layer is the cause, not the destination's own
+   certificate.
+4. **Read the exact error string, not just "certificate error."**
+   `MOZILLA_PKIX_ERROR_MITM_DETECTED` specifically means Firefox's own background
+   check matched the intercepting issuer against your failing page's issuer; plain
+   `SEC_ERROR_UNKNOWN_ISSUER` means it did not run that check or did not get a
+   match, which is common for a one-off self-signed host.
+5. **If a private CA is genuinely trusted and Firefox still refuses it**, check
+   whether the fix requires `security.enterprise_roots.enabled` or, on newer
+   Firefox versions, an enterprise `policies.json`, rather than assuming the
+   OS-level `update-ca-certificates` step was sufficient.
+
+## The honest boundary
+
+Certificate validation runs inside NSS, the same TLS and PKI library this project's
+patched Firefox uses unmodified. `invisible_playwright` does not alter certificate
+handling, does not add a private CA to the trust store on your behalf, and does not
+make an untrusted chain trusted. A clean fingerprint answers what a page can
+observe about the browser; it says nothing about whether the certificate presented
+during the handshake actually chains to a root anyone should trust, which is
+precisely the question this error exists to raise. Fixing it is a certificate and
+trust-store problem, solved the same way for a stock Firefox and for this one.
+
+## Short answers to the questions that lead here
+
+**What does SEC_ERROR_UNKNOWN_ISSUER mean?** Firefox could not build a chain of
+trust from the certificate a site presented up to a root certificate authority it
+trusts. It is Firefox's own NSS-based error, not a Chromium string.
+
+**Is this the same as net::ERR_CERT_AUTHORITY_INVALID?** It is the same category of
+failure, an untrusted issuer, reported by a different browser's own TLS stack.
+Chromium calls it `ERR_CERT_AUTHORITY_INVALID`; Firefox calls it
+`SEC_ERROR_UNKNOWN_ISSUER`. `invisible_playwright` drives Firefox, so this is the
+string that actually appears.
+
+**Why does curl work inside my Docker container while Firefox still fails?** `curl`
+reads the system CA bundle you just updated with `update-ca-certificates`. Firefox
+historically keeps its own separate NSS trust store and, on Linux, does not read
+the OS store by default the way it does on Windows and macOS, so the same fix that
+repairs `curl` often does nothing for Firefox.
+
+**What does MOZILLA_PKIX_ERROR_MITM_DETECTED add over the plain error?** It means
+Firefox ran a background check against its own detection endpoint and found the
+same intercepting issuer there, confirming broad interception rather than one bad
+certificate on one site.
+
+**Does invisible_playwright fix or cause this error?** Neither. NSS enforces
+certificate validation the same way for any Firefox, patched or stock. This
+project's fingerprint work sits above this layer entirely and does not touch trust
+decisions.
+
+## Sources
+
+- Sectigo's own [Firefox error code: SEC_ERROR_UNKNOWN_ISSUER](https://support.sectigo.com/articles/Knowledge/Firefox-error-code-sec-error-unknown-issuer-1527076112539)
+  knowledge base article, for the definition and the missing-intermediate-chain
+  cause, retrieved 2026-08-30.
+- Appuals' [Fix: MOZILLA_PKIX_ERROR_MITM_DETECTED Error on
+  Firefox](https://appuals.com/mozilla-pkix-error-mitm-detected/), for the named
+  real-world triggers (antivirus HTTPS scanning, VPN/proxy interception), retrieved
+  2026-08-30.
+- Mozilla's own bug tracker,
+  [bug 1529643, "On certificate error pages, trigger an internal canary request to
+  detect MitM"](https://bugzilla.mozilla.org/show_bug.cgi?id=1529643), for the
+  priming-request mechanism that distinguishes the MITM-specific error, shipped in
+  Firefox 67, retrieved 2026-08-30.
+- [microsoft/playwright#7611](https://github.com/microsoft/playwright/issues/7611),
+  a real report of `curl` validating a custom certificate inside the official
+  Playwright Docker image while both Chromium and Firefox fail with
+  `SEC_ERROR_UNKNOWN_ISSUER`.
+- [microsoft/playwright#33596](https://github.com/microsoft/playwright/issues/33596),
+  a real report of Firefox on Ubuntu throwing `SEC_ERROR_UNKNOWN_ISSUER` on a
+  `mkcert`-issued certificate that `curl` verifies successfully on the same host.
+- [microsoft/playwright#35815](https://github.com/microsoft/playwright/issues/35815),
+  an open feature request describing Firefox 137's tightened private-CA
+  requirements and the lack of a supported `policies.json` path in Playwright.
+
+**See also:** [ERR_CERT_AUTHORITY_INVALID in Playwright](err-cert-authority-invalid-playwright.md)
+for the Chromium-flavored version of this same failure category and the
+`ignoreHTTPSErrors` tradeoff, [ERR_SSL_PROTOCOL_ERROR in Playwright](err-ssl-protocol-error-playwright.md)
+for the handshake-level failure this one is often confused with, and
+[how to use invisible_playwright in Docker](how-to-use-invisible-playwright-in-docker.md)
+for the rest of what changes about running this project inside a container.
+
+---
+
+*From the notes of [invisible_playwright](https://github.com/feder-cr/invisible_playwright),
+a Firefox patched at the C++ level. Certificate trust is NSS's job, untouched by
+this project's patching; a Docker image that fixes curl and still fails Firefox is
+reading two different trust stores, not fighting two different bugs.*


### PR DESCRIPTION
## Summary

Round 3 of the same content-gap audit as #118. Checked against a fresh clone of the current main (416 files), not a stale worktree. Honest headline: most candidates this round dead-ended into duplicates or vendor walls, documented below rather than padded. Six survived verification.

**hCaptcha** (3 new): had zero dedicated page despite being cited as a source inside the existing Kasada article - an odd gap given reCAPTCHA and GeeTest both already had one. Fixed with the same three-page pattern already used for reCAPTCHA: the mechanism explainer (`hcaptcha-explained.md`), the "does Playwright trigger it more" companion (`does-playwright-trigger-hcaptcha.md`), and the Enterprise-vs-Standard comparison (`hcaptcha-enterprise-vs-standard.md`). All three repeat the boundary explicitly: hCaptcha's visual puzzle is an actual image-classification captcha, and this project does not solve, bypass, or automate past it.

**Two more verbatim errors**: `SEC_ERROR_UNKNOWN_ISSUER`, the Firefox-native NSS certificate error (distinct from the already-covered Chromium-flavored `ERR_CERT_AUTHORITY_INVALID`, and the one this project's own engine actually emits), and `ERR_BLOCKED_BY_CLIENT` via `page.route()`, which reproduces a real ad-blocker's exact error string byte for byte.

**TOTP-based 2FA** (`automating-totp-2fa-login-playwright.md`): pyotp, a shared secret, no inbox - cross-linked both ways against the existing email-OTP page rather than merged into it, since the two mechanisms share nothing except both being called "2FA login."

**Rejected this round, for the record**: Radware/ShieldSquare and Netacea (pure vendor walls), Castle.io (same), Signal Sciences (already covered under the Fastly page it now belongs to), DataDome alternatives as a category (vendor buyer's-guide content, not developer troubleshooting), five more verbatim error codes (no Playwright-specific practitioner discourse), Android WebView and iOS Safari automation (native-app QA audience both times), mobile-fingerprinting reframings (no distinct pain point beyond the existing mobile-emulation page). Playwright has shipped nothing past 1.62 as of this check, so no new version-feature pages this round.

3 touched hub pages updated in the same commit.

## Test plan

- [x] English-only gate clean on this diff (`--range origin/main..HEAD`)
- [x] No em-dash / non-ASCII characters
- [x] Forbidden-names scanner clean (666 files, 15 tokens)
- [x] All internal markdown links resolve
- [x] pytest green, core pin check passed (via pre-push hook)

Generated with Claude Code
