### PR TITLE
The README learns the vendor pages exist, and the agents hub points across

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,16 @@ is the map most other pages link back to, [Playwright detected as a bot on one s
 is the troubleshooting order, and [navigator.webdriver is not the tell you think it is](docs/navigator-webdriver-explained.md)
 explains the most famous property in this space and why patching it alone buys you
 almost nothing.
+
+The detectors section now covers the commercial anti-bot products by name, each
+read from its own documentation or from confirmed reverse engineering:
+[Cloudflare Bot Management](docs/cloudflare-bot-management-explained.md) and
+[Turnstile](docs/cloudflare-turnstile-explained.md),
+[DataDome](docs/datadome-explained.md), [Kasada](docs/kasada-explained.md),
+[Akamai Bot Manager](docs/akamai-bot-manager-explained.md),
+[PerimeterX](docs/perimeterx-explained.md), [hCaptcha](docs/hcaptcha-explained.md),
+[Imperva](docs/imperva-incapsula-explained.md), and
+[the rest of the set](docs/guides-detectors-explained.md).
 - [crawl4ai stealth and custom browser engines](docs/crawl4ai-stealth-custom-browser.md) - browser_type accepts firefox but there is no executable_path; where the adapter seam is
 - [Why headless browsers render different fonts](docs/headless-fonts-differ.md) - the three causes, the per-platform font sets, and why the fix is not installing more fonts
 - [How to make Linux and macOS report real Windows fonts](docs/bundled-fonts-cross-platform.md) - one manifest, three font backends convinced not to ask the host, and the four seams still open

--- a/docs/guides-ai-agents.md
+++ b/docs/guides-ai-agents.md
@@ -17,6 +17,12 @@ verified against the framework's actual source before anything is claimed about 
 several candidates that looked like a fit by star count turned out not to use
 Playwright, or not to touch Firefox, at all.
 
+These pages are for developers wiring an agent to this engine. The
+agent-experience side - what to run, which agent products compare how, what to
+check when an agent gets blocked - lives on the
+[AIHawk wiki](https://github.com/feder-cr/AIHawk/wiki), the agent built on this
+same engine.
+
 ## Framework integrations
 
 - [Give a LangChain agent an invisible_playwright browser](langchain-agent-invisible-playwright-browser.md) - hand PlayWrightBrowserToolkit a launched browser so its tools inherit a real fingerprint.


### PR DESCRIPTION
## Summary

Eighteen anti-bot vendor pages went live in the wiki without a single link from the repository's own README, which is the page crawlers actually visit - and after four days, none of the new pages are indexed yet. The documentation section now names the vendor set (Cloudflare Bot Management, Turnstile, DataDome, Kasada, Akamai, PerimeterX, hCaptcha, Imperva, plus the hub), giving them a crawl path from the repo's highest-authority page.

The AI-agents hub also gains a pointer to the AIHawk wiki, completing the two-way split established when the four agent-experience pages moved there: developers wiring an agent to this engine stay here, people running an agent go there.

## Test plan

- [x] English-only gate clean on the range
- [x] No em/en-dashes
- [x] All added links target real existing pages
- [x] pytest green via pre-push hook

Generated with Claude Code
