### PR TITLE
0.10.0: an ElementHandle can act, and the docs stop contradicting the product

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,37 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-09-03
+
+### Documentation
+
+- **Two pages said there is no MCP server for this project.** Both were written
+  on 2026-07-27 and the server was published on 2026-08-19: true when written,
+  and afterwards they steered readers to Microsoft's server, which cannot carry
+  the seeded profile, for a problem ours solves. The integration page now opens
+  with ours and is what it actually is - how to point Microsoft's playwright-mcp
+  at this engine if you are already on it, and what that costs.
+
+- **The README never mentioned either sibling.** A reader who would rather prompt
+  than script had one hand-off, to the page above, which told them no server
+  existed. There is now a short block after Install with both one-liners, and the
+  Related projects section lists the three siblings before the third-party ones.
+
+- The Python floor was stated only as a badge image about 200 lines below the
+  install block, and the first-run download size disagreed across three READMEs,
+  all three wrong against the packaged seal. One home for it, here.
+
+- Four wiki pages edited in a working tree on 2026-08-30, rescued onto a branch
+  and then lost a second time when the branch was never merged. Landed.
+
+### Internal
+
+- The English-only gate was written for this repository on 2026-08-27 and wired
+  nowhere: not into tests.yml, not into the pre-push hook. Both sibling packages
+  copied the script and the CI step; this one kept only the script. Run here for
+  the first time it found four Italian test files, now translated, and it runs in
+  CI from now on.
+
 ### Added
 
 - **Nine acting methods on `ElementHandle`.** `click`, `hover`, `fill`, `type`,

--- a/docs/ai-browser-agents-stealth.md
+++ b/docs/ai-browser-agents-stealth.md
@@ -213,6 +213,13 @@ Chromium build.
 differently about the GPU, the fonts, the audio device and the screen. The agent is
 identical.
 
+**How do you make an AI agent undetectable?** You do not, as a single setting. Three
+separate problems each need their own fix: the engine fingerprint (what patching Firefox
+at the C++ level answers), the machine surfaces a container gives away regardless of
+engine (GPU, fonts, audio, screen), and the agent loop's own rhythm, which no fingerprint
+patch touches. Fixing only the first and calling the agent undetectable is the mistake
+this whole page is about.
+
 **Which AI agent framework is most stealth-friendly?** The question is usually the wrong
 one. Pick on the agent loop, then fix the machine, then consider the engine.
 

--- a/docs/computer-use-agents-browser-detection.md
+++ b/docs/computer-use-agents-browser-detection.md
@@ -12,8 +12,8 @@ nav_order: 6
 A computer-use agent (CUA) does not read the DOM to decide where to act. It takes a
 screenshot, sends the image to a vision model, gets back a pixel coordinate, clicks
 there, and takes another screenshot. That loop is the whole architecture of OpenAI's
-Computer-Using Agent and of Anthropic's computer-use tool, and it changes which
-detection signals matter and which stop mattering.
+Computer-Using Agent and of Claude's computer use tool (Anthropic's name for the same
+pattern), and it changes which detection signals matter and which stop mattering.
 
 This page is about that shift: why the automation flags people usually worry about are
 moot for a coordinate agent, what is still checkable underneath it, and where
@@ -160,7 +160,7 @@ or DOM automation flags, because a coordinate click never produces them. They ge
 on the engine fingerprint, on the IP, or on the regular timing of the screenshot-click
 loop.
 
-**Does invisible_playwright work with OpenAI or Anthropic computer-use?** Yes. It returns
+**Does invisible_playwright work with OpenAI or Claude computer use?** Yes. It returns
 a real Playwright `Browser`, so `page.screenshot()` and `page.mouse.click(x, y)` - the
 two calls a coordinate agent needs - work exactly as documented, on a Firefox that
 renders like a real Windows desktop.

