### PR TITLE
One silent socket froze the test servers forever

### DIFF
--- a/tests/test_cross_origin_iframe.py
+++ b/tests/test_cross_origin_iframe.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 
 import threading
 import time
-from http.server import BaseHTTPRequestHandler, HTTPServer
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 import pytest
 
@@ -120,6 +120,8 @@ def test_extra_prefs_override_can_break_isolation_only_explicitly():
 
 
 class _SilentHandler(BaseHTTPRequestHandler):
+    #: Una socket muta non pinna piu' un thread: dopo cinque secondi cade.
+    timeout = 5
     """Suppress per-request access logging so pytest output stays clean."""
     PAYLOAD = b""  # set per-instance via subclassing
 
@@ -134,7 +136,7 @@ class _SilentHandler(BaseHTTPRequestHandler):
         self.wfile.write(self.PAYLOAD)
 
 
-def _serve(payload: bytes) -> tuple[HTTPServer, int]:
+def _serve(payload: bytes) -> tuple[ThreadingHTTPServer, int]:
     """Serve ``payload`` on every GET from a kernel-chosen port on 127.0.0.1.
 
     Returns the server and the port it is ALREADY listening on, so the number
@@ -143,7 +145,8 @@ def _serve(payload: bytes) -> tuple[HTTPServer, int]:
     handler_cls = type(
         "_H", (_SilentHandler,), {"PAYLOAD": payload}
     )
-    srv = HTTPServer(("127.0.0.1", 0), handler_cls)
+    srv = ThreadingHTTPServer(("127.0.0.1", 0), handler_cls)
+    srv.daemon_threads = True
     t = threading.Thread(target=srv.serve_forever, daemon=True)
     t.start()
     return srv, srv.server_address[1]
@@ -397,7 +400,8 @@ def test_the_geometry_invariant_holds_inside_a_nested_frame(firefox_binary):
             self.end_headers()
             self.wfile.write(body)
 
-    srv = HTTPServer(("127.0.0.1", 0), _H)
+    srv = ThreadingHTTPServer(("127.0.0.1", 0), _H)
+    srv.daemon_threads = True
     port = srv.server_address[1]
     threading.Thread(target=srv.serve_forever, daemon=True).start()
     from invisible_playwright import InvisiblePlaywright

--- a/tests/test_ua_widget_not_selectable.py
+++ b/tests/test_ua_widget_not_selectable.py
@@ -39,7 +39,7 @@ content, which would be a fingerprinting tell.
 from __future__ import annotations
 
 import threading
-from http.server import BaseHTTPRequestHandler, HTTPServer
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 import pytest
 
@@ -77,6 +77,8 @@ _AUTHOR_PAGE = b"""<!doctype html><html><head><title>author-closed</title></head
 
 
 class _SilentHandler(BaseHTTPRequestHandler):
+    #: Una socket muta non pinna piu' un thread: dopo cinque secondi cade.
+    timeout = 5
     """Serve the two pages by path, and say nothing while doing it."""
 
     def log_message(self, *_a):
@@ -101,7 +103,8 @@ def widget_harness():
     and a port number that has been released is a number two workers can be
     given at the same time.
     """
-    srv = HTTPServer(("127.0.0.1", 0), _SilentHandler)
+    srv = ThreadingHTTPServer(("127.0.0.1", 0), _SilentHandler)
+    srv.daemon_threads = True
     port = srv.server_address[1]
     threading.Thread(target=srv.serve_forever, daemon=True).start()
     try:

--- a/tests/test_webrtc_realness.py
+++ b/tests/test_webrtc_realness.py
@@ -28,7 +28,7 @@ import select
 import socket
 import struct
 import threading
-from http.server import BaseHTTPRequestHandler, HTTPServer
+from http.server import ThreadingHTTPServer, BaseHTTPRequestHandler, HTTPServer
 
 import pytest
 
@@ -427,6 +427,8 @@ def socks5_tcp_only():
 def local_https_page():
     """A trivial localhost page (used by the no-proxy srflx test)."""
     class H(BaseHTTPRequestHandler):
+        #: Una socket muta non pinna piu' un thread: dopo cinque secondi cade.
+        timeout = 5
         def do_GET(self):
             self.send_response(200)
             self.send_header("Content-Type", "text/html")
@@ -436,7 +438,8 @@ def local_https_page():
         def log_message(self, *a):
             pass
 
-    httpd = HTTPServer(("127.0.0.1", 0), H)
+    httpd = ThreadingHTTPServer(("127.0.0.1", 0), H)
+    httpd.daemon_threads = True
     threading.Thread(target=httpd.serve_forever, daemon=True).start()
     yield f"http://127.0.0.1:{httpd.server_address[1]}/"
     httpd.shutdown()


### PR DESCRIPTION
HTTPServer serves one request at a time and BaseHTTPRequestHandler has no timeout, so an accepted connection that sends nothing blocks the whole server forever. Browsers open speculative connections.

Reproduced: normal request 200, then one silent socket, then the same request raises TimeoutError. With ThreadingHTTPServer plus a handler timeout, four silent sockets change nothing.

That is B194 - two cross-origin iframe tests red in CI and green locally, on code that had passed the same job in another run.