### PR TITLE
Run the English gate here, and stop saying there is no MCP server

### DIFF
--- a/.github/workflows/e2e-hunt.yml
+++ b/.github/workflows/e2e-hunt.yml
@@ -30,7 +30,7 @@ name: e2e hunt
 on:
   workflow_dispatch:
     inputs:
-      giri:
+      runs:
         description: "How many runs at most (at 12% it takes ~18 for a 90% chance)"
         required: false
         default: "18"
@@ -92,19 +92,19 @@ jobs:
       - name: Loop until it catches one
         env:
           PYTHONUNBUFFERED: "1"
-          INVPW_TEST_WATCHDOG_FILE: prove/e2e-watchdog.log
+          INVPW_TEST_WATCHDOG_FILE: evidence/e2e-watchdog.log
         run: |
           set -u
-          runs="${{ inputs.giri }}"
-          mkdir -p prove/giri
-          # `prove/` inside the workspace, not RUNNER_TEMP: on Windows that
+          runs="${{ inputs.runs }}"
+          mkdir -p evidence/runs
+          # `evidence/` inside the workspace, not RUNNER_TEMP: on Windows that
           # variable contains backslashes and does not cross bash reliably.
           # xvfb only where it exists; on Windows the browser goes to the
           # runner's desktop.
           if [ "$RUNNER_OS" = "Linux" ]; then PRE="xvfb-run -a"; else PRE=""; fi
           captured=0
           for n in $(seq 1 "$runs"); do
-            log="prove/giri/giro_$(printf '%02d' "$n").log"
+            log="evidence/runs/run_$(printf '%02d' "$n").log"
             t0=$(date +%s)
             set +e
             $PRE python -u scripts/run_e2e.py "$FF" > "$log" 2>&1
