### PR TITLE
0.8.2: the pinned engine has no updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.8.2] - 2026-08-31
+
+### Changed
+
+- **The pinned engine moves to firefox-25, which has no updater.** Until now
+  every session showed an "Update available" badge in the toolbar shortly after
+  start. No preference could remove it: `app.update.auto` stops the download
+  rather than the notification, `app.update.suppressPrompts` only delays the
+  doorhanger because the badge is shown immediately and unconditionally, and
+  `app.update.disabledForTesting` is inert unless the browser is driven by
+  Marionette or the remote agent, which this package is not.
+
+  The engine is therefore built without the update machinery at all: the build
+  options are gone rather than switched off, so nothing checks for an update,
+  nothing can install one over the binary the seal pins, and the badge has no
+  code left to draw it. The update channel is unchanged, because the
+  application's remoting name derives from it.
+
+  One consequence is worth stating: a retail Firefox contacts Mozilla's update
+  service at startup and this build no longer does. No page can observe that -
+  no API exposes the updater's state - but anything watching the connection
+  can.
+
 ## [0.8.1] - 2026-08-30
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "invisible_playwright"
-version = "0.8.1"
+version = "0.8.2"
 description = "Playwright wrapper for a patched Firefox with deterministic stealth profile."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -69,7 +69,7 @@ dependencies = [
     # metadata; nothing in src/ hardcodes a second copy (tests/test_core_pin.py
     # fails if one appears). What stays invisible to install-time machinery is the
     # --no-deps / lockfile residue, and _pin.py is the only layer that sees it.
-    "invisible_core==24.16.0",
+    "invisible_core==25.16.0",
     # ⛔ playwright is NO LONGER a dependency: since the full fork, the Python
     # client lives in src/invisible_playwright/_pw/ and the Node driver in
     # src/invisible_playwright/_driver/. Reintroducing it would not visibly


### PR DESCRIPTION
Moves the core pin to 25.16.0, which seals firefox-25.

That engine is built without the update machinery, so the "Update available" badge that showed up in every session is gone. No preference removed it: app.update.auto stops the download rather than the notification, suppressPrompts only delays the doorhanger, and disabledForTesting is inert unless the browser is driven by Marionette.

Worth knowing, and it is in the changelog: a retail Firefox contacts the update service at startup and this build does not. No page can observe it, anything watching the connection can.