### PR TITLE
feat: add TypeScript Playwright API

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -297,3 +297,134 @@ jobs:
           fi
           echo "::error::the release page for $TAG could not be created. The package IS published; create the page by hand or a later run of the release gate will refuse over it."
           exit 1
+
+  python-release-ready:
+    needs: [already-published, gate, upload]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: require an existing or newly uploaded Python release
+        shell: bash
+        run: |
+          if [ "${{ needs.already-published.result }}" != success ]; then
+            echo "the PyPI version probe did not succeed" >&2
+            exit 1
+          fi
+          if ${{ needs.already-published.outputs.present == 'yes' }}; then
+            echo "::notice::the matching Python version was already on PyPI"
+            exit 0
+          fi
+          if ${{ needs.already-published.outputs.present == 'no' && needs.gate.result == 'success' && needs.upload.result == 'success' }}; then
+            echo "::notice::the matching Python version passed its gate and upload"
+            exit 0
+          fi
+          echo "the matching Python version is unavailable or its release failed" >&2
+          echo "gate=${{ needs.gate.result }} upload=${{ needs.upload.result }}" >&2
+          exit 1
+
+  npm-already-published:
+    # npm trusted publishing must name owner `feder-cr`, repository
+    # `invisible_playwright`, workflow `publish.yml`, and environment `npm`.
+    # Without that registry-side trust this fails closed. Do not add a token to
+    # bootstrap it; establish or transfer package ownership through npm support.
+    runs-on: ubuntu-latest
+    outputs:
+      present: ${{ steps.probe_npm.outputs.present }}
+      version: ${{ steps.probe_npm.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: probe_npm
+        shell: bash
+        working-directory: typescript
+        run: |
+          VERSION="$(node -p "require('./package.json').version")"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          CODE=$(curl -s -o /dev/null -w '%{http_code}' "https://registry.npmjs.org/invisible-playwright/$VERSION")
+          case "$CODE" in
+            200) echo "present=yes" >> "$GITHUB_OUTPUT"
+                 echo "::notice::invisible-playwright $VERSION is already on npm. No-op, not a failure." ;;
+            404) echo "present=no" >> "$GITHUB_OUTPUT" ;;
+            *)   echo "npm answered HTTP $CODE for invisible-playwright $VERSION; refusing rather than guessing" >&2
+                 exit 1 ;;
+          esac
+
+  npm-gate:
+    needs: [npm-already-published, python-release-ready]
+    if: always() && needs.npm-already-published.result == 'success' && needs.python-release-ready.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: typescript/package-lock.json
+      - name: npm and PyPI versions match the tag
+        shell: bash
+        run: |
+          NPM_VERSION="${{ needs.npm-already-published.outputs.version }}"
+          PYTHON_VERSION="$(grep -m1 '^version = ' pyproject.toml | cut -d'"' -f2)"
+          if [ "$NPM_VERSION" != "$PYTHON_VERSION" ]; then
+            echo "npm version $NPM_VERSION does not match Python version $PYTHON_VERSION" >&2
+            exit 1
+          fi
+          if [ "${{ github.event_name }}" = push ] && [ "${GITHUB_REF_NAME#v}" != "$NPM_VERSION" ]; then
+            echo "tag $GITHUB_REF_NAME does not name npm version $NPM_VERSION" >&2
+            exit 1
+          fi
+      - name: test and pack the npm package
+        working-directory: typescript
+        run: |
+          npm ci
+          npm test
+          npm run build
+          npm pack --dry-run
+
+  npm-upload:
+    needs: [npm-already-published, python-release-ready, npm-gate]
+    if: always() && needs.npm-already-published.outputs.present == 'no' && needs.python-release-ready.result == 'success' && needs.npm-gate.result == 'success'
+    runs-on: ubuntu-latest
+    environment: npm
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          registry-url: https://registry.npmjs.org
+          cache: npm
+          cache-dependency-path: typescript/package-lock.json
+      - name: install an npm CLI with trusted publishing support
+        run: npm install --global npm@11.19.1
+      - name: build and publish with npm trusted publishing
+        working-directory: typescript
+        shell: bash
+        run: |
+          npm ci
+          npm run build
+          VERSION="$(node -p "require('./package.json').version")"
+          URL="https://registry.npmjs.org/invisible-playwright/$VERSION"
+          CODE=$(curl -s -o /dev/null -w '%{http_code}' "$URL")
+          case "$CODE" in
+            200) echo "::notice::invisible-playwright $VERSION is already on npm. No-op, not a failure."
+                 exit 0 ;;
+            404) ;;
+            *)   echo "npm answered HTTP $CODE before publish; refusing rather than guessing" >&2
+                 exit 1 ;;
+          esac
+          set +e
+          npm publish --provenance --access public
+          STATUS=$?
+          set -e
+          if [ "$STATUS" -eq 0 ]; then
+            exit 0
+          fi
+          CODE=$(curl -s -o /dev/null -w '%{http_code}' "$URL")
+          if [ "$CODE" = 200 ]; then
+            echo "::notice::invisible-playwright $VERSION already appeared on npm after the publish attempt. No-op, not a failure."
+            exit 0
+          fi
+          echo "npm publish failed and the exact version is still absent (HTTP $CODE)" >&2
+          exit "$STATUS"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -132,6 +132,26 @@ jobs:
           print(f"{passed} tests ran")
           PY
 
+  typescript:
+    name: TypeScript API (node 20)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: typescript/package-lock.json
+
+      - name: Install, test, and build the npm package
+        working-directory: typescript
+        run: |
+          npm ci
+          npm test
+          npm run build
+          npm pack --dry-run
+
   # ONE SINGLE CONTEXT FOR BRANCH PROTECTION. Measured 2026-08-13: this
   # repo's protection required `pytest (windows-latest, py3.11)`, which the
   # matrix explicitly EXCLUDES a few lines up - a context no job can ever
@@ -151,7 +171,7 @@ jobs:
   # release day of all days. So it refuses on `failure` and `cancelled`,
   # never on `skipped`.
   gate:
-    needs: [core-on-index, unit]
+    needs: [core-on-index, unit, typescript]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -159,8 +179,12 @@ jobs:
         run: |
           echo "core-on-index: ${{ needs.core-on-index.result }}"
           echo "unit:          ${{ needs.unit.result }}"
+          echo "typescript:    ${{ needs.typescript.result }}"
           case "${{ needs.unit.result }}" in
             failure|cancelled) echo "the suite did not pass"; exit 1 ;;
+          esac
+          case "${{ needs.typescript.result }}" in
+            failure|cancelled) echo "the TypeScript package did not pass"; exit 1 ;;
           esac
           case "${{ needs.core-on-index.result }}" in
             failure|cancelled) echo "the index check did not run"; exit 1 ;;

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ build/
 .pytest_cache/
 .venv/
 firefox-source/
+typescript/node_modules/
+typescript/dist/
+typescript/dist-test/
 
 # Third-party source trees kept on disk for on-demand compatibility audits.
 # They are somebody else's code, with their own licence and their own .git, and

--- a/README.md
+++ b/README.md
@@ -34,10 +34,21 @@ Once the browser is handled it stops being the variable. If you are still gettin
 
 ## Install
 
+**Python**
+
 ```bash
 pip install invisible-playwright
 python -m invisible_playwright fetch      # one-time ~238 MB download (~544 MB unpacked), sha256-verified
 ```
+
+**TypeScript**
+
+```bash
+pip install invisible-playwright          # profile and sealed browser runtime
+npm install invisible-playwright          # wrapped Playwright API
+```
+
+The TypeScript package downloads and verifies the browser on first launch. It has no CLI and needs no separate fetch command.
 
 Supported platforms: **Windows x86_64**, **Linux x86_64 / arm64**. macOS is no longer supported (releases stopped at firefox-20); on a Mac the package refuses at launch with a clear message rather than downloading a binary that no longer exists.
 