--- a/docs/how-to-scrape-clinical-trial-listings-playwright.md
+++ b/docs/how-to-scrape-clinical-trial-listings-playwright.md
@@ -118,11 +118,10 @@ a numbered or bulleted list under an "Inclusion Criteria" heading, another under
 each line is not something a scraper should try to parse.
 
 An age range written as "must be between 18 and 65 years of age" looks like two numbers
-waiting to be extracted, until the next criterion reads "diagnosed within the last five
-years" or "prior treatment with at least one but no more than three agents," where the
-comparison, the units and the exceptions are all doing real work in the sentence. Storing
-each criterion as its own string keeps the boundary honest: the scraper's job stops at
-splitting the list, and a clinician or a downstream model reads the sentence.
+waiting to be extracted, until the next criterion reads "prior treatment with at least one
+but no more than three agents," where the comparison and the exception are doing real work
+in the sentence. Storing each criterion as its own string keeps the boundary honest: the
+scraper's job stops at splitting the list, and a clinician reads the sentence.
 
 ```python
 def read_eligibility(page):
@@ -211,12 +210,11 @@ and gone through whatever review the registry requires before publishing it. A t
 no results section is, more often than not, simply a trial whose results have not arrived
 yet.
 
-The distinction worth encoding is "not reported" versus "not applicable," and most
-registries mark the second case explicitly rather than leaving it to be inferred: a note
-attached to the results area stating that results reporting does not apply to this study
-type or this outcome. Absent that explicit marker, treat a missing results section on a
-completed or terminated trial as pending, not as evidence the study never finished, and
-re-check it on the same schedule you use for status.
+The distinction worth encoding is "not reported" versus "not applicable." Most registries
+mark the second case explicitly, with a note attached to the results area stating that
+reporting does not apply to this study type. Absent that marker, treat a missing results
+section on a completed or terminated trial as pending, and re-check it on the same
+schedule you use for status.
 
 ```python
 def read_results_status(page):
@@ -238,13 +236,12 @@ a re-check cycle on a record that is already complete in every sense that matter
 
 ## Assembling one row per trial, sized for re-checking
 