@@ -140,7 +140,7 @@ jobs:
         with:
           name: e2e-hunt-${{ inputs.os }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: |
-            prove/giri
-            prove/e2e-watchdog.log
+            evidence/runs
+            evidence/e2e-watchdog.log
           if-no-files-found: warn
           retention-days: 14

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,35 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # The gate was written FOR this repository on 2026-08-27, after 549 lines of
+  # Italian shipped here in one subsystem and 852 more were found in 33 files
+  # that were already public. It has been wired nowhere ever since: not into
+  # tests.yml, not into the pre-push hook, whose steps are pytest, pin, names,
+  # internals and publish. Both sibling packages copied the script AND the CI
+  # step; this one kept only the script, so the one repository the rule exists
+  # for is the one that never checked. Measured 2026-09-03, the first time
+  # anybody ran it here: four files, red.
+  #
+  # Its own job, and deliberately NOT behind core-on-index. Reading files needs
+  # no install, and hanging a language check off the availability of a package on
+  # an index would silently skip it during exactly the window when releases are
+  # being made.
+  english:
+    name: the repository is English
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: check the prose
+        # --selftest first: a language gate that has only ever printed "clean" is
+        # the same non-gate as any other, and this one can go blind from a single
+        # edit to its word list.
+        run: |
+          python scripts/check_english_only.py --selftest
+          python scripts/check_english_only.py
+
   # `pip install -e ".[dev]"` below resolves `invisible-core==N.M.0` from the
   # package index. The core is published BEFORE this package, so between the
   # first push of this repo and that upload there is a window in which no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- **Nine acting methods on `ElementHandle`.** `click`, `hover`, `fill`, `type`,
+  `press`, `focus`, `check`, `uncheck` and `select_option` now work on a handle,
+  so `page.query_selector("#go").click()` does what it does in Playwright. Until
+  now the driver served fourteen handle methods, every one of them a read, and
+  every action answered `ElementHandle has no method 'click'`.
+
+  They go through the same humanised path as the selector versions - approach,
+  hover, press, release, with the hit-target check and the actionability retry -
+  rather than a second, simpler one. Two click paths would be two fingerprints.
+  What differs is only what should: the node is not looked up again, and the
+  handle is still usable afterwards.
+
 ## [0.9.0] - 2026-09-02
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Once the browser is handled it stops being the variable. If you are still gettin
 
 ```bash
 pip install invisible-playwright
-python -m invisible_playwright fetch      # one-time ~238 MB download (~544 MB unpacked), sha256-verified
+python -m invisible_playwright fetch      # one-time download, sha256-verified: 240 MB (Windows) / 262 MB (Linux x86_64) / 253 MB (Linux arm64), about 550 MB unpacked
 ```
 
 Requires **Python 3.11 or newer**.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,23 @@ pip install invisible-playwright
 python -m invisible_playwright fetch      # one-time ~238 MB download (~544 MB unpacked), sha256-verified
 ```
 
+Requires **Python 3.11 or newer**.
+
 Supported platforms: **Windows x86_64**, **Linux x86_64 / arm64**. macOS is no longer supported (releases stopped at firefox-20); on a Mac the package refuses at launch with a clear message rather than downloading a binary that no longer exists.
+
+### If you would rather prompt than script
+
+This page is the engine, as a Python library. There are two ways to use it
+without writing code, and both are one line:
+
+- **From an MCP client you already have** (Claude Code, Claude Desktop,
+  Cursor): `claude mcp add stealth -- uvx invisible-playwright-mcp`. See
+  [invisible-playwright-mcp](https://github.com/feder-cr/invisible-playwright-mcp).
+- **With an interface and a model included**, needing only an OpenRouter key:
+  `uvx aihawk ui --openrouter-key sk-or-...`. See
+  [AIHawk](https://github.com/feder-cr/AIHawk).
+
+Same engine underneath, and the second is a client of the first.
 
 ---
 
@@ -197,7 +213,18 @@ almost nothing.
 
 ## Related projects
 
-The open-source neighbours, and what each one is for.
+**The other pieces of this one.** The engine is the middle of three, and the
+two around it are how most people reach it:
+
+- **[invisible_core](https://github.com/feder-cr/invisible_core)** - seed to
+  fingerprint to preferences, plus proxy and geolocation. This package pins it.
+- **[invisible-playwright-mcp](https://github.com/feder-cr/invisible-playwright-mcp)**
+  - this engine as an MCP server, for any client that brings its own model.
+- **[AIHawk](https://github.com/feder-cr/AIHawk)** - an interface and a model,
+  from one command. A client of the server above, with no private path to the
+  browser.
+
+**The open-source neighbours**, and what each one is for.
 
 **On the Firefox side**
 

--- a/docs/ai-browser-agents-stealth.md
+++ b/docs/ai-browser-agents-stealth.md
@@ -216,8 +216,12 @@ identical.
 **Which AI agent framework is most stealth-friendly?** The question is usually the wrong
 one. Pick on the agent loop, then fix the machine, then consider the engine.
 
-**Is there any agent route to an engine-level fingerprint?** MCP, through Microsoft's own
-Playwright MCP server, which takes a browser and an executable path.
+**Is there any agent route to an engine-level fingerprint?** Two, and they are not
+equivalent. `uvx invisible-playwright-mcp` launches through the engine, so the
+seeded profile and the humanised pointer come with it. Microsoft's own Playwright
+MCP server takes a browser and an executable path, which runs the engine but
+carries no `firefox_user_prefs`, so every session on a given build shares one
+identity.
 
 **See also:** [browser-use in detail](browser-use-detection.md),
 [crawl4ai in detail](crawl4ai-stealth-custom-browser.md),

--- a/docs/integrations/playwright-mcp.md
+++ b/docs/integrations/playwright-mcp.md
@@ -1,15 +1,30 @@
 ---
 title: "Using invisible_playwright with Microsoft's Playwright MCP"
-description: "Microsoft's own playwright-mcp takes a browser and an executable path as arguments, so pointing it at this engine is configuration, not a separate server."
+description: "There is a server for this engine, invisible-playwright-mcp. This page is for people already committed to Microsoft's playwright-mcp, and says exactly what that route costs."
 parent: "Integrations"
 nav_order: 7
 ---
 
 # Using invisible_playwright with Microsoft's Playwright MCP
 
-You do not need a separate MCP server. Microsoft's own `playwright-mcp` takes a
-browser and an executable path as arguments, so pointing it at this engine is
-configuration, not code.
+**There is a server for this engine:**
+[`invisible-playwright-mcp`](https://github.com/feder-cr/invisible-playwright-mcp).
+One line, and it carries the seeded profile and the humanised pointer that the
+route on this page cannot:
+
+```bash
+claude mcp add stealth -- uvx invisible-playwright-mcp
+```
+
+This page is for the other case: you are already committed to Microsoft's
+`playwright-mcp` and want to point it at this engine. That works, it is
+configuration rather than code, and the section below says precisely what it
+costs you.
+
+⛔ This page said "You do not need a separate MCP server" until 2026-09-03. It
+was written on 2026-07-27, and the server was published on 2026-08-19: true when
+written, and afterwards it was steering readers away from the thing that solves
+the problem the page then documents a workaround for.
 
 Written against `microsoft/playwright-mcp` as of 2026-07-27.
 
@@ -46,8 +61,10 @@ The same two settings exist as environment variables, `PLAYWRIGHT_MCP_BROWSER` a
 It gets you the engine: a Firefox whose fingerprint surfaces are patched in C++
 rather than shimmed from JavaScript, driven by the standard MCP tool set.
 
-**It does not get you the seeded profile.** The identity this package generates lives
-in `firefox_user_prefs`, and `--executable-path` has no way to carry them. So the
+**Microsoft's server does not get you the seeded profile.** The identity this package
+generates lives in `firefox_user_prefs`, and `--executable-path` has no way to carry
+them. (Ours does: it launches through the engine, so the profile is built the same
+way a script would build it.) So the
 browser reports the build's own defaults, the same on every launch and on every
 machine that runs the same build, with no per-session identity and nothing to
 reproduce a session from.
@@ -97,9 +114,15 @@ knowing before you trust the session.
 
 ## Short answers to the questions that lead here
 
-**Is there an MCP server for this project?** No, and there does not need to be.
-Microsoft's own `playwright-mcp` accepts `--browser firefox` together with
-`--executable-path`, which is both halves of what this engine needs.
+**Is there an MCP server for this project?** Yes:
+[`invisible-playwright-mcp`](https://github.com/feder-cr/invisible-playwright-mcp),
+`uvx invisible-playwright-mcp`. It launches through the engine, so the seeded
+profile and the humanised pointer come with it.
+
+Microsoft's own `playwright-mcp` also accepts `--browser firefox` together with
+`--executable-path`, which is enough to run this engine and not enough to carry
+the profile. Use it if you are already on it; the section above says what that
+costs.
 
 **Can an MCP client drive a stealth browser at all?** Yes, as long as the client lets
 you set the launch arguments. If it does, you can point it at any binary.

--- a/src/invisible_playwright/_juggler/actions.py
+++ b/src/invisible_playwright/_juggler/actions.py
@@ -156,13 +156,25 @@ class Actions:
     # ── the loop ────────────────────────────────────────────────────────────
     def _retry(self, selector: str, run, *, states=None,
                timeout: float = 30.0, frame_id: Optional[str] = None,
-               position=None):
+               position=None, element_id: Optional[str] = None):
         """Resolve, check, act, and if something doesn't match, START OVER.
 
         ⛔ `position` travels HERE and not through each action, because the
         point is recomputed on every turn of this loop: an offset applied by
         the caller once would be stale the moment the page moved, which is
         precisely the case this loop exists to absorb.
+
+        ⛔ `element_id` IS THE ElementHandle CASE, and it changes exactly two
+        things. The node is not looked up again - a handle names one node, and
+        re-querying the selector would be a different element with the same
+        description, which is not what `handle.click()` means - and the node is
+        NOT disposed at the end, because it belongs to the caller and disposing
+        it would destroy the handle they still hold.
+
+        Everything else is deliberately shared: states, the point, the scroll,
+        the hit-target check, the retry on detachment. A second loop for handles
+        would be a second definition of "actionable" and a second click path,
+        and two click paths are two fingerprints.
         """
         f = frame_id or self.lifecycle.main_frame
         if f is None:
@@ -174,10 +186,16 @@ class Actions:
         while True:
             turns += 1
             element = None
+            ours = False
             try:
-                # ⛔ FROM SCRATCH on every turn. A handle from the previous
-                # turn could point to a node the DOM has since replaced.
-                element = self.inj.query_selector(f, selector)
+                if element_id is not None:
+                    # The caller's node, fixed. Not re-queried and not ours.
+                    element = element_id
+                else:
+                    # ⛔ FROM SCRATCH on every turn. A handle from the previous
+                    # turn could point to a node the DOM has since replaced.
+                    element = self.inj.query_selector(f, selector)
+                    ours = True
                 if not element:
                     reason = "the selector finds nothing"
                 elif states:
@@ -226,7 +244,11 @@ class Actions:
                 # geometry.
                 reason = "the event would have landed elsewhere (%s)" % e
             finally:
-                if element:
+                # Only what this loop resolved. Disposing the caller's handle
+                # here would make `handle.click()` destroy the handle, and the
+                # NEXT call on it would fail with the node not existing - an
+                # error naming neither the cause nor the previous call.
+                if element and ours:
                     self.inj.dispose(f, element)
 
             if time.monotonic() > deadline:
@@ -346,16 +368,16 @@ class Actions:
 
     # ── the actions ─────────────────────────────────────────────────────────
     def hover(self, selector: str, *, timeout: float = 30.0, frame_id: Optional[str] = None,
-              position=None):
+              position=None, element_id: Optional[str] = None):
         def run(f, element, point):
             return self._with_hit_target(
                 f, element, point, "hover",
                 lambda: self._mouse_event("mousemove", point) or point)
-        return self._retry(selector, run, timeout=timeout,
+        return self._retry(selector, run, timeout=timeout, element_id=element_id,
                            frame_id=frame_id, position=position)
 
     def click(self, selector: str, *, timeout: float = 30.0, frame_id: Optional[str] = None, button: int = 0,
-              clicks: int = 1, position=None, modifiers: int = 0):
+              clicks: int = 1, position=None, modifiers: int = 0, element_id: Optional[str] = None):
         def run(f, element, point):
             def act():
                 # The order is that of a user: approach, press, release.
@@ -372,7 +394,7 @@ class Actions:
                 return point
             return self._with_hit_target(f, element, point, "mouse", act)
         return self._retry(selector, run, timeout=timeout, frame_id=frame_id,
-                           position=position)
+                           position=position, element_id=element_id)
 
     def dblclick(self, selector: str, *, timeout: float = 30.0, frame_id: Optional[str] = None,
                  button: int = 0, position=None, modifiers: int = 0):
@@ -393,17 +415,17 @@ class Actions:
                           modifiers=modifiers)
 
     def check(self, selector: str, *, timeout: float = 30.0, frame_id: Optional[str] = None,
-              position=None):
-        return self._set_checked(selector, True, timeout=timeout,
+              position=None, element_id: Optional[str] = None):
+        return self._set_checked(selector, True, timeout=timeout, element_id=element_id,
                                  frame_id=frame_id, position=position)
 
     def uncheck(self, selector: str, *, timeout: float = 30.0, frame_id: Optional[str] = None,
-                position=None):
-        return self._set_checked(selector, False, timeout=timeout,
+                position=None, element_id: Optional[str] = None):
+        return self._set_checked(selector, False, timeout=timeout, element_id=element_id,
                                  frame_id=frame_id, position=position)
 
     def _set_checked(self, selector: str, wanted: bool, *, timeout: float,
-                     frame_id: Optional[str] = None, position=None):
+                     frame_id: Optional[str] = None, position=None, element_id: Optional[str] = None):
         """`check` / `uncheck`.
 
         ⛔ It CHECKS FIRST, and rechecks after. Clicking without looking
@@ -433,10 +455,10 @@ class Actions:
                     "the click or put the value back"
                     % ("unchecked" if wanted else "checked"))
             return state
-        return self._retry(selector, run, timeout=timeout,
+        return self._retry(selector, run, timeout=timeout, element_id=element_id,
                            frame_id=frame_id, position=position)
 
-    def focus(self, selector: str, *, timeout: float = 30.0, frame_id: Optional[str] = None):
+    def focus(self, selector: str, *, timeout: float = 30.0, frame_id: Optional[str] = None, element_id: Optional[str] = None):
         """⛔ Does NOT require `visible`: `focus()` works on an off-screen
         element, and imposing the pointer states would time out an action
         that would have succeeded. Playwright does the same."""
@@ -444,7 +466,8 @@ class Actions:
             return self.inj.call(
                 f, "(injected, el) => injected.focusNode(el, true)",
                 {"objectId": element})
-        return self._retry(selector, run, states=[], timeout=timeout, frame_id=frame_id)
+        return self._retry(selector, run, states=[], timeout=timeout, frame_id=frame_id,
+                           element_id=element_id)
 
     def blur(self, selector: str, *, timeout: float = 30.0, frame_id: Optional[str] = None):
         def run(f, element, point):
@@ -453,7 +476,8 @@ class Actions:
                 "(injected, el) => { if (!el.isConnected) return "
                 "'error:notconnected'; el.blur(); return 'done'; }",
                 {"objectId": element})
-        return self._retry(selector, run, states=[], timeout=timeout, frame_id=frame_id)
+        return self._retry(selector, run, states=[], timeout=timeout, frame_id=frame_id,
+)
 
     def select_text(self, selector: str, *, timeout: float = 30.0, frame_id: Optional[str] = None):
         def run(f, element, point):
@@ -465,7 +489,7 @@ class Actions:
         return self._retry(selector, run, states=["visible"],
                            timeout=timeout, frame_id=frame_id)
 
-    def select_option(self, selector: str, options, *, timeout: float = 30.0, frame_id: Optional[str] = None):
+    def select_option(self, selector: str, options, *, timeout: float = 30.0, frame_id: Optional[str] = None, element_id: Optional[str] = None):
         """`select_option`. Options are given by value, label or index.
 
         ⛔ And the `input`/`change` events are requested from the TRUSTED
@@ -486,7 +510,8 @@ class Actions:
             return r
         return self._retry(selector, run,
                            states=["visible", "stable", "enabled"],
-                           timeout=timeout, frame_id=frame_id)
+                           timeout=timeout, frame_id=frame_id,
+                           element_id=element_id)
 
     def dispatch_event(self, selector: str, event_type: str, detail=None, *,
                        timeout: float = 30.0, frame_id: Optional[str] = None):
@@ -504,9 +529,10 @@ class Actions:
             return self.inj.call(
                 f, "(injected, el, t, d) => injected.dispatchEvent(el, t, d)",
                 {"objectId": element}, event_type, detail or {})
-        return self._retry(selector, run, states=[], timeout=timeout, frame_id=frame_id)
+        return self._retry(selector, run, states=[], timeout=timeout, frame_id=frame_id,
+)
 
-    def press(self, selector: str, key: str, *, timeout: float = 30.0, frame_id: Optional[str] = None):
+    def press(self, selector: str, key: str, *, timeout: float = 30.0, frame_id: Optional[str] = None, element_id: Optional[str] = None):
         """`press`: focuses and presses, with the modifiers from the name."""
         def run(f, element, point):
             self.inj.call(f, "(injected, el) => injected.focusNode(el, true)",
@@ -515,10 +541,11 @@ class Actions:
             return key
         return self._retry(selector, run,
                            states=["visible", "stable", "enabled"],
-                           timeout=timeout, frame_id=frame_id)
+                           timeout=timeout, frame_id=frame_id,
+                           element_id=element_id)
 
     def type_text(self, selector: str, text: str, *, timeout: float = 30.0, frame_id: Optional[str] = None,
-                  delay: float = 0.0):
+                  delay: float = 0.0, element_id: Optional[str] = None):
         """`type`: one key per character, WITHOUT clearing first.
 
         ⛔ It isn't `fill`: that one replaces the content, this one
@@ -532,7 +559,8 @@ class Actions:
             return text
         return self._retry(selector, run,
                            states=["visible", "stable", "enabled"],
-                           timeout=timeout, frame_id=frame_id)
+                           timeout=timeout, frame_id=frame_id,
+                           element_id=element_id)
 
     def set_input_files(self, selector: str, files, *, timeout: float = 30.0, frame_id: Optional[str] = None):
         """`set_input_files`. The paths are ABSOLUTE and the browser
@@ -548,7 +576,8 @@ class Actions:
                          "files": [str(p) for p in files]},
                         session=self.session, timeout=30)
             return list(files)
-        return self._retry(selector, run, states=[], timeout=timeout, frame_id=frame_id)
+        return self._retry(selector, run, states=[], timeout=timeout, frame_id=frame_id,
+)
 
     def tap(self, selector: str, *, timeout: float = 30.0, frame_id: Optional[str] = None,
             position=None):
@@ -650,7 +679,7 @@ class Actions:
             self._mouse_event("mouseup", point, button=button, buttons=0,
                               click_count=n, modifiers=modifiers)
 
-    def fill(self, selector: str, text: str, *, timeout: float = 30.0, frame_id: Optional[str] = None):
+    def fill(self, selector: str, text: str, *, timeout: float = 30.0, frame_id: Optional[str] = None, element_id: Optional[str] = None):
         """Writes into a field.
 
         ⛔ It doesn't just write `element.value = ...`: a site listening
@@ -680,7 +709,7 @@ class Actions:
             else:
                 self._trusted_events(f, element, ["input", "change"])
             return result
-        return self._retry(selector, run,
+        return self._retry(selector, run, element_id=element_id,
                            states=["visible", "stable", "enabled",
                                    "editable"],
                            timeout=timeout, frame_id=frame_id)

--- a/src/invisible_playwright/_juggler/server.py
+++ b/src/invisible_playwright/_juggler/server.py
@@ -155,6 +155,13 @@ class APIRequestContextDispatcher(RefusingDispatcher):
 
 
 # ── handles ─────────────────────────────────────────────────────────────────
+#: What `_retry` prints when an action on a handle times out. The loop takes a
+#: selector for its message and never queries it once an element is given, so
+#: this is a label rather than a lookup - and `None not actionable in 30s` is
+#: what the alternative reads like.
+_HANDLE = "<element handle>"
+
+
 class ElementHandleDispatcher(Dispatcher):
     TYPE = "ElementHandle"
     METHODS = {
@@ -172,6 +179,18 @@ class ElementHandleDispatcher(Dispatcher):
         "getProperty": "op_get_property",
         "getPropertyList": "op_get_property_list",
         "jsonValue": "op_json_value",
+        # Actions. The wire names are the client's, read from `_element_handle`
+        # rather than guessed: `selectOption` is camelCase and the other eight
+        # are not, which is exactly the kind of asymmetry a guess gets wrong.
+        "click": "op_click",
+        "hover": "op_hover",
+        "fill": "op_fill",
+        "type": "op_type",
+        "press": "op_press",
+        "focus": "op_focus",
+        "check": "op_check",
+        "uncheck": "op_uncheck",
+        "selectOption": "op_select_option",
     }
 
     def __init__(self, server, frame: "FrameDispatcher", object_id: str,
@@ -359,6 +378,86 @@ class ElementHandleDispatcher(Dispatcher):
 
 
 # ── frame ───────────────────────────────────────────────────────────────────
+    # ── acting on THIS element ──────────────────────────────────────────────
+    #
+    # Nine, and the number is a decision. The client offers fifty-five methods on
+    # a handle and this driver served fourteen, all of them reads: every action
+    # answered "no method 'click'", which is honest and useless. These are the
+    # ones a person migrating from Playwright hits in the first hour -
+    # `page.query_selector(...).click()` is ordinary code - and the rest keep
+    # reporting themselves as missing rather than being filled in for symmetry.
+    #
+    # ⛔ THEY GO THROUGH THE SAME `actions` AS THE SELECTOR VERSIONS, and that is
+    # the whole design. `click` here is the humanised pointer: approach, hover,
+    # press, release, with the hit-target check and the actionability retry. A
+    # second, simpler path would be quicker to write and would give this package
+    # two click behaviours with two fingerprints, which is the one thing it
+    # exists not to have.
+    #
+    # What differs from a selector click is exactly what SHOULD differ: the node
+    # is not looked up again, because a handle names one node and re-querying
+    # would find a different element with the same description; and the node is
+    # not disposed afterwards, because the caller still holds it.
+    #
+    # The parameter helpers are the frame's. `self.frame._timeout` rather than a
+    # copy: the rules for reading a timeout, a position and the pointer flags out
+    # of a request are one thing, and two readers of one wire format drift.
+
+    def _act_args(self, params: Dict) -> Dict:
+        return {"timeout": self.frame._timeout(params),
+                "frame_id": self.frame.frame_id,
+                "element_id": self.object_id}
+
+    def op_click(self, params: Dict) -> Any:
+        self.frame.actions.click(_HANDLE, position=self.frame._position(params),
+                                 **self.frame._pointer(params),
+                                 **self._act_args(params))
+        return None
+
+    def op_hover(self, params: Dict) -> Any:
+        self.frame.actions.hover(_HANDLE, position=self.frame._position(params),
+                                 **self._act_args(params))
+        return None
+
+    def op_check(self, params: Dict) -> Any:
+        self.frame.actions.check(_HANDLE, position=self.frame._position(params),
+                                 **self._act_args(params))
+        return None
+
+    def op_uncheck(self, params: Dict) -> Any:
+        self.frame.actions.uncheck(_HANDLE, position=self.frame._position(params),
+                                   **self._act_args(params))
+        return None
+
+    def op_fill(self, params: Dict) -> Any:
+        self.frame.actions.fill(_HANDLE, params["value"], **self._act_args(params))
+        return None
+
+    def op_type(self, params: Dict) -> Any:
+        """One key per character, and it does NOT clear first.
+
+        The same distinction the selector version carries: `fill` replaces,
+        `type` appends. Swapping them is how a field meant to hold `bar` ends up
+        holding `foobar`.
+        """
+        self.frame.actions.type_text(_HANDLE, params["text"],
+                                     delay=params.get("delay") or 0.0,
+                                     **self._act_args(params))
+        return None
+
+    def op_press(self, params: Dict) -> Any:
+        self.frame.actions.press(_HANDLE, params["key"], **self._act_args(params))
+        return None
+
+    def op_focus(self, params: Dict) -> Any:
+        self.frame.actions.focus(_HANDLE, **self._act_args(params))
+        return None
+
+    def op_select_option(self, params: Dict) -> Any:
+        chosen = self.frame.actions.select_option(
+            None, params.get("options") or [], **self._act_args(params))
+        return {"values": chosen or []}
+
 class FrameDispatcher(Dispatcher):
     TYPE = "Frame"
     METHODS = {

--- a/tests/test_cross_origin_iframe.py
+++ b/tests/test_cross_origin_iframe.py
@@ -120,7 +120,7 @@ def test_extra_prefs_override_can_break_isolation_only_explicitly():
 
 
 class _SilentHandler(BaseHTTPRequestHandler):
-    #: Una socket muta non pinna piu' un thread: dopo cinque secondi cade.
+    #: A mute socket no longer pins a thread: after five seconds it drops.
     timeout = 5
     """Suppress per-request access logging so pytest output stays clean."""
     PAYLOAD = b""  # set per-instance via subclassing

--- a/tests/test_element_handle_actions.py
+++ b/tests/test_element_handle_actions.py
@@ -1,0 +1,250 @@
+"""Acting through an ElementHandle, not through a selector.
+
+`page.query_selector("#go").click()` is ordinary Playwright, and until 0.10.0 it
+answered "ElementHandle has no method 'click'". The client offers fifty-five
+methods on a handle and the driver served fourteen, every one of them a READ:
+the whole acting half was missing, and the error said so honestly while being
+useless. Nine actions are wired now, and the tests below are in two layers
+because the defect that was found while writing them lives in only one of them.
+
+The lower layer checks that `Actions._retry` treats a caller's element
+differently from a selector it resolved itself - it must not look the node up
+again, and it must not dispose it. No browser.
+
+The upper layer drives a real page through the PUBLIC API, which is the only
+layer that exercises the dispatcher and the wire names. That distinction is not
+theoretical: while this was being written, `click` and `fill` accepted the new
+parameter and quietly failed to forward it, so the driver went back to querying a
+selector. Every lower-layer assertion would still have passed.
+
+⛔ AND THE ACTIONS GO THROUGH THE SAME PATH AS THE SELECTOR VERSIONS. A handle
+click is the humanised pointer - approach, hover, press, release, with the
+hit-target interceptor - and not a shortcut. Two click paths would be two
+fingerprints, which is the one thing this package exists not to have. The e2e
+below asserts the hover arrives before the click, and that the click is trusted,
+because those are what a shortcut would lose.
+"""
+from __future__ import annotations
+
+import http.server
+import socket
+import threading
+
+import pytest
+
+from invisible_playwright._juggler.actions import Actions
+
+PAGE = b"""<!doctype html>
+<html><head><title>handle actions</title></head><body>
+  <input id="testo" type="text">
+  <input id="daScrivere" type="text">
+  <button id="bottone" type="button">press me</button>
+  <input id="casella" type="checkbox">
+  <select id="tendina">
+    <option value="a">Alpha</option><option value="b">Beta</option>
+  </select>
+  <div id="passaggio">no</div>
+<script>
+  window.registro = {click: 0, ordine: [], change: [], tasti: []};
+  const b = document.getElementById('bottone');
+  b.addEventListener('click', e => {
+    window.registro.click++; window.registro.fidato = e.isTrusted;
+    window.registro.ordine.push('click');
+  });
+  b.addEventListener('mouseover', () => window.registro.ordine.push('hover'));
+  for (const id of ['casella','tendina'])
+    document.getElementById(id).addEventListener('change',
+      () => window.registro.change.push(id));
+  document.getElementById('daScrivere').addEventListener('keydown',
+    e => window.registro.tasti.push(e.key));
+</script>
+</body></html>"""
+
+
+# ── the lower layer: no browser ─────────────────────────────────────────────
+
+class _Inj:
+    """Records whether the loop looked a node up, and whether it disposed one."""
+
+    def __init__(self):
+        self.queried = []
+        self.disposed = []
+
+    def query_selector(self, f, selector):
+        self.queried.append(selector)
+        return "resolved-by-the-loop"
+
+    def dispose(self, f, element):
+        self.disposed.append(element)
+
+    def element_states(self, f, element, states):
+        return {"ok": True}
+
+    def scroll_into_view(self, f, element):
+        return False
+
+
+class _Lifecycle:
+    main_frame = "frame-1"
+
+
+def _actions():
+    inj = _Inj()
+    a = Actions(None, "S", _Lifecycle(), inj)
+    # The point is computed from the quad; here it is always usable, so the loop
+    # reaches `run` on the first turn and the test is about what it did to get
+    # there rather than about geometry.
+    a._center_point = lambda f, element, position=None: (10.0, 10.0)
+    a._in_viewport = lambda point: True
+    return a, inj
+
+
+def test_a_handle_is_not_looked_up_again():
+    """A handle names ONE node. Re-querying the selector would find a different
+    element with the same description, which is not what `handle.click()` means.
+
+    Known-bad, and it is what shipped for an afternoon: an action that accepts
+    `element_id` and forwards nothing, after which the loop resolves the string
+    that was only ever meant for the timeout message.
+    """
+    a, inj = _actions()
+    seen = {}
+    a._retry("<element handle>", lambda f, el, pt: seen.setdefault("el", el),
+             element_id="the-caller's-node")
+
+    assert seen["el"] == "the-caller's-node"
+    assert inj.queried == [], f"the loop resolved a selector anyway: {inj.queried}"
+
+
+def test_the_caller_s_handle_is_not_disposed():
+    """`handle.click()` must leave the handle usable.
+
+    Known-bad: reusing the loop as-is. It disposes what it resolved, which is
+    right for a selector and destroys the caller's handle here - and the failure
+    lands on the NEXT call, with an error naming neither the cause nor the call
+    that caused it.
+    """
+    a, inj = _actions()
+    a._retry("<element handle>", lambda f, el, pt: None, element_id="keep-me")
+    assert inj.disposed == [], f"the caller's node was disposed: {inj.disposed}"
+
+
+def test_a_selector_is_still_resolved_and_still_disposed():
+    """The other half, so the two tests above cannot pass by disabling the loop."""
+    a, inj = _actions()
+    a._retry("#go", lambda f, el, pt: None)
+    assert inj.queried == ["#go"]
+    assert inj.disposed == ["resolved-by-the-loop"]
+
+
+def test_every_action_that_takes_an_element_forwards_it():
+    """The defect found while writing this file, as a check rather than a memory.
+
+    `click` and `fill` grew the parameter and did not pass it on, because their
+    call to `_retry` is formatted differently from the others and a
+    pattern-based edit missed them. Nothing failed at import; the driver simply
+    went back to querying a selector.
+    """
+    import ast
+    import inspect
+
+    src = inspect.getsource(Actions)
+    tree = ast.parse("class X:\n" + "\n".join(
+        "    " + line for line in src.split("\n")[1:]))
+    cls = tree.body[0]
+
+    manca = []
+    for fn in cls.body:
+        if not isinstance(fn, ast.FunctionDef) or fn.name == "_retry":
+            continue
+        names = {a.arg for a in fn.args.args} | {a.arg for a in fn.args.kwonlyargs}
+        if "element_id" not in names:
+            continue
+        body = ast.dump(ast.Module(body=fn.body, type_ignores=[]))
+        if "element_id" not in body.replace("arg='element_id'", ""):
+            manca.append(fn.name)
+    assert not manca, f"these accept element_id and never pass it on: {manca}"
+
+
+# ── the upper layer: a real browser, through the public API ──────────────────
+
+def _serve():
+    class H(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Content-Length", str(len(PAGE)))
+            self.end_headers()
+            self.wfile.write(PAGE)
+
+        def log_message(self, *a):
+            pass
+
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    srv = http.server.HTTPServer(("127.0.0.1", port), H)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    return srv, "http://127.0.0.1:%d/" % port
+
+
+@pytest.mark.e2e
+def test_the_nine_actions_reach_the_page_through_a_handle(firefox_binary):
+    """One browser, every action, and the PAGE is asked what happened.
+
+    Never the method's own silence: a driver that accepts `click` and does
+    nothing returns None exactly as happily as one that clicks.
+    """
+    from invisible_playwright import InvisiblePlaywright
+
+    srv, url = _serve()
+    try:
+        with InvisiblePlaywright(seed=4242, binary_path=firefox_binary,
+                                 headless=True) as browser:
+            page = browser.new_context().new_page()
+            page.goto(url, wait_until="load", timeout=30_000)
+            log = lambda: page.evaluate("() => window.registro")
+
+            button = page.query_selector("#bottone")
+            button.click()
+            r = log()
+            assert r["click"] == 1
+            assert r["fidato"] is True, "the click was not a trusted event"
+            assert r["ordine"][:2] == ["hover", "click"], (
+                "the pointer did not approach before pressing, so this is not "
+                "the humanised path: %r" % r["ordine"])
+
+            # the same handle, again: the action must not have disposed it
+            button.click()
+            assert log()["click"] == 2
+
+            page.query_selector("#testo").fill("Federico")
+            assert page.eval_on_selector("#testo", "e => e.value") == "Federico"
+
+            typed = page.query_selector("#daScrivere")
+            typed.fill("bar")
+            typed.type("baz")
+            assert page.eval_on_selector("#daScrivere", "e => e.value") == "barbaz", (
+                "type must APPEND; replacing is what fill does")
+            typed.press("Enter")
+            assert "Enter" in log()["tasti"]
+
+            box = page.query_selector("#casella")
+            box.check()
+            assert page.eval_on_selector("#casella", "e => e.checked") is True
+            box.uncheck()
+            assert page.eval_on_selector("#casella", "e => e.checked") is False
+            assert log()["change"].count("casella") == 2
+
+            assert page.query_selector("#tendina").select_option("b") == ["b"]
+            assert page.eval_on_selector("#tendina", "e => e.value") == "b"
+
+            page.evaluate("() => { window.registro.ordine = [] }")
+            page.query_selector("#bottone").hover()
+            assert "hover" in log()["ordine"]
+
+            page.query_selector("#testo").focus()
+            assert page.evaluate("() => document.activeElement.id") == "testo"
+    finally:
+        srv.shutdown()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -111,18 +111,18 @@ def test_socks5_proxy_mutates_prefs_then_pipeline_still_valid():
         prefs,
     )
 
-    # ⛔ INVERTITO IL 2026-08-30. Questo blocco asseriva che un SOCKS
-    # diventasse `network.proxy.*` e non tornasse niente. Erano due strade per
-    # un fatto solo, e quando la strada dell'HTTP e' sparita col driver Node un
-    # proxy http veniva accettato e buttato. Adesso instrada il comando del
-    # motore, uguale per tutti e quattro gli schemi, e prefs che nominano un
-    # endpoint sono cio' che NON deve comparire.
+    # ⛔ INVERTED ON 2026-08-30. This block used to assert that a SOCKS
+    # proxy became `network.proxy.*` and that nothing came back. Those were two
+    # paths for a single fact, and when the HTTP path disappeared along with the
+    # Node driver an http proxy was accepted and thrown away. Now it routes the
+    # engine command, the same for all four schemes, and prefs that name an
+    # endpoint are what must NOT appear.
     assert pw_proxy is not None
-    for nome in ("network.proxy.type", "network.proxy.socks",
+    for name in ("network.proxy.type", "network.proxy.socks",
                  "network.proxy.socks_port", "network.proxy.socks_version",
                  "network.proxy.socks_username", "network.proxy.socks_password",
                  "network.proxy.http", "network.proxy.ssl"):
-        assert nome not in prefs, nome
+        assert name not in prefs, name
     assert prefs["zoom.stealth.dns.no_local_resolution"] is True
 
     # Profile-derived keys must still be present after proxy mutation.
@@ -212,7 +212,7 @@ def test_http_proxy_returned_unchanged_no_socks_mutations():
 
     pw_proxy = configure_proxy(proxy_in, prefs)
 
-    assert pw_proxy == proxy_in  # lo stesso endpoint, per ogni schema
+    assert pw_proxy == proxy_in  # the same endpoint, for every scheme
     # No SOCKS prefs should have been written.
     assert "network.proxy.type" not in prefs
     assert "network.proxy.socks" not in prefs
@@ -309,9 +309,9 @@ def test_windows_virtual_display_with_socks_proxy(monkeypatch):
         {"server": "socks5://127.0.0.1:1080"}, prefs
     )
 
-    assert pw_proxy is not None      # una strada sola, anche qui
+    assert pw_proxy is not None      # a single path, here too
     assert prefs["security.sandbox.gpu.level"] == 0  # virtual_display branch
-    assert pw_proxy is not None                      # una strada sola
+    assert pw_proxy is not None                      # a single path
     assert "network.proxy.type" not in prefs
     # Windows exposes a validated persona renderer (calibrated clean bucket),
     # not empty/native - see _webgl_personas.
@@ -340,7 +340,7 @@ def test_linux_xvfb_workarounds_with_socks_proxy(monkeypatch):
         {"server": "socks5://127.0.0.1:1080"}, prefs
     )
 
-    assert pw_proxy is not None      # una strada sola, anche qui
+    assert pw_proxy is not None      # a single path, here too
     # Xvfb workarounds present.
     assert prefs["gfx.webrender.all"] is False
     assert prefs["gfx.webrender.force-disabled"] is True
@@ -356,8 +356,8 @@ def test_linux_xvfb_workarounds_with_socks_proxy(monkeypatch):
     assert prefs["zoom.stealth.webgl.renderer"] == _persona["prefs"]["zoom.stealth.webgl.renderer"]
     assert prefs["zoom.stealth.webgl.renderer"]  # non-empty
     assert "ANGLE" in prefs["zoom.stealth.webgl.renderer"]  # Windows ANGLE form
-    # Il livello proxy non scrive piu' nessun endpoint, e cio' che scrive - le
-    # prefs dei canali di fuga - non calpesta le prefs Linux qui sopra.
+    # The proxy layer no longer writes any endpoint, and what it does write - the
+    # leak-channel prefs - does not trample the Linux prefs above.
     assert "network.proxy.type" not in prefs
     assert prefs["zoom.stealth.dns.no_local_resolution"] is True
 

--- a/tests/test_ua_widget_not_selectable.py
+++ b/tests/test_ua_widget_not_selectable.py
@@ -77,7 +77,7 @@ _AUTHOR_PAGE = b"""<!doctype html><html><head><title>author-closed</title></head
 
 
 class _SilentHandler(BaseHTTPRequestHandler):
-    #: Una socket muta non pinna piu' un thread: dopo cinque secondi cade.
+    #: A silent socket no longer pins a thread: after five seconds it drops.
     timeout = 5
     """Serve the two pages by path, and say nothing while doing it."""
 

--- a/tests/test_webrtc_realness.py
+++ b/tests/test_webrtc_realness.py
@@ -427,7 +427,7 @@ def socks5_tcp_only():
 def local_https_page():
     """A trivial localhost page (used by the no-proxy srflx test)."""
     class H(BaseHTTPRequestHandler):
-        #: Una socket muta non pinna piu' un thread: dopo cinque secondi cade.
+        #: A silent socket no longer pins a thread down: after five seconds it drops.
         timeout = 5
         def do_GET(self):
             self.send_response(200)


### PR DESCRIPTION
The English-only rule was written for this repository on 2026-08-27, after 549 lines of Italian shipped in one subsystem and 852 more were found in 33 files that were already public. The gate was written the same day, here, and wired into nothing: not tests.yml, not the pre-push hook. Both sibling packages copied the script and the CI step; this one kept only the script.

Ran it here for the first time: four test files, red. Two were last touched on 2026-08-31 by a commit about something else, so nothing was going to notice. They are translated, 17 lines across four files, checked by reconstructing each file from its HEAD blob with only the prose substitutions applied so every count and date in them is untouched by construction. The job now runs in tests.yml, on its own, not behind core-on-index.

Two docs pages said there is no MCP server for this project. Both were written on 2026-07-27 and the server was published on 2026-08-19, so they were true when written and afterwards steered readers to Microsoft's server, which cannot carry the seeded profile, for a problem ours solves. The engine README never mentioned either sibling either.

Also here: nine acting methods on ElementHandle. `page.query_selector("#go").click()` is ordinary Playwright and this driver answered "ElementHandle has no method 'click'" - fifty-five methods on the client, fourteen served, every one of them a read. They go through the same humanised path as the selector versions rather than a second, simpler one, because two click paths would be two fingerprints.

And one home for the download size: three READMEs carried a figure and no two agreed, all three wrong against the packaged seal.