@@ -77,7 +88,24 @@ async with InvisiblePlaywright(proxy={"server": "socks5://...", "username": "u",
     await page.click("#submit")
 ```
 
-The `browser` object is a `playwright.sync_api.Browser` / `playwright.async_api.Browser` - every Playwright method works as-is.
+**TypeScript**
+```ts
+import { InvisiblePlaywright } from "invisible-playwright";
+
+const invisible = new InvisiblePlaywright({ seed: 42, proxy });
+try {
+  const context = await invisible.launch();
+  const page = context.pages()[0] ?? await context.newPage();
+  await page.goto("https://example.com");
+  await page.click("#submit");
+} finally {
+  await invisible.close();
+}
+```
+
+`launch()` returns a standard Playwright `BrowserContext`; its pages, locators, routes and events use the regular TypeScript API. The persistent context lets Firefox read the generated fingerprint profile before startup. See [`typescript/README.md`](typescript/README.md) for options and runtime details.
+
+The Python `browser` object is a `playwright.sync_api.Browser` / `playwright.async_api.Browser` - every Playwright method works as-is.
 
 Log the seed to replay a run:
 

--- a/src/invisible_playwright/_typescript_bridge.py
+++ b/src/invisible_playwright/_typescript_bridge.py
@@ -1,0 +1,417 @@
+"""Private bridge used by the TypeScript package.
+
+This is not a user-facing CLI.  The Node wrapper keeps this process alive while
+its Playwright context is open so a Linux virtual display and an ephemeral
+Firefox profile have the same lifetime as that context.
+"""
+from __future__ import annotations
+
+import json
+import math
+import os
+import re
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from invisible_core import configure_proxy, prepare_session_geo, resolve_session_locale
+
+from ._cursor import ENGINE_BINARY
+from ._engine import resolve_executable
+from ._juggler._profile import _write_user_js
+from ._reaper import (
+    SessionToken,
+    TOKEN_VAR,
+    alive,
+    find_processes,
+    guard_for,
+    psutil,
+    terminate,
+)
+from .launcher import InvisiblePlaywright
+
+_OPTIONS = {
+    "seed",
+    "pin",
+    "headless",
+    "proxy",
+    "extraArgs",
+    "humanize",
+    "locale",
+    "timezone",
+    "extraPrefs",
+    "binaryPath",
+    "profileDir",
+    "showCursor",
+}
+
+_OWNER_PREFIX = "invisible-playwright-node-owner-"
+_CLEANUP_PATH_VAR = "INVPW_TYPESCRIPT_CLEANUP_PATH"
+_CLEANUP_NONCE_VAR = "INVPW_TYPESCRIPT_CLEANUP_NONCE"
+_CLEANUP_FIELDS = {
+    "version", "nonce", "profileDir", "removeProfile", "sessionToken",
+    "virtualDisplayPid",
+}
+
+
+def _load_cleanup_metadata(metadata_path: Path, expected_nonce: str) -> dict[str, Any]:
+    path = metadata_path.expanduser().resolve()
+    owner = path.parent
+    if path.name != "cleanup.json" or not owner.name.startswith(_OWNER_PREFIX):
+        raise ValueError("cleanup metadata path is not wrapper-owned")
+    if not re.fullmatch(r"[0-9a-f]{64}", expected_nonce):
+        raise ValueError("cleanup nonce is invalid")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if type(payload) is not dict or set(payload) != _CLEANUP_FIELDS:
+        raise ValueError("cleanup metadata has an incompatible shape")
+    if payload["version"] != 1 or payload["nonce"] != expected_nonce:
+        raise ValueError("cleanup metadata identity does not match its owner")
+    token = payload["sessionToken"]
+    if not isinstance(token, str) or (token and not re.fullmatch(r"[0-9a-f]{32}", token)):
+        raise ValueError("cleanup session token is invalid")
+    profile = payload["profileDir"]
+    if not isinstance(profile, str) or not Path(profile).is_absolute():
+        raise ValueError("cleanup profile path is invalid")
+    if not isinstance(payload["removeProfile"], bool):
+        raise ValueError("cleanup profile ownership is invalid")
+    if payload["removeProfile"] and Path(profile).resolve() != owner / "profile":
+        raise ValueError("refusing to remove a profile outside its wrapper owner")
+    display_pid = payload["virtualDisplayPid"]
+    if display_pid is not None and (
+            not isinstance(display_pid, int) or isinstance(display_pid, bool) or
+            display_pid <= 0):
+        raise ValueError("cleanup virtual display pid is invalid")
+    return payload
+
+
+def _emergency_cleanup(metadata_path: Path, expected_nonce: str) -> None:
+    payload = _load_cleanup_metadata(metadata_path, expected_nonce)
+    token = SessionToken(payload["sessionToken"])
+    if token:
+        guard_for().reap(token)
+        if find_processes(token):
+            raise RuntimeError("session-token processes remain after emergency cleanup")
+    display_pid = payload["virtualDisplayPid"]
+    if display_pid is not None:
+        if not token:
+            raise RuntimeError("cannot confirm virtual display ownership without a token")
+        try:
+            display = psutil.Process(display_pid)
+        except psutil.NoSuchProcess:
+            display = None
+        if display is not None:
+            if not token.matches(display):
+                raise RuntimeError("virtual display does not carry the cleanup token")
+            terminate([display])
+            if alive(display):
+                raise RuntimeError("virtual display remains after emergency cleanup")
+    if payload["removeProfile"]:
+        profile = Path(payload["profileDir"])
+        if profile.exists():
+            shutil.rmtree(profile, ignore_errors=False)
+        if profile.exists():
+            raise RuntimeError("ephemeral profile remains after emergency cleanup")
+
+
+class _CleanupOwner:
+    def __init__(self, metadata_path: Path, nonce: str) -> None:
+        self.metadata_path = metadata_path.expanduser().resolve()
+        self.nonce = nonce
+        self._payload = _load_cleanup_metadata(self.metadata_path, nonce)
+
+    @property
+    def profile_dir(self) -> Path:
+        return Path(self._payload["profileDir"]).resolve()
+
+    @property
+    def remove_profile(self) -> bool:
+        return self._payload["removeProfile"]
+
+    def update(self, token: SessionToken, display_pid: int | None = None) -> None:
+        self._payload["sessionToken"] = token.value
+        self._payload["virtualDisplayPid"] = display_pid
+        temporary = self.metadata_path.with_suffix(".tmp")
+        temporary.write_text(
+            json.dumps(self._payload, separators=(",", ":")),
+            encoding="utf-8",
+        )
+        temporary.replace(self.metadata_path)
+
+    def prepared_metadata(self) -> dict[str, Any]:
+        prepared = {**self._payload, "metadataPath": str(self.metadata_path)}
+        if prepared["virtualDisplayPid"] is None:
+            del prepared["virtualDisplayPid"]
+        return prepared
+
+
+def _resolve_headless_with_cleanup(
+        launcher: InvisiblePlaywright, cleanup_owner: _CleanupOwner | None) -> bool:
+    if cleanup_owner is None:
+        return launcher._resolve_headless()
+    token = launcher._session_token
+    cleanup_owner.update(token)
+    previous = os.environ.get(TOKEN_VAR)
+    os.environ[TOKEN_VAR] = token.value
+    try:
+        headless = launcher._resolve_headless()
+    finally:
+        if previous is None:
+            os.environ.pop(TOKEN_VAR, None)
+        else:
+            os.environ[TOKEN_VAR] = previous
+    display = launcher._virtual_display
+    process = getattr(display, "_proc", None) if display is not None else None
+    display_pid = getattr(process, "pid", None)
+    if not isinstance(display_pid, int) or display_pid <= 0:
+        display_pid = None
+    cleanup_owner.update(token, display_pid)
+    return headless
+
+
+def _validate_options(options: dict[str, Any]) -> None:
+    unknown = sorted(set(options) - _OPTIONS)
+    if unknown:
+        raise ValueError("unknown TypeScript option: " + ", ".join(unknown))
+
+    seed = options.get("seed")
+    if seed is not None and (not isinstance(seed, int) or isinstance(seed, bool)):
+        raise TypeError("seed must be an integer or null")
+
+    pin = options.get("pin")
+    if pin is not None and type(pin) is not dict:
+        raise TypeError("pin must be a plain object or null")
+
+    proxy = options.get("proxy")
+    if proxy is not None:
+        if type(proxy) is not dict:
+            raise TypeError("proxy must be a plain object or null")
+        allowed_proxy_fields = {"server", "username", "password", "bypass"}
+        extra_proxy_fields = sorted(set(proxy) - allowed_proxy_fields)
+        if extra_proxy_fields:
+            raise ValueError("proxy contains unknown fields: " + ", ".join(extra_proxy_fields))
+        if not isinstance(proxy.get("server"), str):
+            raise TypeError("proxy.server must be a string")
+        for field in ("username", "password", "bypass"):
+            if field in proxy and not isinstance(proxy[field], str):
+                raise TypeError(f"proxy.{field} must be a string")
+
+    extra_args = options.get("extraArgs")
+    if extra_args is not None and (
+            not isinstance(extra_args, list) or
+            not all(isinstance(arg, str) for arg in extra_args)):
+        raise TypeError("extraArgs must be an array of strings or null")
+
+    humanize = options.get("humanize", True)
+    valid_number = (
+        isinstance(humanize, (int, float)) and
+        not isinstance(humanize, bool) and
+        math.isfinite(humanize) and
+        humanize >= 0
+    )
+    if not isinstance(humanize, bool) and not valid_number:
+        raise TypeError("humanize must be a boolean or a finite nonnegative number")
+
+    for name in ("locale", "timezone", "binaryPath", "profileDir"):
+        if name in options and not isinstance(options[name], str):
+            raise TypeError(f"{name} must be a string")
+
+    extra_prefs = options.get("extraPrefs")
+    if extra_prefs is not None:
+        if type(extra_prefs) is not dict:
+            raise TypeError("extraPrefs must be a plain object or null")
+        for key, value in extra_prefs.items():
+            if not isinstance(key, str):
+                raise TypeError("extraPrefs keys must be strings")
+            scalar = value is None or isinstance(value, (str, bool, int, float))
+            if not scalar or (isinstance(value, float) and not math.isfinite(value)):
+                raise TypeError(f"extraPrefs.{key} must be a JSON scalar")
+
+    if "headless" in options and not isinstance(options["headless"], bool):
+        raise TypeError("headless must be a boolean")
+    show_cursor = options.get("showCursor")
+    if show_cursor is not None and not isinstance(show_cursor, bool):
+        raise TypeError("showCursor must be a boolean or null")
+
+
+class PreparedSession:
+    """A prepared Firefox profile plus any display process that supports it."""
+
+    def __init__(self, launcher: InvisiblePlaywright, config: dict[str, Any],
+                 profile_dir: Path, remove_profile: bool) -> None:
+        self._launcher = launcher
+        self.config = config
+        self._profile_dir = profile_dir
+        self._remove_profile = remove_profile
+        self._closed = False
+
+    @classmethod
+    def from_options(
+            cls, options: dict[str, Any], *,
+            cleanup_owner: _CleanupOwner | None = None) -> PreparedSession:
+        _validate_options(options)
+
+        supplied_profile = options.get("profileDir")
+        profile_dir: Path | None = None
+        launcher: InvisiblePlaywright | None = None
+        remove_profile = cleanup_owner.remove_profile if cleanup_owner else not bool(supplied_profile)
+
+        try:
+            if cleanup_owner is not None:
+                profile_dir = cleanup_owner.profile_dir
+                expected_remove = not bool(supplied_profile)
+                expected_profile = (
+                    Path(supplied_profile).expanduser().resolve()
+                    if supplied_profile else cleanup_owner.metadata_path.parent / "profile"
+                )
+                if remove_profile != expected_remove or profile_dir != expected_profile:
+                    raise ValueError("cleanup metadata does not match profile ownership")
+            else:
+                profile_dir = (Path(supplied_profile).expanduser().resolve()
+                               if supplied_profile else
+                               Path(tempfile.mkdtemp(prefix="invisible-playwright-node-")))
+            launcher = InvisiblePlaywright(
+                seed=options.get("seed"),
+                pin=options.get("pin"),
+                headless=options.get("headless", False),
+                proxy=options.get("proxy"),
+                extra_args=options.get("extraArgs"),
+                humanize=options.get("humanize", True),
+                locale=options.get("locale", "auto"),
+                timezone=options.get("timezone", ""),
+                extra_prefs=options.get("extraPrefs"),
+                binary_path=options.get("binaryPath"),
+                profile_dir=profile_dir,
+                show_cursor=options.get("showCursor"),
+            )
+            # Node cannot run the Python-side cursor generator. The patched browser
+            # implements the same ordinary Playwright pointer API, so select that
+            # engine explicitly instead of writing a pref that disables motion.
+            launcher._cursor_engine = ENGINE_BINARY
+
+            geo = prepare_session_geo(launcher._timezone, launcher._proxy)
+            launcher._timezone = geo.timezone
+            launcher._webrtc_egress_ip = geo.egress_ip
+            launcher._srflx_dichiarato = geo.srflx_da_dichiarare()
+            if (launcher._locale or "").strip().lower() == "auto":
+                launcher._locale = resolve_session_locale(
+                    geo.egress_ip, launcher._proxy)
+
+            launcher._session_token = SessionToken.mint()
+            executable = resolve_executable(launcher._binary_path)
+            playwright_headless = _resolve_headless_with_cleanup(launcher, cleanup_owner)
+            prefs = launcher._build_prefs()
+            playwright_proxy = configure_proxy(launcher._proxy, prefs)
+            profile_dir.mkdir(parents=True, exist_ok=True)
+            _write_user_js(str(profile_dir), prefs)
+
+            complete_env = launcher._build_env(prefs)
+            env_delta = {
+                key: value for key, value in complete_env.items()
+                if os.environ.get(key) != value
+            }
+            context = launcher._default_context_kwargs()
+            context_config: dict[str, Any] = {
+                "viewport": context["viewport"],
+                "screen": context["screen"],
+            }
+            if "locale" in context:
+                context_config["locale"] = context["locale"]
+            if "timezone_id" in context:
+                context_config["timezoneId"] = context["timezone_id"]
+
+            config: dict[str, Any] = {
+                "seed": launcher.seed,
+                "executablePath": str(executable),
+                "profileDir": str(profile_dir),
+                "headless": playwright_headless,
+                "args": launcher._extra_args,
+                "env": env_delta,
+                "context": context_config,
+            }
+            if playwright_proxy is not None:
+                config["proxy"] = playwright_proxy
+            if cleanup_owner is not None:
+                config["cleanup"] = cleanup_owner.prepared_metadata()
+            return cls(launcher, config, profile_dir, remove_profile)
+        except BaseException:
+            cls._clean(launcher, profile_dir, remove_profile)
+            raise
+
+    @staticmethod
+    def _clean(launcher: InvisiblePlaywright | None, profile_dir: Path | None,
+               remove_profile: bool) -> None:
+        cleanup_failure: Exception | None = None
+        if launcher is not None:
+            token = launcher._session_token
+            if token:
+                try:
+                    guard_for().reap(token)
+                except Exception as failure:  # noqa: BLE001 - cleanup must continue
+                    cleanup_failure = failure
+                launcher._session_token = SessionToken()
+            display = launcher._virtual_display
+            launcher._virtual_display = None
+            if display is not None:
+                try:
+                    display.stop()
+                except Exception as failure:  # noqa: BLE001 - cleanup must continue
+                    if cleanup_failure is None:
+                        cleanup_failure = failure
+        if remove_profile and profile_dir is not None:
+            shutil.rmtree(profile_dir, ignore_errors=True)
+        if cleanup_failure is not None:
+            raise cleanup_failure
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        self._clean(self._launcher, self._profile_dir, self._remove_profile)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = sys.argv[1:] if argv is None else argv
+    if args:
+        if len(args) != 3 or args[0] != "--cleanup":
+            sys.stderr.write("invisible_playwright TypeScript bridge: invalid private mode\n")
+            return 2
+        try:
+            _emergency_cleanup(Path(args[1]), args[2])
+            return 0
+        except BaseException as failure:  # noqa: BLE001 - process boundary
+            sys.stderr.write(
+                f"invisible_playwright TypeScript emergency cleanup: {failure}\n")
+            return 1
+
+    session: PreparedSession | None = None
+    try:
+        cleanup_owner = _CleanupOwner(
+            Path(os.environ[_CLEANUP_PATH_VAR]),
+            os.environ[_CLEANUP_NONCE_VAR],
+        )
+        line = sys.stdin.readline()
+        if not line:
+            raise RuntimeError("the TypeScript bridge received no launch options")
+        payload = json.loads(line)
+        if not isinstance(payload, dict):
+            raise TypeError("the TypeScript bridge options must be a JSON object")
+        session = PreparedSession.from_options(payload, cleanup_owner=cleanup_owner)
+        sys.stdout.write(json.dumps(session.config, separators=(",", ":")) + "\n")
+        sys.stdout.flush()
+        # Node closes stdin when the Playwright context closes. Keeping this
+        # process alive keeps Xvfb alive too; EOF is the ownership boundary.
+        while sys.stdin.buffer.read(8192):
+            pass
+        return 0
+    except BaseException as failure:  # noqa: BLE001 - process boundary
+        sys.stderr.write(f"invisible_playwright TypeScript bridge: {failure}\n")
+        return 1
+    finally:
+        if session is not None:
+            session.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_node_bridge.py
+++ b/tests/test_node_bridge.py
@@ -1,0 +1,368 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+def test_node_bridge_prepares_a_profile_without_launching_a_browser(
+        tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    import invisible_playwright._typescript_bridge as bridge
+    from invisible_playwright._typescript_bridge import PreparedSession
+
+    binary = tmp_path / "firefox"
+    binary.write_text("not launched", encoding="utf-8")
+    binary.chmod(0o755)
+    profile = tmp_path / "profile"
+    monkeypatch.setattr(bridge, "resolve_executable", lambda path: Path(path))
+    monkeypatch.setattr(bridge.InvisiblePlaywright, "_build_env", lambda self, prefs: {})
+
+    session = PreparedSession.from_options({
+        "seed": 42,
+        "headless": False,
+        "locale": "en-US",
+        "timezone": "UTC",
+        "binaryPath": str(binary),
+        "profileDir": str(profile),
+        "humanize": True,
+    })
+    try:
+        config = session.config
+        assert config["seed"] == 42
+        assert config["executablePath"] == str(binary)
+        assert config["profileDir"] == str(profile)
+        assert config["headless"] is False
+        assert "proxy" not in config
+        assert config["context"]["locale"] == "en-US"
+        assert config["context"]["timezoneId"] == "UTC"
+        assert config["context"]["screen"] == {"width": 1920, "height": 1080}
+        assert config["context"]["viewport"] == {"width": 1920, "height": 947}
+        user_js = (profile / "user.js").read_text(encoding="utf-8")
+        assert 'user_pref("general.useragent.override"' in user_js
+        assert 'user_pref("stealthfox.humanize", true);' in user_js
+        json.dumps(config)
+    finally:
+        session.close()
+
+
+def test_private_cleanup_mode_runs_the_bounded_owner_cleanup(
+        tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    import invisible_playwright._typescript_bridge as bridge
+
+    metadata = tmp_path / "cleanup.json"
+    calls = []
+    monkeypatch.setattr(
+        bridge,
+        "_emergency_cleanup",
+        lambda path, nonce: calls.append((path, nonce)),
+    )
+
+    assert bridge.main(["--cleanup", str(metadata), "e" * 64]) == 0
+    assert calls == [(metadata, "e" * 64)]
+
+
+def test_virtual_display_is_token_stamped_before_spawn_and_recorded(
+        monkeypatch: pytest.MonkeyPatch):
+    import invisible_playwright._typescript_bridge as bridge
+    from invisible_playwright._reaper import SessionToken, TOKEN_VAR
+
+    token = SessionToken.mint()
+    seen_tokens = []
+    updates = []
+    launcher = SimpleNamespace(
+        _session_token=token,
+        _virtual_display=None,
+    )
+
+    def resolve_headless():
+        seen_tokens.append(os.environ.get(TOKEN_VAR))
+        launcher._virtual_display = SimpleNamespace(
+            _proc=SimpleNamespace(pid=9876),
+        )
+        return False
+
+    launcher._resolve_headless = resolve_headless
+    owner = SimpleNamespace(update=lambda value, pid=None: updates.append((value, pid)))
+    monkeypatch.delenv(TOKEN_VAR, raising=False)
+
+    assert bridge._resolve_headless_with_cleanup(launcher, owner) is False
+    assert seen_tokens == [token.value]
+    assert TOKEN_VAR not in os.environ
+    assert updates == [(token, None), (token, 9876)]
+
+
+def test_prepared_session_publishes_validated_cleanup_identity(
+        tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    import invisible_playwright._typescript_bridge as bridge
+
+    owner_dir = tmp_path / "invisible-playwright-node-owner-test"
+    owner_dir.mkdir()
+    profile = owner_dir / "profile"
+    metadata = owner_dir / "cleanup.json"
+    nonce = "d" * 64
+    metadata.write_text(json.dumps({
+        "version": 1,
+        "nonce": nonce,
+        "profileDir": str(profile),
+        "removeProfile": True,
+        "sessionToken": "",
+        "virtualDisplayPid": None,
+    }), encoding="utf-8")
+    binary = tmp_path / "firefox"
+    binary.write_text("binary", encoding="utf-8")
+    binary.chmod(0o755)
+    monkeypatch.setattr(bridge, "resolve_executable", lambda path: Path(path))
+    monkeypatch.setattr(bridge.InvisiblePlaywright, "_build_env", lambda self, prefs: {})
+    cleanup_owner = bridge._CleanupOwner(metadata, nonce)
+
+    session = bridge.PreparedSession.from_options(
+        {"binaryPath": str(binary), "headless": False},
+        cleanup_owner=cleanup_owner,
+    )
+    try:
+        cleanup = session.config["cleanup"]
+        assert cleanup["metadataPath"] == str(metadata.resolve())
+        assert cleanup["nonce"] == nonce
+        assert cleanup["profileDir"] == str(profile.resolve())
+        assert cleanup["removeProfile"] is True
+        assert len(cleanup["sessionToken"]) == 32
+    finally:
+        session.close()
+
+
+def test_emergency_cleanup_reaps_token_and_removes_owned_ephemeral_profile(
+        tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    import invisible_playwright._typescript_bridge as bridge
+    from invisible_playwright._reaper import SessionToken
+
+    owner = tmp_path / "invisible-playwright-node-owner-test"
+    owner.mkdir()
+    profile = owner / "profile"
+    profile.mkdir()
+    metadata = owner / "cleanup.json"
+    nonce = "a" * 64
+    token = SessionToken.mint()
+    metadata.write_text(json.dumps({
+        "version": 1,
+        "nonce": nonce,
+        "profileDir": str(profile),
+        "removeProfile": True,
+        "sessionToken": token.value,
+        "virtualDisplayPid": None,
+    }), encoding="utf-8")
+    reaped = []
+    monkeypatch.setattr(bridge, "guard_for", lambda: SimpleNamespace(reap=reaped.append))
+    monkeypatch.setattr(bridge, "find_processes", lambda _token: [])
+
+    bridge._emergency_cleanup(metadata, nonce)
+
+    assert reaped == [token]
+    assert not profile.exists()
+
+
+def test_emergency_cleanup_never_removes_a_supplied_persistent_profile(
+        tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    import invisible_playwright._typescript_bridge as bridge
+
+    owner = tmp_path / "invisible-playwright-node-owner-test"
+    owner.mkdir()
+    profile = tmp_path / "persistent"
+    profile.mkdir()
+    marker = profile / "keep"
+    marker.write_text("persistent", encoding="utf-8")
+    metadata = owner / "cleanup.json"
+    nonce = "b" * 64
+    metadata.write_text(json.dumps({
+        "version": 1,
+        "nonce": nonce,
+        "profileDir": str(profile),
+        "removeProfile": False,
+        "sessionToken": "",
+        "virtualDisplayPid": None,
+    }), encoding="utf-8")
+    monkeypatch.setattr(bridge, "find_processes", lambda _token: [])
+
+    bridge._emergency_cleanup(metadata, nonce)
+
+    assert marker.read_text(encoding="utf-8") == "persistent"
+
+
+def test_emergency_cleanup_terminates_a_token_owned_virtual_display(
+        tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    import invisible_playwright._typescript_bridge as bridge
+    from invisible_playwright._reaper import SessionToken, TOKEN_VAR
+
+    owner = tmp_path / "invisible-playwright-node-owner-test"
+    owner.mkdir()
+    profile = owner / "profile"
+    profile.mkdir()
+    metadata = owner / "cleanup.json"
+    nonce = "c" * 64
+    token = SessionToken.mint()
+    metadata.write_text(json.dumps({
+        "version": 1,
+        "nonce": nonce,
+        "profileDir": str(profile),
+        "removeProfile": True,
+        "sessionToken": token.value,
+        "virtualDisplayPid": 4321,
+    }), encoding="utf-8")
+    process = SimpleNamespace(pid=4321, environ=lambda: {TOKEN_VAR: token.value})
+    terminated = []
+    monkeypatch.setattr(bridge, "guard_for", lambda: SimpleNamespace(reap=lambda _token: 0))
+    monkeypatch.setattr(bridge, "find_processes", lambda _token: [])
+    monkeypatch.setattr(bridge.psutil, "Process", lambda _pid: process)
+    monkeypatch.setattr(bridge, "terminate", lambda processes: terminated.extend(processes))
+    monkeypatch.setattr(bridge, "alive", lambda _process: False)
+
+    bridge._emergency_cleanup(metadata, nonce)
+
+    assert terminated == [process]
+
+
+def test_node_bridge_rejects_unknown_options():
+    from invisible_playwright._typescript_bridge import PreparedSession
+
+    with pytest.raises(ValueError, match="unknown TypeScript option: typo"):
+        PreparedSession.from_options({"typo": True})
+
+
+def test_node_bridge_rejects_non_boolean_headless():
+    from invisible_playwright._typescript_bridge import PreparedSession
+
+    with pytest.raises(TypeError, match="headless must be a boolean"):
+        PreparedSession.from_options({"headless": "false"})
+
+
+def test_node_bridge_rejects_non_array_extra_args():
+    from invisible_playwright._typescript_bridge import PreparedSession
+
+    with pytest.raises(TypeError, match="extraArgs must be an array of strings or null"):
+        PreparedSession.from_options({"extraArgs": "--private"})
+
+
+@pytest.mark.parametrize(("option", "value", "message"), [
+    ("seed", True, "seed must be an integer or null"),
+    ("seed", 1.5, "seed must be an integer or null"),
+    ("pin", [], "pin must be a plain object or null"),
+    ("proxy", [], "proxy must be a plain object or null"),
+    ("proxy", {}, "proxy.server must be a string"),
+    ("proxy", {"server": 7}, "proxy.server must be a string"),
+    ("proxy", {"server": "http://proxy", "username": False},
+     "proxy.username must be a string"),
+    ("proxy", {"server": "http://proxy", "extra": "no"},
+     "proxy contains unknown fields: extra"),
+    ("extraArgs", ["--ok", 1], "extraArgs must be an array of strings or null"),
+    ("humanize", "false", "humanize must be a boolean or a finite nonnegative number"),
+    ("humanize", -0.1, "humanize must be a boolean or a finite nonnegative number"),
+    ("humanize", float("inf"), "humanize must be a boolean or a finite nonnegative number"),
+    ("locale", False, "locale must be a string"),
+    ("timezone", 1, "timezone must be a string"),
+    ("binaryPath", [], "binaryPath must be a string"),
+    ("profileDir", False, "profileDir must be a string"),
+    ("extraPrefs", [], "extraPrefs must be a plain object or null"),
+    ("extraPrefs", {"pref": []}, "extraPrefs.pref must be a JSON scalar"),
+    ("extraPrefs", {"pref": float("nan")}, "extraPrefs.pref must be a JSON scalar"),
+    ("headless", "false", "headless must be a boolean"),
+    ("showCursor", "false", "showCursor must be a boolean or null"),
+], ids=lambda value: repr(value))
+def test_node_bridge_rejects_erased_javascript_option_types(
+        option: str, value: object, message: str):
+    from invisible_playwright._typescript_bridge import PreparedSession
+
+    with pytest.raises((TypeError, ValueError), match=message.replace(".", r"\.")):
+        PreparedSession.from_options({option: value})
+
+
+def test_node_bridge_accepts_nullable_option_values():
+    import invisible_playwright._typescript_bridge as bridge
+
+    validate = getattr(bridge, "_validate_options", None)
+    assert validate is not None, "the bridge must validate options before creating resources"
+    validate({
+        "seed": None,
+        "pin": None,
+        "proxy": None,
+        "extraArgs": None,
+        "extraPrefs": None,
+        "showCursor": None,
+    })
+
+
+def test_ephemeral_profile_is_removed_when_launcher_construction_fails(
+        tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    import invisible_playwright._typescript_bridge as bridge
+
+    profile = tmp_path / "ephemeral"
+
+    def make_profile(**_kwargs):
+        profile.mkdir()
+        return str(profile)
+
+    monkeypatch.setattr(bridge.tempfile, "mkdtemp", make_profile)
+
+    def fail_constructor(**_kwargs):
+        raise RuntimeError("constructor failed")
+
+    monkeypatch.setattr(bridge, "InvisiblePlaywright", fail_constructor)
+
+    with pytest.raises(RuntimeError, match="constructor failed"):
+        bridge.PreparedSession.from_options({})
+
+    assert not profile.exists()
+
+
+def test_prepared_session_surfaces_reaper_failure_and_finishes_other_cleanup(
+        tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    import invisible_playwright._typescript_bridge as bridge
+    from invisible_playwright._reaper import SessionToken
+
+    profile = tmp_path / "ephemeral"
+    profile.mkdir()
+    (profile / "marker").write_text("remove me", encoding="utf-8")
+    display_stops = []
+    token = SessionToken.mint()
+    launcher = SimpleNamespace(
+        _virtual_display=SimpleNamespace(stop=lambda: display_stops.append(True)),
+        _session_token=token,
+    )
+
+    def fail_reap(_token):
+        raise RuntimeError("reaper failed")
+
+    monkeypatch.setattr(bridge, "guard_for", lambda: SimpleNamespace(reap=fail_reap))
+    session = bridge.PreparedSession(launcher, {}, profile, True)
+
+    with pytest.raises(RuntimeError, match="reaper failed"):
+        session.close()
+
+    assert launcher._session_token == SessionToken()
+    assert display_stops == [True]
+    assert not profile.exists()
+
+
+def test_prepared_session_reaps_browser_processes_with_its_session_token(
+        tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    import invisible_playwright._typescript_bridge as bridge
+    from invisible_playwright._reaper import SessionToken
+
+    token = SessionToken.mint()
+    launcher = SimpleNamespace(_virtual_display=None, _session_token=token)
+    reaped = []
+    monkeypatch.setattr(
+        bridge,
+        "guard_for",
+        lambda: SimpleNamespace(reap=reaped.append),
+        raising=False,
+    )
+    session = bridge.PreparedSession(launcher, {}, tmp_path, False)
+
+    session.close()
+    session.close()
+
+    assert reaped == [token]

--- a/tests/test_npm_publication_wiring.py
+++ b/tests/test_npm_publication_wiring.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_REPO = Path(__file__).resolve().parents[1]
+_WORKFLOW = _REPO / ".github" / "workflows" / "publish.yml"
+_PACKAGE = _REPO / "typescript" / "package.json"
+
+
+def test_publish_workflow_uses_idempotent_npm_trusted_publishing():
+    workflow = _WORKFLOW.read_text(encoding="utf-8")
+
+    assert "npm-already-published:" in workflow
+    assert "https://registry.npmjs.org/invisible-playwright/$VERSION" in workflow
+    assert "npm-upload:" in workflow
+    assert "environment: npm" in workflow
+    assert "id-token: write" in workflow
+    assert "npm publish --provenance --access public" in workflow
+    assert "already appeared on npm after the publish attempt" in workflow
+
+
+def test_npm_release_waits_for_a_successful_python_release_path():
+    workflow = _WORKFLOW.read_text(encoding="utf-8")
+
+    assert "python-release-ready:" in workflow
+    assert "needs: [already-published, gate, upload]" in workflow
+    assert "needs.already-published.outputs.present == 'yes'" in workflow
+    assert "needs.upload.result == 'success'" in workflow
+    assert "npm-gate:\n    needs: [npm-already-published, python-release-ready]" in workflow
+    npm_gate = workflow.split("  npm-gate:", 1)[1].split("\n  npm-upload:", 1)[0]
+    assert "needs.npm-already-published.outputs.present != 'yes'" not in npm_gate
+    assert "if: always()" in npm_gate
+    assert "needs.python-release-ready.result == 'success'" in npm_gate
+    npm_upload = workflow.split("  npm-upload:", 1)[1]
+    assert "needs.npm-already-published.outputs.present == 'no'" in npm_upload
+    assert "needs.npm-gate.result == 'success'" in npm_upload
+
+
+def test_trusted_publishing_uses_the_exact_reviewed_npm_cli():
+    workflow = _WORKFLOW.read_text(encoding="utf-8")
+
+    assert "npm install --global npm@11.19.1" in workflow
+    assert "npm install --global npm@11\n" not in workflow
+
+
+def test_npm_and_python_packages_have_the_same_release_version():
+    import tomllib
+
+    package = json.loads(_PACKAGE.read_text(encoding="utf-8"))
+    project = tomllib.loads((_REPO / "pyproject.toml").read_text(encoding="utf-8"))
+
+    assert package["name"] == "invisible-playwright"
+    assert package["version"] == project["project"]["version"] == "0.8.3"
+    assert package["dependencies"]["playwright-core"] == "1.61.0"

--- a/typescript/LICENSE
+++ b/typescript/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 stealthfox contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -1,0 +1,57 @@
+# invisible-playwright for TypeScript
+
+Drive invisible_playwright's patched Firefox through the ordinary Playwright TypeScript API. The Python package prepares the sealed browser, seeded fingerprint, proxy/locale/timezone settings, and profile before Playwright starts; pages, locators, requests, and events remain standard Playwright objects.
+
+## Install
+
+Both runtimes are required. The browser is downloaded and verified automatically on the first launch; there is no TypeScript CLI or separate fetch step.
+
+```bash
+pip install invisible-playwright
+npm install invisible-playwright
+```
+
+Node.js 18+ and Python 3.11+ are supported. If Python is not available as `python3` on Linux or `python` on Windows, pass `pythonExecutable` or set `INVPW_PYTHON`.
+
+## Usage
+
+```ts
+import { InvisiblePlaywright } from "invisible-playwright";
+
+const invisible = new InvisiblePlaywright({
+  seed: 42,
+  proxy: {
+    server: "socks5://gate.example.com:1080",
+    username: "user",
+    password: "pass",
+  },
+});
+
+try {
+  const context = await invisible.launch();
+  const page = context.pages()[0] ?? await context.newPage();
+  await page.goto("https://example.com");
+  await page.click("#submit");
+  console.log("seed =", invisible.seed);
+} finally {
+  await invisible.close();
+}
+```
+
+`launch()` returns a Playwright `BrowserContext`. A persistent context is required because the patched browser reads its fingerprint preferences from the Firefox profile before startup; sending `firefoxUserPrefs` after startup is deliberately rejected. The returned context and every page, locator, route, request, and event use Playwright's normal API.
+
+## Options
+
+- `seed`: reproducible fingerprint seed; omitted means a fresh random seed.
+- `pin`: force selected fingerprint fields while the rest stay seed-derived.
+- `headless`: same behavior as the Python wrapper. On Linux the default stealth path requires Xvfb; `INVPW_TRUE_HEADLESS=1` opts into Firefox's real headless rendering path.
+- `proxy`: Playwright proxy object. SOCKS credentials and DNS routing are composed into the Firefox profile automatically.
+- `humanize`: `true` by default, `false` to disable, or a number to cap pointer movement duration in seconds. The browser-side generator humanizes ordinary Playwright pointer calls.
+- `locale` / `timezone`: default to automatic egress-derived values; explicit values win.
+- `extraArgs` / `extraPrefs`: additional Firefox arguments or preferences.
+- `binaryPath`: deliberately use a specific sealed binary.
+- `profileDir`: reuse a persistent Firefox profile. Without it, the wrapper creates and removes an ephemeral profile.
+- `showCursor`: show or hide the browser-chrome cursor marker.
+- `pythonExecutable`: Python interpreter containing the matching `invisible-playwright` installation.
+
+Always call `close()`. It closes the Playwright context, removes an ephemeral profile, and stops the Linux virtual display when one was created.

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,0 +1,66 @@
+{
+  "name": "invisible-playwright",
+  "version": "0.8.3",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "invisible-playwright",
+      "version": "0.8.3",
+      "license": "MIT",
+      "dependencies": {
+        "playwright-core": "1.61.0"
+      },
+      "devDependencies": {
+        "@types/node": "^24.0.0",
+        "typescript": "^5.9.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
+      "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "invisible-playwright",
+  "version": "0.8.3",
+  "description": "TypeScript wrapper for invisible_playwright's patched Firefox",
+  "license": "MIT",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {"types": "./dist/index.d.ts", "import": "./dist/index.js"}
+  },
+  "files": ["dist", "README.md", "LICENSE"],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/feder-cr/invisible_playwright.git"
+  },
+  "homepage": "https://github.com/feder-cr/invisible_playwright#readme",
+  "bugs": {"url": "https://github.com/feder-cr/invisible_playwright/issues"},
+  "publishConfig": {"access": "public", "provenance": true},
+  "engines": {"node": ">=18"},
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "tsc -p tsconfig.test.json && node --test dist-test/test/*.test.js",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "playwright-core": "1.61.0"
+  },
+  "devDependencies": {
+    "@types/node": "^24.0.0",
+    "typescript": "^5.9.0"
+  }
+}

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -1,0 +1,2 @@
+export { InvisiblePlaywright } from "./internal.js";
+export type { InvisiblePlaywrightOptions } from "./internal.js";

--- a/typescript/src/internal.ts
+++ b/typescript/src/internal.ts
@@ -1,0 +1,636 @@
+import { spawn } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { homedir, tmpdir } from "node:os";
+import path from "node:path";
+import process from "node:process";
+
+import { firefox, type BrowserContext } from "playwright-core";
+
+type PersistentContextOptions = NonNullable<Parameters<typeof firefox.launchPersistentContext>[1]>;
+type ProxySettings = NonNullable<PersistentContextOptions["proxy"]>;
+
+export interface PreparedCleanup {
+  version: 1;
+  nonce: string;
+  metadataPath: string;
+  profileDir: string;
+  removeProfile: boolean;
+  sessionToken: string;
+  virtualDisplayPid?: number;
+}
+
+export interface PreparedLaunch {
+  seed: number;
+  executablePath: string;
+  profileDir: string;
+  headless: boolean;
+  args: string[];
+  env: Record<string, string>;
+  proxy?: ProxySettings;
+  context: Pick<PersistentContextOptions, "viewport" | "screen" | "locale" | "timezoneId">;
+  cleanup: PreparedCleanup;
+}
+
+export interface BridgeHandle {
+  prepared: PreparedLaunch;
+  close(): Promise<void>;
+}
+
+export interface ContextLike {
+  close(): Promise<void>;
+  on(event: "close", listener: () => void): unknown;
+}
+
+export interface BrowserTypeLike {
+  launchPersistentContext(
+    profileDir: string,
+    options: PersistentContextOptions,
+  ): Promise<ContextLike>;
+}
+
+export type BridgeFactory<Options> = (options: Options) => Promise<BridgeHandle>;
+
+function incompatible(reason: string): never {
+  throw new Error(`incompatible Python bridge response: ${reason}`);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function requireExactKeys(
+  value: Record<string, unknown>,
+  required: readonly string[],
+  optional: readonly string[] = [],
+  label = "response",
+): void {
+  const allowed = new Set([...required, ...optional]);
+  const actual = Object.keys(value);
+  const missing = required.filter(key => !Object.hasOwn(value, key));
+  const extra = actual.filter(key => !allowed.has(key));
+  if (missing.length || extra.length) {
+    incompatible(`${label} has invalid keys`);
+  }
+}
+
+function positiveInteger(value: unknown): boolean {
+  return typeof value === "number" && Number.isFinite(value) &&
+    Number.isInteger(value) && value > 0;
+}
+
+function validateDimensions(value: unknown, label: string): void {
+  if (!isRecord(value)) incompatible(`${label} must be an object`);
+  requireExactKeys(value, ["width", "height"], [], label);
+  if (!positiveInteger(value.width) || !positiveInteger(value.height)) {
+    incompatible(`${label} dimensions must be positive finite integers`);
+  }
+}
+
+function validatePreparedLaunch(value: unknown): PreparedLaunch {
+  if (!isRecord(value)) incompatible("response must be an object");
+  requireExactKeys(
+    value,
+    ["seed", "executablePath", "profileDir", "headless", "args", "env", "context", "cleanup"],
+    ["proxy"],
+  );
+  if (typeof value.seed !== "number" || !Number.isFinite(value.seed) ||
+      !Number.isInteger(value.seed)) incompatible("seed must be a finite integer");
+  for (const field of ["executablePath", "profileDir"] as const) {
+    if (typeof value[field] !== "string" || value[field].length === 0) {
+      incompatible(`${field} must be a nonempty string`);
+    }
+  }
+  if (typeof value.headless !== "boolean") incompatible("headless must be a boolean");
+  if (!Array.isArray(value.args) || !value.args.every(arg => typeof arg === "string")) {
+    incompatible("args must be an array of strings");
+  }
+  if (!isRecord(value.env) ||
+      !Object.entries(value.env).every(([key, entry]) => key.length > 0 && typeof entry === "string")) {
+    incompatible("env must contain only nonempty string keys and string values");
+  }
+  if (Object.hasOwn(value, "proxy")) {
+    const proxy = value.proxy;
+    if (!isRecord(proxy)) incompatible("proxy must be an object when present");
+    requireExactKeys(proxy, ["server"], ["username", "password", "bypass"], "proxy");
+    if (typeof proxy.server !== "string" || proxy.server.length === 0) {
+      incompatible("proxy.server must be a nonempty string");
+    }
+    for (const field of ["username", "password", "bypass"] as const) {
+      if (Object.hasOwn(proxy, field) && typeof proxy[field] !== "string") {
+        incompatible(`proxy.${field} must be a string`);
+      }
+    }
+  }
+  const context = value.context;
+  if (!isRecord(context)) incompatible("context must be an object");
+  requireExactKeys(context, ["viewport", "screen"], ["locale", "timezoneId"], "context");
+  validateDimensions(context.viewport, "context.viewport");
+  validateDimensions(context.screen, "context.screen");
+  for (const field of ["locale", "timezoneId"] as const) {
+    if (Object.hasOwn(context, field) && typeof context[field] !== "string") {
+      incompatible(`context.${field} must be a string`);
+    }
+  }
+  const cleanup = value.cleanup;
+  if (!isRecord(cleanup)) incompatible("cleanup must be an object");
+  requireExactKeys(
+    cleanup,
+    ["version", "nonce", "metadataPath", "profileDir", "removeProfile", "sessionToken"],
+    ["virtualDisplayPid"],
+    "cleanup",
+  );
+  if (cleanup.version !== 1) incompatible("cleanup.version must be 1");
+  if (typeof cleanup.nonce !== "string" || !/^[0-9a-f]{64}$/.test(cleanup.nonce)) {
+    incompatible("cleanup.nonce is invalid");
+  }
+  for (const field of ["metadataPath", "profileDir"] as const) {
+    if (typeof cleanup[field] !== "string" || !path.isAbsolute(cleanup[field])) {
+      incompatible(`cleanup.${field} must be an absolute path`);
+    }
+  }
+  if (cleanup.profileDir !== value.profileDir) {
+    incompatible("cleanup.profileDir does not match profileDir");
+  }
+  if (typeof cleanup.removeProfile !== "boolean") {
+    incompatible("cleanup.removeProfile must be a boolean");
+  }
+  if (typeof cleanup.sessionToken !== "string" ||
+      !/^[0-9a-f]{32}$/.test(cleanup.sessionToken)) {
+    incompatible("cleanup.sessionToken is invalid");
+  }
+  if (Object.hasOwn(cleanup, "virtualDisplayPid") &&
+      !positiveInteger(cleanup.virtualDisplayPid)) {
+    incompatible("cleanup.virtualDisplayPid must be a positive finite integer");
+  }
+  return value as unknown as PreparedLaunch;
+}
+
+export function validatePreparedLaunchForTest(value: unknown): PreparedLaunch {
+  return validatePreparedLaunch(value);
+}
+
+function validateSerializableOptions(options: { seed?: number }): void {
+  if (options.seed !== undefined &&
+      (!Number.isFinite(options.seed) || !Number.isInteger(options.seed))) {
+    throw new TypeError("seed must be a finite integer");
+  }
+}
+
+const START_TIMEOUT_MS = 120_000;
+const CLOSE_TIMEOUT_MS = 5_000;
+const FORCE_KILL_TIMEOUT_MS = 1_000;
+const EMERGENCY_CLEANUP_TIMEOUT_MS = 10_000;
+const CLEANUP_PATH_VAR = "INVPW_TYPESCRIPT_CLEANUP_PATH";
+const CLEANUP_NONCE_VAR = "INVPW_TYPESCRIPT_CLEANUP_NONCE";
+
+interface ExitWaitChild {
+  exitCode: number | null;
+  signalCode: NodeJS.Signals | null;
+  kill(signal?: NodeJS.Signals | number): boolean;
+  once(event: "exit", listener: () => void): unknown;
+  removeListener(event: "exit", listener: () => void): unknown;
+}
+
+function waitForExit(
+  child: ExitWaitChild,
+  timeoutMs: number,
+  forceKillTimeoutMs = FORCE_KILL_TIMEOUT_MS,
+  finalTimeoutMs = FORCE_KILL_TIMEOUT_MS,
+): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    let forceTimer: NodeJS.Timeout | undefined;
+    let finalTimer: NodeJS.Timeout | undefined;
+    const finish = (callback: () => void) => {
+      clearTimeout(timer);
+      if (forceTimer) clearTimeout(forceTimer);
+      if (finalTimer) clearTimeout(finalTimer);
+      child.removeListener("exit", onExit);
+      callback();
+    };
+    const onExit = () => finish(resolve);
+    const timer = setTimeout(() => {
+      child.kill("SIGTERM");
+      forceTimer = setTimeout(() => {
+        if (child.exitCode !== null || child.signalCode !== null) return;
+        child.kill("SIGKILL");
+        finalTimer = setTimeout(() => {
+          if (child.exitCode === null && child.signalCode === null) {
+            finish(() => reject(new Error("bridge process did not exit after SIGKILL")));
+          }
+        }, finalTimeoutMs);
+      }, forceKillTimeoutMs);
+    }, timeoutMs);
+    child.once("exit", onExit);
+  });
+}
+
+export function waitForExitForTest(
+  child: ExitWaitChild,
+  timeoutMs: number,
+  forceKillTimeoutMs: number,
+  finalTimeoutMs: number,
+): Promise<void> {
+  return waitForExit(child, timeoutMs, forceKillTimeoutMs, finalTimeoutMs);
+}
+
+interface CleanupOwner {
+  directory: string;
+  metadataPath: string;
+  nonce: string;
+  profileDir: string;
+  removeProfile: boolean;
+}
+
+function resolveProfilePath(profileDir: string): string {
+  const expanded = profileDir === "~"
+    ? homedir()
+    : profileDir.startsWith(`~${path.sep}`)
+      ? path.join(homedir(), profileDir.slice(2))
+      : profileDir;
+  return path.resolve(expanded);
+}
+
+async function createCleanupOwner(bridgeOptions: Record<string, unknown>): Promise<CleanupOwner> {
+  const directory = await mkdtemp(path.join(tmpdir(), "invisible-playwright-node-owner-"));
+  const metadataPath = path.join(directory, "cleanup.json");
+  const supplied = typeof bridgeOptions.profileDir === "string" && bridgeOptions.profileDir.length > 0;
+  const profileDir = supplied
+    ? resolveProfilePath(bridgeOptions.profileDir as string)
+    : path.join(directory, "profile");
+  const owner = {
+    directory,
+    metadataPath,
+    nonce: randomBytes(32).toString("hex"),
+    profileDir,
+    removeProfile: !supplied,
+  };
+  await writeFile(metadataPath, JSON.stringify({
+    version: 1,
+    nonce: owner.nonce,
+    profileDir,
+    removeProfile: owner.removeProfile,
+    sessionToken: "",
+    virtualDisplayPid: null,
+  }), { encoding: "utf8", mode: 0o600 });
+  return owner;
+}
+
+function validateCleanupOwnership(prepared: PreparedLaunch, owner: CleanupOwner): void {
+  const cleanup = prepared.cleanup;
+  if (cleanup.nonce !== owner.nonce || cleanup.metadataPath !== owner.metadataPath ||
+      cleanup.removeProfile !== owner.removeProfile) {
+    incompatible("cleanup identity does not match the Node owner");
+  }
+  if (owner.removeProfile && cleanup.profileDir !== owner.profileDir) {
+    incompatible("ephemeral cleanup profile does not match the Node owner");
+  }
+}
+
+async function runEmergencyCleanup(
+  python: string,
+  owner: CleanupOwner,
+  baseEnv: NodeJS.ProcessEnv,
+): Promise<void> {
+  const cleanup = spawn(
+    python,
+    ["-m", "invisible_playwright._typescript_bridge", "--cleanup", owner.metadataPath, owner.nonce],
+    { env: baseEnv, stdio: ["ignore", "ignore", "pipe"], windowsHide: true },
+  );
+  let stderr = "";
+  cleanup.stderr.setEncoding("utf8");
+  cleanup.stderr.on("data", chunk => { stderr = (stderr + chunk).slice(-16_384); });
+  const spawnFailure = new Promise<never>((_resolve, reject) => {
+    cleanup.once("error", reject);
+  });
+  await Promise.race([
+    waitForExit(cleanup, EMERGENCY_CLEANUP_TIMEOUT_MS),
+    spawnFailure,
+  ]);
+  if (cleanup.exitCode !== 0) {
+    const status = cleanup.signalCode
+      ? `terminated by ${cleanup.signalCode}`
+      : `exited with code ${cleanup.exitCode}`;
+    throw new Error(
+      `emergency cleanup could not be confirmed: helper ${status}` +
+      `${stderr ? `: ${stderr.trim()}` : ""}`,
+    );
+  }
+  await rm(owner.directory, { recursive: true, force: true });
+}
+
+async function combineCleanupFailure(original: unknown, cleanup: Promise<void>): Promise<never> {
+  try {
+    await cleanup;
+  } catch (cleanupFailure) {
+    throw new AggregateError(
+      [original, cleanupFailure],
+      "Python bridge failed and emergency cleanup could not be confirmed",
+    );
+  }
+  throw original;
+}
+
+async function startPythonBridgeWithTimeout<Options extends { pythonExecutable?: string; seed?: number }>(
+  options: Options,
+  startTimeoutMs: number,
+): Promise<BridgeHandle> {
+  validateSerializableOptions(options);
+  const { pythonExecutable, ...bridgeOptions } = options;
+  const python = pythonExecutable || process.env.INVPW_PYTHON ||
+    (process.platform === "win32" ? "python" : "python3");
+  const owner = await createCleanupOwner(bridgeOptions as Record<string, unknown>);
+  const bridgeEnv = {
+    ...process.env,
+    [CLEANUP_PATH_VAR]: owner.metadataPath,
+    [CLEANUP_NONCE_VAR]: owner.nonce,
+  };
+  const child = spawn(python, ["-m", "invisible_playwright._typescript_bridge"], {
+    env: bridgeEnv,
+    stdio: ["pipe", "pipe", "pipe"],
+    windowsHide: true,
+  });
+
+  let stderr = "";
+  child.stderr.setEncoding("utf8");
+  child.stderr.on("data", chunk => { stderr = (stderr + chunk).slice(-16_384); });
+
+  try {
+    const prepared = await new Promise<PreparedLaunch>((resolve, reject) => {
+      let stdout = "";
+      const timer = setTimeout(() => {
+        reject(new Error(`invisible_playwright Python bridge timed out after ${startTimeoutMs} ms`));
+      }, startTimeoutMs);
+      timer.unref();
+
+      const finish = (callback: () => void) => {
+        clearTimeout(timer);
+        child.stdout.removeAllListeners("data");
+        child.removeListener("error", onError);
+        child.removeListener("exit", onExit);
+        callback();
+      };
+      const onError = (error: Error) => finish(() => reject(new Error(
+        `could not start ${python}: ${error.message}`,
+        { cause: error },
+      )));
+      const onExit = (code: number | null, signal: NodeJS.Signals | null) => finish(() => reject(new Error(
+        `invisible_playwright Python bridge exited before launch preparation ` +
+        `(code ${code}, signal ${signal})${stderr ? `: ${stderr.trim()}` : ""}`,
+      )));
+
+      child.once("error", onError);
+      child.once("exit", onExit);
+      child.stdout.setEncoding("utf8");
+      child.stdout.on("data", chunk => {
+        stdout += chunk;
+        const newline = stdout.indexOf("\n");
+        if (newline === -1) return;
+        const line = stdout.slice(0, newline);
+        finish(() => {
+          try {
+            const response = validatePreparedLaunch(JSON.parse(line));
+            validateCleanupOwnership(response, owner);
+            resolve(response);
+          } catch (error) {
+            if (error instanceof SyntaxError) {
+              reject(new Error("invisible_playwright Python bridge returned invalid JSON", { cause: error }));
+            } else {
+              reject(error);
+            }
+          }
+        });
+      });
+
+      child.stdin.write(JSON.stringify(bridgeOptions) + "\n");
+    });
+
+    let closed = false;
+    return {
+      prepared,
+      async close() {
+        if (closed) return;
+        closed = true;
+        child.stdin.end();
+        await waitForExit(child, CLOSE_TIMEOUT_MS);
+        if (child.exitCode !== 0) {
+          const status = child.signalCode
+            ? `terminated by ${child.signalCode}`
+            : `exited with code ${child.exitCode}`;
+          const failure = new Error(
+            `invisible_playwright Python bridge ${status}${stderr ? `: ${stderr.trim()}` : ""}`,
+          );
+          return combineCleanupFailure(
+            failure,
+            runEmergencyCleanup(python, owner, bridgeEnv),
+          );
+        }
+        await rm(owner.directory, { recursive: true, force: true });
+      },
+    };
+  } catch (error) {
+    child.stdin.destroy();
+    child.kill();
+    let exitFailure: unknown;
+    try {
+      await waitForExit(child, CLOSE_TIMEOUT_MS);
+    } catch (failure) {
+      exitFailure = failure;
+    }
+    const original = exitFailure
+      ? new AggregateError([error, exitFailure], "Python bridge startup and termination failed")
+      : error;
+    return combineCleanupFailure(
+      original,
+      runEmergencyCleanup(python, owner, bridgeEnv),
+    );
+  }
+}
+
+export function startPythonBridge<Options extends { pythonExecutable?: string; seed?: number }>(
+  options: Options,
+): Promise<BridgeHandle> {
+  return startPythonBridgeWithTimeout(options, START_TIMEOUT_MS);
+}
+
+export function startPythonBridgeForTest<Options extends { pythonExecutable?: string; seed?: number }>(
+  options: Options,
+  startTimeoutMs: number,
+): Promise<BridgeHandle> {
+  return startPythonBridgeWithTimeout(options, startTimeoutMs);
+}
+
+export type PublicContext = BrowserContext;
+
+export interface InvisiblePlaywrightOptions {
+  seed?: number;
+  pin?: Record<string, unknown>;
+  headless?: boolean;
+  proxy?: ProxySettings;
+  extraArgs?: string[];
+  humanize?: boolean | number;
+  locale?: string;
+  timezone?: string;
+  extraPrefs?: Record<string, string | number | boolean>;
+  binaryPath?: string;
+  profileDir?: string;
+  showCursor?: boolean;
+  /** Python interpreter containing the matching invisible-playwright package. */
+  pythonExecutable?: string;
+}
+
+function inheritedEnvironment(delta: Record<string, string>): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value !== undefined) env[key] = value;
+  }
+  return { ...env, ...delta };
+}
+
+async function withTimeout(
+  operation: Promise<void>,
+  timeoutMs: number,
+  description: string,
+): Promise<void> {
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    await Promise.race([
+      operation,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => {
+          reject(new Error(`${description} timed out after ${timeoutMs} ms`));
+        }, timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+export class InvisiblePlaywright {
+  readonly options: Readonly<InvisiblePlaywrightOptions>;
+  seed: number | undefined;
+
+  private readonly browserType: BrowserTypeLike;
+  private readonly bridgeFactory: BridgeFactory<InvisiblePlaywrightOptions>;
+  private readonly closeTimeoutMs: number;
+  private context: ContextLike | undefined;
+  private bridge: BridgeHandle | undefined;
+  private bridgeCloseStarted: Promise<void> | undefined;
+  private launchStarted = false;
+  private launchSettled: Promise<void> | undefined;
+  private closeStarted: Promise<void> | undefined;
+
+  constructor(options?: InvisiblePlaywrightOptions);
+  constructor(
+    options: InvisiblePlaywrightOptions = {},
+    browserType: BrowserTypeLike = firefox,
+    bridgeFactory: BridgeFactory<InvisiblePlaywrightOptions> = startPythonBridge,
+    closeTimeoutMs = CLOSE_TIMEOUT_MS,
+  ) {
+    this.options = Object.freeze({ ...options });
+    this.browserType = browserType;
+    this.bridgeFactory = bridgeFactory;
+    this.closeTimeoutMs = closeTimeoutMs;
+    this.seed = options.seed;
+  }
+
+  async launch(): Promise<BrowserContext> {
+    if (this.closeStarted) throw new Error("InvisiblePlaywright has already been closed");
+    if (this.launchStarted) throw new Error("InvisiblePlaywright.launch() may only be called once");
+    this.launchStarted = true;
+    let markLaunchSettled!: () => void;
+    this.launchSettled = new Promise<void>(resolve => { markLaunchSettled = resolve; });
+
+    try {
+      const bridge = await this.bridgeFactory({ ...this.options });
+      this.bridge = bridge;
+      this.seed = bridge.prepared.seed;
+      const prepared = bridge.prepared;
+
+      try {
+        const launchOptions: PersistentContextOptions = {
+          executablePath: prepared.executablePath,
+          headless: prepared.headless,
+          args: prepared.args,
+          env: inheritedEnvironment(prepared.env),
+          ...prepared.context,
+        };
+        if (prepared.proxy) launchOptions.proxy = prepared.proxy;
+        const context = await this.browserType.launchPersistentContext(
+          prepared.profileDir,
+          launchOptions,
+        );
+        this.context = context;
+        context.on("close", () => { void this.closeBridge().catch(() => {}); });
+        return context as BrowserContext;
+      } catch (error) {
+        await this.closeBridge();
+        throw error;
+      }
+    } finally {
+      markLaunchSettled();
+    }
+  }
+
+  private async closeBridge(): Promise<void> {
+    if (this.bridgeCloseStarted) return this.bridgeCloseStarted;
+    const bridge = this.bridge;
+    this.bridge = undefined;
+    this.bridgeCloseStarted = (async () => {
+      if (bridge) await bridge.close();
+    })();
+    return this.bridgeCloseStarted;
+  }
+
+  async close(): Promise<void> {
+    if (this.closeStarted) return this.closeStarted;
+    this.closeStarted = (async () => {
+      if (this.launchSettled) await this.launchSettled;
+      const context = this.context;
+      this.context = undefined;
+      let contextFailure: unknown;
+      try {
+        if (context) {
+          await withTimeout(
+            context.close(),
+            this.closeTimeoutMs,
+            "Playwright context close",
+          );
+        }
+      } catch (failure) {
+        contextFailure = failure;
+      }
+      let bridgeFailure: unknown;
+      try {
+        await this.closeBridge();
+      } catch (failure) {
+        bridgeFailure = failure;
+      }
+      if (contextFailure && bridgeFailure) {
+        throw new AggregateError(
+          [contextFailure, bridgeFailure],
+          "Playwright context and Python bridge cleanup both failed",
+        );
+      }
+      if (contextFailure) throw contextFailure;
+      if (bridgeFailure) throw bridgeFailure;
+    })();
+    return this.closeStarted;
+  }
+}
+
+export function createInvisiblePlaywrightForTest(
+  options: InvisiblePlaywrightOptions,
+  browserType: BrowserTypeLike,
+  bridgeFactory: BridgeFactory<InvisiblePlaywrightOptions>,
+  closeTimeoutMs = CLOSE_TIMEOUT_MS,
+): InvisiblePlaywright {
+  return new (InvisiblePlaywright as unknown as new (
+    options: InvisiblePlaywrightOptions,
+    browserType: BrowserTypeLike,
+    bridgeFactory: BridgeFactory<InvisiblePlaywrightOptions>,
+    closeTimeoutMs: number,
+  ) => InvisiblePlaywright)(options, browserType, bridgeFactory, closeTimeoutMs);
+}

--- a/typescript/test/invisible-playwright.test.ts
+++ b/typescript/test/invisible-playwright.test.ts
@@ -1,0 +1,541 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { chmod, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import { promisify } from "node:util";
+
+import { InvisiblePlaywright } from "../src/index.js";
+import {
+  createInvisiblePlaywrightForTest,
+  startPythonBridge,
+  startPythonBridgeForTest,
+  validatePreparedLaunchForTest,
+  waitForExitForTest,
+  type PreparedLaunch,
+} from "../src/internal.js";
+
+const execFileAsync = promisify(execFile);
+
+const prepared: PreparedLaunch = {
+  seed: 42,
+  executablePath: "/patched/firefox",
+  profileDir: "/tmp/profile",
+  headless: true,
+  args: ["--one"],
+  env: { TEST_ENV: "yes" },
+  proxy: { server: "http://proxy.test:8080" },
+  context: {
+    viewport: { width: 1920, height: 947 },
+    screen: { width: 1920, height: 1080 },
+    locale: "en-US",
+    timezoneId: "UTC",
+  },
+  cleanup: {
+    version: 1,
+    nonce: "a".repeat(64),
+    metadataPath: "/tmp/invisible-playwright-node-owner-test/cleanup.json",
+    profileDir: "/tmp/profile",
+    removeProfile: false,
+    sessionToken: "b".repeat(32),
+  },
+};
+
+class FakeContext extends EventEmitter {
+  closeCalls = 0;
+  async close(): Promise<void> {
+    this.closeCalls += 1;
+    this.emit("close");
+  }
+}
+
+test("the public entry point is the InvisiblePlaywright class", () => {
+  assert.equal(typeof InvisiblePlaywright, "function");
+});
+
+for (const seed of [Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY]) {
+  test(`non-finite seed ${String(seed)} is rejected before starting Python`, async () => {
+    await assert.rejects(
+      startPythonBridge({ seed, pythonExecutable: "/definitely/not/a/python" }),
+      /seed must be a finite integer/,
+    );
+  });
+}
+
+test("every prepared launch field is validated before Playwright sees it", () => {
+  const invalid: Array<[string, unknown]> = [
+    ["root shape", null],
+    ["root keys", { ...prepared, surprise: true }],
+    ["seed", { ...prepared, seed: 1.5 }],
+    ["executablePath", { ...prepared, executablePath: "" }],
+    ["profileDir", { ...prepared, profileDir: "" }],
+    ["headless", { ...prepared, headless: "yes" }],
+    ["args", { ...prepared, args: ["--ok", 7] }],
+    ["env", { ...prepared, env: { OK: "yes", BAD: 7 } }],
+    ["proxy shape", { ...prepared, proxy: null }],
+    ["proxy server", { ...prepared, proxy: { server: "" } }],
+    ["proxy keys", { ...prepared, proxy: { server: "http://proxy", extra: "no" } }],
+    ["context keys", { ...prepared, context: { ...prepared.context, extra: true } }],
+    ["viewport width", {
+      ...prepared,
+      context: { ...prepared.context, viewport: { width: 0, height: 947 } },
+    }],
+    ["screen height", {
+      ...prepared,
+      context: { ...prepared.context, screen: { width: 1920, height: Number.POSITIVE_INFINITY } },
+    }],
+    ["locale", { ...prepared, context: { ...prepared.context, locale: 7 } }],
+    ["timezoneId", { ...prepared, context: { ...prepared.context, timezoneId: false } }],
+    ["cleanup keys", { ...prepared, cleanup: { ...prepared.cleanup, extra: true } }],
+    ["cleanup nonce", { ...prepared, cleanup: { ...prepared.cleanup, nonce: "bad" } }],
+    ["cleanup metadataPath", {
+      ...prepared,
+      cleanup: { ...prepared.cleanup, metadataPath: "relative.json" },
+    }],
+    ["cleanup profile ownership", {
+      ...prepared,
+      cleanup: { ...prepared.cleanup, removeProfile: "yes" },
+    }],
+    ["cleanup token", { ...prepared, cleanup: { ...prepared.cleanup, sessionToken: "bad" } }],
+    ["cleanup display pid", {
+      ...prepared,
+      cleanup: { ...prepared.cleanup, virtualDisplayPid: 0 },
+    }],
+  ];
+
+  for (const [name, value] of invalid) {
+    assert.throws(
+      () => validatePreparedLaunchForTest(value),
+      /incompatible Python bridge response/,
+      name,
+    );
+  }
+  assert.deepEqual(validatePreparedLaunchForTest(prepared), prepared);
+});
+
+test("npm metadata pins the runtime and requests public provenance", async () => {
+  const packageJson = JSON.parse(await readFile("package.json", "utf8")) as {
+    name: string;
+    version: string;
+    dependencies: Record<string, string>;
+    publishConfig?: Record<string, unknown>;
+    exports?: Record<string, unknown>;
+    repository?: unknown;
+    homepage?: string;
+    bugs?: unknown;
+  };
+
+  assert.equal(packageJson.name, "invisible-playwright");
+  assert.equal(packageJson.version, "0.8.3");
+  assert.equal(packageJson.dependencies["playwright-core"], "1.61.0");
+  assert.deepEqual(packageJson.publishConfig, { access: "public", provenance: true });
+  assert.deepEqual(packageJson.exports, {
+    ".": { types: "./dist/index.d.ts", import: "./dist/index.js" },
+  });
+  assert.deepEqual(packageJson.repository, {
+    type: "git",
+    url: "git+https://github.com/feder-cr/invisible_playwright.git",
+  });
+  assert.equal(packageJson.homepage, "https://github.com/feder-cr/invisible_playwright#readme");
+  assert.deepEqual(packageJson.bugs, {
+    url: "https://github.com/feder-cr/invisible_playwright/issues",
+  });
+});
+
+test("the npm LICENSE exactly matches the repository MIT license", async () => {
+  assert.equal(await readFile("LICENSE", "utf8"), await readFile("../LICENSE", "utf8"));
+});
+
+test("npm pack contains only the built API, readme, and metadata", async () => {
+  const npm = process.platform === "win32" ? "npm.cmd" : "npm";
+  await execFileAsync(npm, ["run", "build"]);
+  const { stdout } = await execFileAsync(npm, ["pack", "--dry-run", "--json"]);
+  const packed = JSON.parse(stdout) as Array<{ files: Array<{ path: string }> }>;
+
+  assert.deepEqual(
+    packed[0].files.map(file => file.path).sort(),
+    [
+      "LICENSE",
+      "README.md",
+      "dist/index.d.ts",
+      "dist/index.js",
+      "dist/internal.d.ts",
+      "dist/internal.js",
+      "package.json",
+    ],
+  );
+});
+
+test("launch returns the ordinary Playwright context with prepared launch options", async () => {
+  const context = new FakeContext();
+  let received: unknown;
+  const browserType = {
+    async launchPersistentContext(profileDir: string, options: unknown) {
+      received = { profileDir, options };
+      return context;
+    },
+  };
+  let bridgeClosed = 0;
+  const session = createInvisiblePlaywrightForTest(
+    { seed: 42, headless: true },
+    browserType,
+    async () => ({ prepared, close: async () => { bridgeClosed += 1; } }),
+  );
+
+  const launched = await session.launch();
+
+  assert.equal(launched, context);
+  assert.equal(session.seed, 42);
+  assert.equal((received as { options: { env: Record<string, string> } }).options.env.TEST_ENV, "yes");
+  const receivedWithoutInheritedEnv = structuredClone(received) as {
+    profileDir: string;
+    options: Record<string, unknown>;
+  };
+  delete receivedWithoutInheritedEnv.options.env;
+  assert.deepEqual(receivedWithoutInheritedEnv, {
+    profileDir: "/tmp/profile",
+    options: {
+      executablePath: "/patched/firefox",
+      headless: true,
+      args: ["--one"],
+      proxy: { server: "http://proxy.test:8080" },
+      viewport: { width: 1920, height: 947 },
+      screen: { width: 1920, height: 1080 },
+      locale: "en-US",
+      timezoneId: "UTC",
+    },
+  });
+
+  context.emit("close");
+  await new Promise(resolve => setImmediate(resolve));
+  assert.equal(bridgeClosed, 1);
+});
+
+test("launch omits an absent proxy instead of passing null to Playwright", async () => {
+  const context = new FakeContext();
+  let receivedOptions: Record<string, unknown> | undefined;
+  const noProxy = { ...prepared, proxy: undefined };
+  const session = createInvisiblePlaywrightForTest(
+    {},
+    {
+      async launchPersistentContext(_profileDir, options) {
+        receivedOptions = options as Record<string, unknown>;
+        return context;
+      },
+    },
+    async () => ({ prepared: noProxy, close: async () => {} }),
+  );
+
+  await session.launch();
+
+  assert.equal(Object.hasOwn(receivedOptions!, "proxy"), false);
+  await session.close();
+});
+
+test("close shuts down both the Playwright context and Python bridge once", async () => {
+  const context = new FakeContext();
+  let bridgeClosed = 0;
+  const session = createInvisiblePlaywrightForTest(
+    {},
+    { async launchPersistentContext() { return context; } },
+    async () => ({ prepared, close: async () => { bridgeClosed += 1; } }),
+  );
+
+  await session.launch();
+  await session.close();
+  await session.close();
+
+  assert.equal(context.closeCalls, 1);
+  assert.equal(bridgeClosed, 1);
+});
+
+test("a failed browser launch does not leave the bridge alive", async () => {
+  let bridgeClosed = 0;
+  const session = createInvisiblePlaywrightForTest(
+    {},
+    { async launchPersistentContext() { throw new Error("launch failed"); } },
+    async () => ({ prepared, close: async () => { bridgeClosed += 1; } }),
+  );
+
+  await assert.rejects(session.launch(), /launch failed/);
+  assert.equal(bridgeClosed, 1);
+});
+
+test("launch is rejected after close has completed", async () => {
+  let bridgeStarts = 0;
+  const session = createInvisiblePlaywrightForTest(
+    {},
+    { async launchPersistentContext() { return new FakeContext(); } },
+    async () => {
+      bridgeStarts += 1;
+      return { prepared, close: async () => {} };
+    },
+  );
+
+  await session.close();
+
+  await assert.rejects(session.launch(), /closed/);
+  assert.equal(bridgeStarts, 0);
+});
+
+test("close waits for an in-flight launch and cleans up its late context", async () => {
+  const context = new FakeContext();
+  let resolveContext!: (context: FakeContext) => void;
+  let markLaunchEntered!: () => void;
+  const launchEntered = new Promise<void>(resolve => { markLaunchEntered = resolve; });
+  const session = createInvisiblePlaywrightForTest(
+    {},
+    {
+      async launchPersistentContext() {
+        markLaunchEntered();
+        return new Promise<FakeContext>(resolve => { resolveContext = resolve; });
+      },
+    },
+    async () => ({ prepared, close: async () => {} }),
+  );
+
+  const launchPromise = session.launch();
+  await launchEntered;
+  let closeSettled = false;
+  const closePromise = session.close().then(() => { closeSettled = true; });
+  await new Promise(resolve => setImmediate(resolve));
+
+  assert.equal(closeSettled, false);
+  resolveContext(context);
+  await launchPromise;
+  await closePromise;
+  assert.equal(context.closeCalls, 1);
+});
+
+test("explicit close awaits bridge cleanup started by the context close event", async () => {
+  const context = new FakeContext();
+  let finishBridgeClose!: () => void;
+  let markBridgeCloseStarted!: () => void;
+  const bridgeCloseStarted = new Promise<void>(resolve => { markBridgeCloseStarted = resolve; });
+  const session = createInvisiblePlaywrightForTest(
+    {},
+    { async launchPersistentContext() { return context; } },
+    async () => ({
+      prepared,
+      close: async () => {
+        markBridgeCloseStarted();
+        await new Promise<void>(resolve => { finishBridgeClose = resolve; });
+      },
+    }),
+  );
+  await session.launch();
+
+  context.emit("close");
+  await bridgeCloseStarted;
+  let closeSettled = false;
+  const closePromise = session.close().then(() => { closeSettled = true; });
+  await new Promise(resolve => setImmediate(resolve));
+
+  assert.equal(closeSettled, false);
+  finishBridgeClose();
+  await closePromise;
+});
+
+test("context close cleanup rejection is handled until explicit close observes it", async () => {
+  const context = new FakeContext();
+  const unhandled: unknown[] = [];
+  const onUnhandled = (failure: unknown) => { unhandled.push(failure); };
+  process.on("unhandledRejection", onUnhandled);
+  const session = createInvisiblePlaywrightForTest(
+    {},
+    { async launchPersistentContext() { return context; } },
+    async () => ({
+      prepared,
+      close: async () => { throw new Error("reaper failed"); },
+    }),
+  );
+
+  try {
+    await session.launch();
+    context.emit("close");
+    await new Promise(resolve => setImmediate(resolve));
+    assert.deepEqual(unhandled, []);
+    await assert.rejects(session.close(), /reaper failed/);
+  } finally {
+    process.removeListener("unhandledRejection", onUnhandled);
+  }
+});
+
+test("explicit close bounds a stuck context and still reports failed bridge cleanup", async () => {
+  let bridgeCloseCalls = 0;
+  const session = createInvisiblePlaywrightForTest(
+    {},
+    {
+      async launchPersistentContext() {
+        return {
+          close: async () => new Promise<void>(() => {}),
+          on() {},
+        };
+      },
+    },
+    async () => ({
+      prepared,
+      close: async () => {
+        bridgeCloseCalls += 1;
+        throw new Error("bridge cleanup failed");
+      },
+    }),
+    10,
+  );
+  await session.launch();
+
+  const failure = await session.close().then(
+    () => undefined,
+    error => error as AggregateError,
+  );
+
+  assert(failure instanceof AggregateError);
+  assert.deepEqual(
+    failure.errors.map(error => String(error)),
+    [
+      "Error: Playwright context close timed out after 10 ms",
+      "Error: bridge cleanup failed",
+    ],
+  );
+  assert.equal(bridgeCloseCalls, 1);
+});
+
+test("waitForExit has a final bound after SIGKILL", async () => {
+  const child = Object.assign(new EventEmitter(), {
+    exitCode: null as number | null,
+    signalCode: null as NodeJS.Signals | null,
+    killSignals: [] as NodeJS.Signals[],
+    kill(signal: NodeJS.Signals) {
+      this.killSignals.push(signal);
+      return true;
+    },
+  });
+
+  await assert.rejects(
+    waitForExitForTest(child, 5, 5, 5),
+    /did not exit after SIGKILL/,
+  );
+  assert.deepEqual(child.killSignals, ["SIGTERM", "SIGKILL"]);
+});
+
+test("bridge close reports a nonzero bridge exit", async () => {
+  const directory = await mkdtemp(path.join(process.cwd(), ".tmp-failing-bridge-"));
+  const executable = path.join(directory, "bridge");
+  await writeFile(executable, `#!/usr/bin/env node
+import fs from "node:fs";
+if (process.argv.includes("--cleanup")) process.exit(0);
+process.stdin.once("data", () => {
+  const result = ${JSON.stringify(prepared)};
+  const metadataPath = process.env.INVPW_TYPESCRIPT_CLEANUP_PATH;
+  const metadata = JSON.parse(fs.readFileSync(metadataPath, "utf8"));
+  metadata.sessionToken = "c".repeat(32);
+  fs.writeFileSync(metadataPath, JSON.stringify(metadata));
+  result.profileDir = metadata.profileDir;
+  result.cleanup = { ...metadata, metadataPath };
+  if (result.cleanup.virtualDisplayPid === null) delete result.cleanup.virtualDisplayPid;
+  process.stdout.write(JSON.stringify(result) + "\\n");
+});
+process.stdin.once("end", () => {
+  process.stderr.write("reaper failed\\n");
+  process.exit(7);
+});
+`);
+  await chmod(executable, 0o755);
+
+  try {
+    const bridge = await startPythonBridge({ pythonExecutable: executable });
+    await assert.rejects(bridge.close(), /code 7.*reaper failed/);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("startup timeout invokes a separate cleanup helper for the owned profile", async () => {
+  const directory = await mkdtemp(path.join(process.cwd(), ".tmp-startup-cleanup-"));
+  const executable = path.join(directory, "bridge");
+  const cleanupMarker = path.join(directory, "cleanup-ran");
+  await writeFile(executable, `#!/usr/bin/env node
+import fs from "node:fs";
+const cleanupIndex = process.argv.indexOf("--cleanup");
+if (cleanupIndex !== -1) {
+  const metadata = JSON.parse(fs.readFileSync(process.argv[cleanupIndex + 1], "utf8"));
+  if (metadata.removeProfile) fs.rmSync(metadata.profileDir, { recursive: true, force: true });
+  fs.writeFileSync(${JSON.stringify(cleanupMarker)}, "confirmed");
+  process.exit(0);
+}
+process.on("SIGTERM", () => process.exit(0));
+process.stdin.once("data", () => {
+  const metadataPath = process.env.INVPW_TYPESCRIPT_CLEANUP_PATH;
+  const metadata = JSON.parse(fs.readFileSync(metadataPath, "utf8"));
+  fs.mkdirSync(metadata.profileDir, { recursive: true });
+});
+setInterval(() => {}, 1000);
+`);
+  await chmod(executable, 0o755);
+
+  try {
+    await assert.rejects(
+      startPythonBridgeForTest({ pythonExecutable: executable }, 20),
+      /timed out after 20 ms/,
+    );
+    assert.equal(await readFile(cleanupMarker, "utf8"), "confirmed");
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("bridge close escalates and waits for a child that ignores termination", async () => {
+  const directory = await mkdtemp(path.join(process.cwd(), ".tmp-stubborn-bridge-"));
+  const executable = path.join(directory, "bridge");
+  const cleanupMarker = path.join(directory, "emergency-cleanup-ran");
+  const childPrepared = { ...prepared, seed: 0 };
+  await writeFile(executable, `#!/usr/bin/env node
+import fs from "node:fs";
+import nodePath from "node:path";
+const cleanupIndex = process.argv.indexOf("--cleanup");
+if (cleanupIndex !== -1) {
+  const metadata = JSON.parse(fs.readFileSync(process.argv[cleanupIndex + 1], "utf8"));
+  if (metadata.removeProfile) fs.rmSync(metadata.profileDir, { recursive: true, force: true });
+  fs.writeFileSync(${JSON.stringify(cleanupMarker)}, "confirmed");
+  process.exit(0);
+}
+process.on("SIGTERM", () => {});
+process.stdin.once("data", () => {
+  const prepared = ${JSON.stringify(childPrepared)};
+  const metadataPath = process.env.INVPW_TYPESCRIPT_CLEANUP_PATH;
+  if (metadataPath) {
+    const metadata = JSON.parse(fs.readFileSync(metadataPath, "utf8"));
+    metadata.sessionToken = "c".repeat(32);
+    fs.writeFileSync(metadataPath, JSON.stringify(metadata));
+    fs.mkdirSync(metadata.profileDir, { recursive: true });
+    fs.writeFileSync(nodePath.join(metadata.profileDir, "owned"), "yes");
+    prepared.profileDir = metadata.profileDir;
+    prepared.cleanup = { ...metadata, metadataPath };
+    if (prepared.cleanup.virtualDisplayPid === null) delete prepared.cleanup.virtualDisplayPid;
+  }
+  prepared.seed = process.pid;
+  process.stdout.write(JSON.stringify(prepared) + "\\n");
+});
+setInterval(() => {}, 1000);
+`);
+  await chmod(executable, 0o755);
+  let pid: number | undefined;
+  let ownedProfile: string | undefined;
+
+  try {
+    const bridge = await startPythonBridge({ pythonExecutable: executable });
+    pid = bridge.prepared.seed;
+    ownedProfile = bridge.prepared.profileDir;
+    await assert.rejects(bridge.close(), /terminated by SIGKILL/);
+
+    assert.throws(() => process.kill(pid!, 0));
+    assert.equal(await readFile(cleanupMarker, "utf8"), "confirmed");
+    await assert.rejects(readFile(path.join(ownedProfile, "owned"), "utf8"));
+  } finally {
+    if (pid !== undefined) {
+      try { process.kill(pid, "SIGKILL"); } catch {}
+    }
+    await rm(directory, { recursive: true, force: true });
+  }
+});

--- a/typescript/tsconfig.json
+++ b/typescript/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/typescript/tsconfig.test.json
+++ b/typescript/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": false,
+    "outDir": "dist-test",
+    "rootDir": "."
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}


### PR DESCRIPTION
Adds an independently buildable TypeScript package that prepares the patched Firefox through a private Python bridge and returns an ordinary `playwright-core` `BrowserContext`. Consumers keep using normal Playwright pages, locators, routes, requests, and events; there is no TypeScript CLI or separate fetch command.

The bridge validates options and launch metadata at the runtime boundary, coordinates context/profile/display lifetime across Node and Python, and uses token-verified emergency cleanup when normal shutdown cannot complete. The release workflow publishes the npm package through trusted OIDC only after the matching Python release is available. Maintainers must configure npm trusted publishing for `publish.yml` with environment `npm` before the first automated npm release.

### Tests

- `python -m ruff check --select F821,F811,F601 --no-cache --output-format concise .`
- `pytest tests/ -q` — 582 passed, 5 skipped
- `npm test` — 21 passed
- `npm run typecheck`
- `npm run build`
- `npm pack --dry-run --json` — exact seven-file package including `LICENSE`
- Real patched-Firefox Node E2E — seed 42, `navigator.webdriver === false`, Firefox 151 user agent, 1920×1080 screen

---
_Implemented by Hermes Agent using **gpt-5.6-sol**, acting on behalf of @luantak._