-Put the pieces together and the record for one trial is a dict with a handful of scalar
-fields, two nested lists (eligibility, sites), and a checked-at timestamp that makes the
-whole thing safe to overwrite on the next pass instead of trusting it forever. Getting to
-that record usually means walking a paginated search listing first to collect trial URLs,
-the same [numbered pagination](how-to-scrape-paginated-pages-playwright.md) pattern used
-on any other listing page, then visiting each one, which is the general [list-to-detail
-crawl](how-to-crawl-list-to-detail-pages-playwright.md) shape.
+Put the pieces together and one trial's record is a dict with a handful of scalar fields,
+two nested lists, and a checked-at timestamp that makes the whole thing safe to overwrite
+on the next pass. Getting there means walking a paginated search listing first to collect
+trial URLs, the same [numbered pagination](how-to-scrape-paginated-pages-playwright.md)
+pattern used on any listing page, then visiting each one, the general
+[list-to-detail crawl](how-to-crawl-list-to-detail-pages-playwright.md) shape.
 
 ```python
 from invisible_playwright import InvisiblePlaywright
@@ -291,14 +288,13 @@ database](how-to-scrape-into-a-database-playwright.md), and it is what makes the
 ## Conclusion
 
 A clinical trial listing is not one fact, it is several records at different ages sharing
-a page. Status decays and needs a re-check timestamp. The registry-specific identifier and
-the international identifier both belong on the row, because a dedup step across
-registries needs the second one. Eligibility criteria stay as text, because the logic
-inside them is not something a scraper should parse. Enrollment needs its label kept
-alongside the number, or a target quietly becomes a headcount. Site status is a separate,
-finer field than trial status. And a missing results section is usually a timing gap, not
-a dead end, unless the page says otherwise. Build the row to be overwritten safely on the
-next pass, and the pipeline stays honest about how current every field actually is.
+a page. Status decays and needs a re-check timestamp. Both identifiers belong on the row,
+because a dedup step across registries needs the international one. Eligibility criteria
+stay as text, because the logic inside them is not something a scraper should parse.
+Enrollment needs its label kept alongside the number, or a target quietly becomes a
+headcount. Site status is a separate, finer field than trial status, and a missing results
+section is usually a timing gap rather than a dead end. Build the row to be overwritten
+safely on the next pass, and the pipeline stays honest about how current every field is.
 
 ## Short answers to the questions that lead here
 
@@ -315,20 +311,14 @@ inside the sentences is a separate problem from scraping the page.
 often the target written into the protocol, and it is only an actual count when the page
 labels it that way. Store the label with the number.
 
-**A trial shows one status but a location page shows a different one for a specific
-site. Which is right?** Both, because they are different fields. Trial-level status and
-site-level status move independently, and a site can close or open without the overall
-trial status changing.
+**A trial shows one status but a listed site shows a different one. Which is right?**
+Both. They are different fields, and a site can close or open without the overall trial
+status changing.
 
 **A completed trial has no results section. Is that a bug in my scraper?** Probably not.
 Results are added long after registration, sometimes years later, so a completed trial can
 legitimately show no results yet. Look for an explicit "not applicable" marker before
 assuming the study never finished.
-
-**How often should I re-scrape a trial once I have it?** Often enough that the
-`status_checked_at` field stays meaningful for your use case. A recruiting trial changes
-state more often than a completed one, so a fixed schedule for every trial wastes cycles
-on the ones that rarely move and under-checks the ones that do.
 
 ## Sources
 
@@ -339,10 +329,9 @@ on the ones that rarely move and under-checks the ones that do.
 - Playwright's
   [`wait_for_load_state`](https://playwright.dev/python/docs/api/class-page#page-wait-for-load-state),
   used to detect the end of a pagination click before reading the next page's rows.
-- This page describes registry mechanics in generic terms on purpose: field names,
-  status vocabularies and identifier formats differ between registries, so verify the
-  selectors above against the specific registry you are reading before trusting them
-  at scale.
+- This page describes registry mechanics in generic terms on purpose, since field names
+  and identifier formats differ between registries: verify the selectors above against
+  the specific registry you are reading before trusting them at scale.
 
 **See also:** [crawling a list to its detail pages](how-to-crawl-list-to-detail-pages-playwright.md)
 for the general listing-to-detail shape used in the last section,

--- a/docs/how-to-scrape-course-catalogs-playwright.md
+++ b/docs/how-to-scrape-course-catalogs-playwright.md
@@ -118,17 +118,27 @@ with zero sections and no error.
 Click each course, wait for its own container rather than a timeout, then read:
 
 ```python
