### PR TITLE
The driver reads a key the client never sends, so wait_for_timeout never waited

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,45 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-09-02
+
+### Fixed
+
+- **`wait_for_timeout` has never waited.** A request for 2000ms returned in
+  1ms, in both the sync and the async API and in every caller of either, for as
+  long as this package has had its own driver. Nothing raised, so nothing
+  showed.
+
+  The defect was in `_juggler/server.py`, the driver written here to replace the
+  Node one: `op_wait_for_timeout` read `params.get("timeout")`, a key the client
+  never sends for this call, so the sleep was always zero. The client sends
+  `waitTimeout`, which looks like a typo and is not - upstream Playwright
+  declares this one parameter under its own name because `timeout` is the
+  reserved key on that channel, carrying the per-call action timeout for every
+  other call.
+
+  ⛔ The first attempt patched the vendored client instead, to make it send
+  the key the server happened to read. That is a fix at the symptom: it leaves
+  the defect in the code this project owns, the next re-vendor of upstream would
+  silently undo it, and it committed a false claim about the protocol into a
+  comment, this changelog and a test. Review caught it before it shipped.
+
+  What it cost, where it was found. A corpus run against real sites reported
+  three of them as blocked by three different anti-bot products, one with the
+  challenge markup sitting in the document; all three serve their real page once
+  the wait exists, so those verdicts were artefacts of the tool rather than
+  measurements of anything. A fourth site was reported as never loading and
+  loads in twenty seconds. In the MCP package a polling loop of sixty
+  one-second waits ran to completion instantly, so a test with a sixty-second
+  budget failed in fourteen for no reason anybody could see.
+
+  ⛔ **This changes timings for existing callers**, which is why it is a
+  minor bump and not a patch. Code that called `wait_for_timeout` and returned
+  instantly will now take the time it asked for. That is the documented
+  behaviour of the API and the old behaviour was silently wrong, but a script
+  that waited in a loop will get slower rather than faster.
+
+
 ## [0.8.3] - 2026-08-31
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "invisible_playwright"
-version = "0.8.3"
+version = "0.9.0"
 description = "Playwright wrapper for a patched Firefox with deterministic stealth profile."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/invisible_playwright/_juggler/server.py
+++ b/src/invisible_playwright/_juggler/server.py
@@ -787,7 +787,22 @@ class FrameDispatcher(Dispatcher):
         return None
 
     def op_wait_for_timeout(self, params: Dict) -> Any:
-        time.sleep((params.get("timeout") or 0) / 1000.0)
+        # `waitTimeout`, not `timeout`, because that is what the client sends.
+        # Playwright's protocol.yml declares this one parameter under its own
+        # name precisely BECAUSE `timeout` is reserved on this channel: every
+        # other call carries a per-call action timeout under that key, and
+        # `_connection.py` rewrites it on the way out.
+        #
+        # Reading the wrong key made this a no-op that reported success. A
+        # request for 2000ms returned in 1ms, in both the sync and the async
+        # API, and in every caller of either, for as long as this server has
+        # existed. Nothing failed, so nothing showed.
+        #
+        # ⛔ THE CLIENT IS NOT THE PLACE TO FIX THIS. `_pw/_impl/_frame.py` is
+        # vendored upstream Playwright and its line is correct; patching it
+        # there would leave this defect in the code this project owns, and the
+        # next re-vendor would silently undo the repair.
+        time.sleep((params.get("waitTimeout") or 0) / 1000.0)
         return None
 
     def op_wait_for_load_state(self, params: Dict) -> Any:

--- a/tests/test_wait_for_timeout.py
+++ b/tests/test_wait_for_timeout.py
@@ -1,0 +1,94 @@
+"""`wait_for_timeout` has to actually wait.
+
+Measured 2026-09-02: it did not. A request for 2000ms returned in 1ms, in both
+the sync and the async API, and in every caller of either, for as long as this
+package has had its own driver. Nothing raised, so nothing showed.
+
+WHERE the defect was is the interesting part, because the obvious answer is the
+wrong one. The client sends `{"waitTimeout": timeout}`, which looks like a
+typo and is not: upstream Playwright's protocol declares this one parameter
+under its own name, and the vendored client is byte-identical to upstream on
+that line. `timeout` is the RESERVED key on this channel - every other call
+carries a per-call action timeout under it - which is exactly why the wait got
+a name of its own.
+
+The defect was in `_juggler/server.py`, the driver this project wrote to replace
+the Node one: `op_wait_for_timeout` read `params.get("timeout")`, a key the
+client never sends for this call, so the sleep was always zero.
+
+The first attempt at this fix patched the vendored client instead, to make it
+send the key the server happened to read. That is a patch at the symptom: it
+leaves the defect in the code this project owns, it would be undone by the next
+re-vendor of upstream, and it committed a false claim about the protocol into a
+comment, a changelog and a test. It was found by review before it shipped.
+
+What it cost, before it was found. A corpus run against real sites reported
+three of them as blocked by three different anti-bot products, one with the
+challenge markup sitting in the document; all three serve their real page once
+the wait exists, so those verdicts were artefacts of the tool. A fourth site was
+reported as never loading and loads in twenty seconds. In the MCP package a
+polling loop of sixty one-second waits ran to completion instantly, so a test
+with a sixty-second budget failed in fourteen for no reason anybody could see.
+
+Two tests, and they are not the same test. The first pins the key the SERVER
+reads, without a browser, so it runs on every push. The second measures elapsed
+time against a real engine, because a name that looks right and a wait that
+happens are still two different claims.
+"""
+from __future__ import annotations
+
+import inspect
+import re
+import time
+
+import pytest
+
+
+def test_the_server_reads_the_key_the_client_actually_sends():
+    """The two halves of one call, checked against each other rather than
+    against anybody's memory of the protocol.
+
+    Comments are stripped first: the comment beside the fix names the wrong key
+    on purpose, to say why it must not come back, and a check that read it would
+    go red over its own documentation.
+    """
+    from invisible_playwright._juggler.server import FrameDispatcher
+    from invisible_playwright._pw._impl._frame import Frame
+
+    sent = re.sub(r"#[^\n]*", "", inspect.getsource(Frame.wait_for_timeout))
+    read = re.sub(r"#[^\n]*", "", inspect.getsource(FrameDispatcher.op_wait_for_timeout))
+
+    assert '"waitTimeout"' in sent, (
+        "the vendored client no longer sends waitTimeout; it is upstream "
+        "Playwright's own parameter name and should not have been changed")
+    assert '"waitTimeout"' in read, (
+        "the driver is reading a key the client does not send for this call, "
+        "so the sleep is always zero and reports success")
+    assert '"timeout"' not in read, (
+        "the driver is reading `timeout`, which is the reserved per-call action "
+        "timeout on this channel and not the wait duration")
+
+
+@pytest.mark.e2e
+@pytest.mark.parametrize("requested", [1000, 3000])
+def test_the_wait_takes_the_time_it_was_asked_for(requested):
+    """A key that matches and a wait that happens are two claims.
+
+    The floor is generous on purpose: this asserts that time passed at all,
+    which is what was broken, not that the timer is precise. Before the fix a
+    request for 2000ms returned in 1ms, so anything above a small fraction of
+    the request separates working from not.
+    """
+    from invisible_playwright import InvisiblePlaywright
+
+    with InvisiblePlaywright(seed=1, headless=True) as browser:
+        ctx = browser.new_context()
+        page = ctx.new_page()
+        page.goto("data:text/html,<p>wait</p>")
+        started = time.time()
+        page.wait_for_timeout(requested)
+        elapsed_ms = (time.time() - started) * 1000
+        ctx.close()
+
+    assert elapsed_ms >= requested * 0.8, (
+        f"asked to wait {requested}ms and returned after {elapsed_ms:.0f}ms")


### PR DESCRIPTION
A request for 2000ms returned in 1ms, in both the sync and the async API and in
every caller of either, for as long as this package has had its own driver.
Nothing raised, so nothing showed.

op_wait_for_timeout in _juggler/server.py read params.get("timeout"). The client
sends waitTimeout, which looks like a typo and is not: upstream Playwright
declares this one parameter under its own name because timeout is the reserved
key on that channel, carrying the per-call action timeout for every other call.
The vendored client was byte-identical to upstream on that line.

The first attempt at this fix changed the client instead, to make it send the
key the server happened to read. That is a fix at the symptom: it leaves the
defect in the code this project owns, the next re-vendor of upstream would
silently undo it, and it committed a false claim about the protocol into a
comment, a changelog entry and a test assertion. Review caught it before it
shipped, by reading upstream's protocol.yml rather than anybody's memory of it.

What it cost, where it was found. A corpus run against real sites reported three
of them as blocked by three different anti-bot products, one with the challenge
markup sitting in the document. All three serve their real page once the wait
exists, so the verdicts were artefacts of the tool. A fourth site was reported
as never loading and loads in twenty seconds. In the MCP package a polling loop
of sixty one-second waits ran to completion instantly, so a test with a
sixty-second budget failed in fourteen for no reason anybody could see.

Two tests. The first checks the two halves of the call against EACH OTHER, the
key the client sends against the key the server reads, rather than against
anybody's memory of the protocol; it needs no browser, so it runs on every push,
and it was checked against the defect put back. The second measures elapsed time
against a real engine, because a key that matches and a wait that happens are
still two different claims.