-for course in page.query_selector_all("[data-course-id]"):
-    cid = course.get_attribute("data-course-id")
-    course.click()
-    page.wait_for_selector(f"[data-sections-for='{cid}'] [data-section-id]")
-    for sec in page.query_selector_all(f"[data-sections-for='{cid}'] [data-section-id]"):
-        rows.append(parse_section(sec, cid))
+courses = page.locator("[data-course-id]")
+ids = [courses.nth(i).get_attribute("data-course-id")
+       for i in range(courses.count())]          # read ids first, hold no handles
+
+for cid in ids:
+    page.locator(f"[data-course-id='{cid}']").click()   # re-resolved every round
+    sections = page.locator(f"[data-sections-for='{cid}'] [data-section-id]")
+    sections.first.wait_for()
+    for i in range(sections.count()):
+        rows.append(parse_section(sections.nth(i), cid))
 ```
 
 Waiting for the container keyed to that specific course matters. A generic wait on
 `[data-section-id]` passes immediately because the previous course's sections are still
 in the DOM, and you parse the same section twice under two different course codes.
+
+Holding the element handles from a first pass and clicking them one by one looks
+equivalent and is not. A catalog that re-renders its course list when a row expands
+detaches every handle taken before that click, and the loop dies on the second course
+with a detached-node error. Reading the identifiers first and re-resolving the locator on
+each round costs one extra query and removes the failure.
 
 The same trap in its general form is described in
 [how to scrape a load-more button with Playwright](how-to-scrape-load-more-button-playwright.md).
@@ -207,28 +217,31 @@ that only the seat counts moved.
 
 ## Short answers to the questions that lead here
 
-### Should one row be a course or a section?
-
-A section. A course with two sections has two instructors, two schedules and two seat
+**Should one row be a course or a section?** A section. A course with two sections has two instructors, two schedules and two seat
 counts, and a course-level row cannot hold either pair without duplicating the other.
 
-### Why do the seat numbers differ from the page?
-
-The badge on the results page is usually a cached rendering that stops updating once a
+**Why do the seat numbers differ from the page?** The badge on the results page is usually a cached rendering that stops updating once a
 section closes. The section endpoint carries the current integers, so read the response
 rather than the element.
 
-### Why does the filtered result count not match the rows I extract?
-
-Catalog filters commonly count courses while returning sections. Partition the crawl by
+**Why does the filtered result count not match the rows I extract?** Catalog filters commonly count courses while returning sections. Partition the crawl by
 department and term, then filter locally.
 
-### Is a cross-listed course a duplicate?
-
-No. It is one section reachable under two course codes. Keep one row per section and
+**Is a cross-listed course a duplicate?** No. It is one section reachable under two course codes. Keep one row per section and
 record the additional codes alongside it.
 
 ## Sources
 
 - Playwright documentation, [Events and response handling](https://playwright.dev/python/docs/events), retrieved 2026-08-28
 - Playwright documentation, [Auto-waiting](https://playwright.dev/python/docs/actionability), retrieved 2026-08-28
+
+**See also:** [capturing XHR API responses](how-to-capture-xhr-api-responses-playwright.md)
+for reading the section endpoint instead of the badge, [scraping a load-more button](how-to-scrape-load-more-button-playwright.md)
+for the wait that passes on the previous panel, and [resuming an interrupted scrape](how-to-resume-an-interrupted-scrape-playwright.md)
+for picking a long term back up.
+
+---
+
+*Written while maintaining [invisible_playwright](https://github.com/feder-cr/invisible_playwright),
+a Firefox patched at the C++ level driven by stock Playwright. The generic wait on `[data-section-id]` is a mistake that shipped here first: it
+passes on the previous course's sections and doubles them under a new code.*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "invisible_playwright"
-version = "0.9.0"
+version = "0.10.0"
 description = "Playwright wrapper for a patched Firefox with deterministic stealth profile."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
`page.query_selector("#go").click()` is ordinary Playwright, and this driver answered "ElementHandle has no method 'click'". The client offers fifty-five methods on a handle and the driver served fourteen, every one of them a read. Nine acting methods are wired, through the same humanised path as the selector versions rather than a second, simpler one: two click paths would be two fingerprints.

That landed on main already. What this release adds is the decision to ship it. Until it is on the index the method fails for everybody, and it is now verified in three places rather than one: the e2e ran it against a real browser in CI, and both consumers were run against THIS tree rather than the published engine. That second check matters because invisible-playwright-mcp declares an open bound (`invisible-playwright>=0.9.0`), so publishing here changes what every `uvx invisible-playwright-mcp` install resolves. 147 tests on the server, 132 on the interface, against this engine.

The documentation half is larger by volume. Two pages told readers there is no MCP server for this project, written on 2026-07-27 before there was one, and afterwards steering them to Microsoft's server, which cannot carry the seeded profile. The README named neither sibling. Four wiki pages edited in a working tree on 2026-08-30 were rescued onto a branch and lost a second time when nobody merged it; they are in.

And the English-only gate, written for this repository on 2026-08-27 and wired nowhere since, now runs in CI. Its first run here found four Italian test files.