### PR TITLE
A screenshot photographs where the page is, and full_page means the page

### DIFF
--- a/src/invisible_playwright/_juggler/server.py
+++ b/src/invisible_playwright/_juggler/server.py
@@ -1954,13 +1954,49 @@ class PageDispatcher(Dispatcher):
         # like sending it as null: `Object "<root>.clip" is undefined, but has
         # some scheme`. Reading the type declaration is what settled this -
         # both of the obvious readings of the error are wrong.
+        #
+        # ⛔ AND THE CLIP IS IN DOCUMENT COORDINATES, WHICH IS WHY THIS USED TO
+        # PHOTOGRAPH THE WRONG THING. It was built as
+        # `{x: 0, y: 0, width: innerWidth, height: innerHeight}`, which is not
+        # the viewport - it is the top-left corner of the DOCUMENT, at viewport
+        # size. Two promises broke on that one line, both silently:
+        #
+        #   * scrolling did nothing. `scrollTo(0, 3000)` then `screenshot()`
+        #     returned the top of the page, and the caller has no way to see
+        #     that: the image is a valid screenshot of somewhere else. For an
+        #     agent that scrolls and looks, every look answered the same thing.
+        #   * `full_page=True` was never read here at all, so it returned the
+        #     viewport-sized top corner too. Measured on a 4000px document:
+        #     800x600 where 800x4000 was asked for.
+        #
+        # Both are the same defect - the clip was computed from nothing - so
+        # both are fixed by computing it from the page: where the viewport
+        # actually is, or how big the document actually is.
+        #
+        # A clip the CALLER supplied is passed through untouched. Playwright
+        # documents it in page coordinates, which is what the engine wants, so
+        # there is nothing to translate.
         clip = params.get("clip")
         if not clip:
-            size = self.injected.evaluate(
+            box = self.injected.evaluate(
                 self.frame.frame_id,
-                "({x: 0, y: 0, width: window.innerWidth,"
-                " height: window.innerHeight})")
-            clip = size or {"x": 0, "y": 0, "width": 1280, "height": 720}
+                "({x: window.scrollX, y: window.scrollY,"
+                " width: window.innerWidth, height: window.innerHeight,"
+                " fullWidth: Math.max(document.documentElement.scrollWidth,"
+                "                     document.body ? document.body.scrollWidth : 0),"
+                " fullHeight: Math.max(document.documentElement.scrollHeight,"
+                "                      document.body ? document.body.scrollHeight : 0)})")
+            # A page that cannot be measured still gets photographed, at the
+            # size the caller most likely has. Failing here would turn an
+            # unusual page into no screenshot at all.
+            box = box or {"x": 0, "y": 0, "width": 1280, "height": 720,
+                          "fullWidth": 1280, "fullHeight": 720}
+            if params.get("fullPage"):
+                clip = {"x": 0, "y": 0,
+                        "width": box["fullWidth"], "height": box["fullHeight"]}
+            else:
+                clip = {"x": box["x"], "y": box["y"],
+                        "width": box["width"], "height": box["height"]}
         result = self.send("Page.screenshot", _only_set({
             "mimeType": "image/jpeg" if params.get("type") == "jpeg"
                         else "image/png",

--- a/tests/test_screenshot_looks_where_you_are.py
+++ b/tests/test_screenshot_looks_where_you_are.py
@@ -1,0 +1,269 @@
+"""A screenshot photographs where the page IS, and `full_page` means the page.
+
+⛔ NEITHER WAS TRUE UNTIL 2026-09-03, and both failed the same way: silently,
+with a valid image of the wrong place.
+
+`op_screenshot` built its clip as `{x: 0, y: 0, width: innerWidth,
+height: innerHeight}`. The engine reads a clip in DOCUMENT coordinates, so that
+is not the viewport - it is the document's top-left corner, at viewport size.
+Two promises broke on that one line:
+
+  * scrolling did nothing. `scrollTo(0, 3000)` then `screenshot()` returned the
+    top of the page. Measured on a 4000px document with a red band at y=1000:
+    after scrolling to 1000 the image was still all white. For an agent that
+    scrolls and looks - which is what browser_take_screenshot is for - every
+    look answered the same picture, and nothing in the image says so.
+  * `full_page=True` was never read by the driver at all. On the same document
+    it returned 800x600 where 800x4000 was asked for.
+
+⛔ AND THE VENDORED UPSTREAM SUITE COULD NOT HAVE CAUGHT IT. It is excluded from
+collection by `norecursedirs`, but that is the smaller half: its
+`test_screenshot.py` carries three tests - mask, inferring the type from the
+path, and the type argument - and neither `full_page` nor scrolling is among
+them. A subset of somebody else's suite is not coverage of the part they left
+out.
+
+The assertions here read PIXELS, not sizes. A size proves the crop was the right
+shape; only a pixel proves it was taken from the right place, and the defect was
+a right-shaped crop of the wrong place.
+"""
+from __future__ import annotations
+
+import http.server
+import socket
+import struct
+import threading
+import zlib
+
+import pytest
+
+# White down to 1000, one RED band 1000..1200, black to 4000, and a GREEN
+# column at x=1400 so the same trick works sideways. Reading the colour at a
+# known place in the image says which part of the document it came from.
+ROSSO = (204, 0, 0)
+VERDE = (0, 170, 0)
+PAGE = b"""<!doctype html><html><body style="margin:0">
+<div style="height:1000px;background:#fff"></div>
+<div id="band" style="height:200px;background:#c00"></div>
+<div style="height:2800px;background:#000"></div>
+<div id="colonna" style="position:absolute;top:0;left:1400px;width:200px;height:600px;background:#0a0"></div>
+</body></html>"""
+
+
+def _serve():
+    class H(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Content-Length", str(len(PAGE)))
+            self.end_headers()
+            self.wfile.write(PAGE)
+
+        def log_message(self, *a):
+            pass
+
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    srv = http.server.HTTPServer(("127.0.0.1", port), H)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    return srv, "http://127.0.0.1:%d/" % port
+
+
+# ── reading a PNG without adding a dependency ───────────────────────────────
+#
+# Pillow would do this in one line and is not in this package's dev extras.
+# Adding it so a single test can read one pixel is a heavier change than the
+# thirty lines below, which decode exactly as much as the assertions need: the
+# header, and the first few rows.
+
+def _size(path) -> tuple:
+    with open(path, "rb") as fh:
+        head = fh.read(24)
+    assert head[:8] == b"\x89PNG\r\n\x1a\n", "not a PNG: %r" % head[:8]
+    return struct.unpack(">II", head[16:24])
+
+
+def _first_rows(path, rows: int = 4) -> list:
+    """The first `rows` scanlines as lists of (r, g, b).
+
+    Un-filtering needs every row up to the one you want, so this stops as early
+    as it can: the assertions only look near the top.
+    """
+    raw = open(path, "rb").read()
+    assert raw[:8] == b"\x89PNG\r\n\x1a\n"
+    width, height, depth, colour = struct.unpack(">IIBB", raw[16:26])
+    assert depth == 8, "expected 8 bits per channel, got %d" % depth
+    canali = {2: 3, 6: 4, 0: 1}.get(colour)
+    assert canali, "unsupported PNG colour type %d" % colour
+
+    dati, i = b"", 8
+    while i < len(raw):
+        lung, tipo = struct.unpack(">I4s", raw[i:i + 8])
+        if tipo == b"IDAT":
+            dati += raw[i + 8:i + 8 + lung]
+        elif tipo == b"IEND":
+            break
+        i += 12 + lung
+    grezzo = zlib.decompress(dati)
+
+    passo = width * canali
+    sopra = bytearray(passo)
+    fuori = []
+    for r in range(min(rows, height)):
+        base = r * (passo + 1)
+        filtro = grezzo[base]
+        riga = bytearray(grezzo[base + 1:base + 1 + passo])
+        for x in range(passo):
+            a = riga[x - canali] if x >= canali else 0
+            b = sopra[x]
+            c = sopra[x - canali] if x >= canali else 0
+            if filtro == 1:
+                riga[x] = (riga[x] + a) & 0xFF
+            elif filtro == 2:
+                riga[x] = (riga[x] + b) & 0xFF
+            elif filtro == 3:
+                riga[x] = (riga[x] + (a + b) // 2) & 0xFF
+            elif filtro == 4:
+                p = a + b - c
+                pa, pb, pc = abs(p - a), abs(p - b), abs(p - c)
+                pr = a if (pa <= pb and pa <= pc) else (b if pb <= pc else c)
+                riga[x] = (riga[x] + pr) & 0xFF
+        sopra = riga
+        fuori.append([tuple(riga[x:x + 3]) for x in range(0, passo, canali)])
+    return fuori
+
+
+def test_the_png_reader_reads(tmp_path):
+    """Everything below is worthless if the decoder is. Known-bad on purpose:
+    a PNG this package produced, whose colour at a known place is known."""
+    import base64
+
+    # 2x1, left pixel red, right pixel black, written by hand
+    dati = zlib.compress(bytes([0, 204, 0, 0, 0, 0, 0]))
+    png = (b"\x89PNG\r\n\x1a\n"
+           + _chunk(b"IHDR", struct.pack(">IIBBBBB", 2, 1, 8, 2, 0, 0, 0))
+           + _chunk(b"IDAT", dati) + _chunk(b"IEND", b""))
+    f = tmp_path / "due.png"
+    f.write_bytes(png)
+    assert _size(f) == (2, 1)
+    assert _first_rows(f, 1)[0] == [ROSSO, (0, 0, 0)]
+
+
+def _chunk(tipo: bytes, corpo: bytes) -> bytes:
+    return (struct.pack(">I", len(corpo)) + tipo + corpo
+            + struct.pack(">I", zlib.crc32(tipo + corpo) & 0xFFFFFFFF))
+
+
+@pytest.fixture(scope="module")
+def scatti(tmp_path_factory, firefox_binary):
+    """One browser, four photographs, so the assertions cost nothing after."""
+    from invisible_playwright import InvisiblePlaywright
+
+    out = tmp_path_factory.mktemp("scatti")
+    srv, url = _serve()
+    try:
+        with InvisiblePlaywright(seed=4242, binary_path=firefox_binary,
+                                 headless=True) as browser:
+            page = browser.new_context(
+                viewport={"width": 800, "height": 600}).new_page()
+            page.goto(url, wait_until="load", timeout=30_000)
+            alto = page.evaluate("() => document.documentElement.scrollHeight")
+
+            page.screenshot(path=str(out / "cima.png"))
+            page.screenshot(path=str(out / "intera.png"), full_page=True)
+            page.evaluate("() => window.scrollTo(0, 1000)")
+            page.wait_for_timeout(300)
+            page.screenshot(path=str(out / "scorsa.png"))
+            page.screenshot(path=str(out / "ritagliata.png"),
+                            clip={"x": 0, "y": 1000, "width": 400, "height": 200})
+            # ⛔ scrollTo is CLAMPED to the maximum: asking for 1400 on a
+            # 1600px document in an 800px viewport lands on 800. The test
+            # reads back where it actually went rather than assuming, which
+            # is the same mistake in miniature as the defect it covers.
+            page.evaluate("() => window.scrollTo(1400, 0)")
+            page.wait_for_timeout(300)
+            dove = page.evaluate("() => Math.round(window.scrollX)")
+            page.screenshot(path=str(out / "di-lato.png"))
+            largo = page.evaluate(
+                "() => document.documentElement.scrollWidth")
+            yield out, alto, largo, dove
+    finally:
+        srv.shutdown()
+
+
+@pytest.mark.e2e
+def test_the_page_is_the_shape_the_test_believes(scatti):
+    """Otherwise every assertion below is about a document of another shape."""
+    _, alto, largo, _ = scatti
+    assert (largo, alto) == (1600, 4000), (
+        "the fixture page is %dx%d, not 1600x4000" % (largo, alto))
+
+
+@pytest.mark.e2e
+def test_an_unscrolled_screenshot_is_the_top_of_the_page(scatti):
+    out = scatti[0]
+    assert _size(out / "cima.png") == (800, 600)
+    assert _first_rows(out / "cima.png", 1)[0][400] == (255, 255, 255)
+
+
+@pytest.mark.e2e
+def test_after_scrolling_it_photographs_where_you_scrolled_to(scatti):
+    """The one that was broken, and the only test here that a size cannot pass.
+
+    At scrollY 1000 the viewport starts exactly on the red band, so the top row
+    is red. Before the fix this image was white: a correctly sized picture of
+    the wrong place.
+    """
+    out = scatti[0]
+    assert _size(out / "scorsa.png") == (800, 600)
+    riga = _first_rows(out / "scorsa.png", 1)[0]
+    assert riga[400] == ROSSO, (
+        "the top of the image is %s, not the red band the viewport is sitting "
+        "on - the screenshot ignored the scroll" % (riga[400],))
+
+
+@pytest.mark.e2e
+def test_full_page_means_the_whole_page(scatti):
+    """It was never read by the driver, so it returned the viewport."""
+    out = scatti[0]
+    # 1600 and not 800: the document is wider than the viewport, and taking
+    # the viewport width here would be the same defect on the other axis.
+    assert _size(out / "intera.png") == (1600, 4000), (
+        "full_page returned %s; the document is 1600x4000" % (
+            _size(out / "intera.png"),))
+    assert _first_rows(out / "intera.png", 1)[0][400] == (255, 255, 255)
+
+
+@pytest.mark.e2e
+def test_a_clip_the_caller_gave_is_left_alone(scatti):
+    """Playwright documents `clip` in page coordinates, which is what the engine
+    wants, so there is nothing to translate - and the fix must not start
+    translating it. Known-bad: adding the scroll offset to a caller's clip,
+    which would move this crop 1000px down onto the black."""
+    out = scatti[0]
+    assert _size(out / "ritagliata.png") == (400, 200)
+    assert _first_rows(out / "ritagliata.png", 1)[0][200] == ROSSO
+
+
+@pytest.mark.e2e
+def test_it_follows_a_sideways_scroll_too(scatti):
+    """The fix reads `window.scrollX` as well, and nothing was checking it.
+
+    Found by mutation: replacing `x: box["x"]` with `x: 0` left every other
+    test in this file green, because none of them scrolled sideways. A green
+    suite that cannot see half of a two-line fix is measuring one line.
+    """
+    out, _, _, dove = scatti
+    assert dove > 0, "the page did not scroll sideways at all"
+    assert _size(out / "di-lato.png") == (800, 600)
+    # The green column lives at document x 1400..1600, so in an image taken
+    # at scrollX `dove` it starts at 1400 - dove. Computed, not guessed.
+    x = 1400 - dove + 100
+    assert 0 <= x < 800, "the column is not in this viewport (scrollX=%d)" % dove
+    riga = _first_rows(out / "di-lato.png", 1)[0]
+    assert riga[x] == VERDE, (
+        "at image x=%d the colour is %s, not the green column that sits there "
+        "when the viewport is at scrollX=%d - the screenshot ignored the "
+        "horizontal scroll" % (x, riga[x], dove))

--- a/tests/test_screenshot_looks_where_you_are.py
+++ b/tests/test_screenshot_looks_where_you_are.py
@@ -40,13 +40,13 @@ import pytest
 # White down to 1000, one RED band 1000..1200, black to 4000, and a GREEN
 # column at x=1400 so the same trick works sideways. Reading the colour at a
 # known place in the image says which part of the document it came from.
-ROSSO = (204, 0, 0)
-VERDE = (0, 170, 0)
+RED = (204, 0, 0)
+GREEN = (0, 170, 0)
 PAGE = b"""<!doctype html><html><body style="margin:0">
 <div style="height:1000px;background:#fff"></div>
 <div id="band" style="height:200px;background:#c00"></div>
 <div style="height:2800px;background:#000"></div>
-<div id="colonna" style="position:absolute;top:0;left:1400px;width:200px;height:600px;background:#0a0"></div>
+<div id="column" style="position:absolute;top:0;left:1400px;width:200px;height:600px;background:#0a0"></div>
 </body></html>"""
 
 
@@ -95,44 +95,44 @@ def _first_rows(path, rows: int = 4) -> list:
     assert raw[:8] == b"\x89PNG\r\n\x1a\n"
     width, height, depth, colour = struct.unpack(">IIBB", raw[16:26])
     assert depth == 8, "expected 8 bits per channel, got %d" % depth
-    canali = {2: 3, 6: 4, 0: 1}.get(colour)
-    assert canali, "unsupported PNG colour type %d" % colour
+    channels = {2: 3, 6: 4, 0: 1}.get(colour)
+    assert channels, "unsupported PNG colour type %d" % colour
 
-    dati, i = b"", 8
+    data, i = b"", 8
     while i < len(raw):
-        lung, tipo = struct.unpack(">I4s", raw[i:i + 8])
-        if tipo == b"IDAT":
-            dati += raw[i + 8:i + 8 + lung]
-        elif tipo == b"IEND":
+        length, kind = struct.unpack(">I4s", raw[i:i + 8])
+        if kind == b"IDAT":
+            data += raw[i + 8:i + 8 + length]
+        elif kind == b"IEND":
             break
-        i += 12 + lung
-    grezzo = zlib.decompress(dati)
+        i += 12 + length
+    unpacked = zlib.decompress(data)
 
-    passo = width * canali
-    sopra = bytearray(passo)
-    fuori = []
+    stride = width * channels
+    prior = bytearray(stride)
+    out = []
     for r in range(min(rows, height)):
-        base = r * (passo + 1)
-        filtro = grezzo[base]
-        riga = bytearray(grezzo[base + 1:base + 1 + passo])
-        for x in range(passo):
-            a = riga[x - canali] if x >= canali else 0
-            b = sopra[x]
-            c = sopra[x - canali] if x >= canali else 0
-            if filtro == 1:
-                riga[x] = (riga[x] + a) & 0xFF
-            elif filtro == 2:
-                riga[x] = (riga[x] + b) & 0xFF
-            elif filtro == 3:
-                riga[x] = (riga[x] + (a + b) // 2) & 0xFF
-            elif filtro == 4:
+        base = r * (stride + 1)
+        filt = unpacked[base]
+        row = bytearray(unpacked[base + 1:base + 1 + stride])
+        for x in range(stride):
+            a = row[x - channels] if x >= channels else 0
+            b = prior[x]
+            c = prior[x - channels] if x >= channels else 0
+            if filt == 1:
+                row[x] = (row[x] + a) & 0xFF
+            elif filt == 2:
+                row[x] = (row[x] + b) & 0xFF
+            elif filt == 3:
+                row[x] = (row[x] + (a + b) // 2) & 0xFF
+            elif filt == 4:
                 p = a + b - c
                 pa, pb, pc = abs(p - a), abs(p - b), abs(p - c)
                 pr = a if (pa <= pb and pa <= pc) else (b if pb <= pc else c)
-                riga[x] = (riga[x] + pr) & 0xFF
-        sopra = riga
-        fuori.append([tuple(riga[x:x + 3]) for x in range(0, passo, canali)])
-    return fuori
+                row[x] = (row[x] + pr) & 0xFF
+        prior = row
+        out.append([tuple(row[x:x + 3]) for x in range(0, stride, channels)])
+    return out
 
 
 def test_the_png_reader_reads(tmp_path):
@@ -141,27 +141,27 @@ def test_the_png_reader_reads(tmp_path):
     import base64
 
     # 2x1, left pixel red, right pixel black, written by hand
-    dati = zlib.compress(bytes([0, 204, 0, 0, 0, 0, 0]))
+    data = zlib.compress(bytes([0, 204, 0, 0, 0, 0, 0]))
     png = (b"\x89PNG\r\n\x1a\n"
            + _chunk(b"IHDR", struct.pack(">IIBBBBB", 2, 1, 8, 2, 0, 0, 0))
-           + _chunk(b"IDAT", dati) + _chunk(b"IEND", b""))
-    f = tmp_path / "due.png"
+           + _chunk(b"IDAT", data) + _chunk(b"IEND", b""))
+    f = tmp_path / "two.png"
     f.write_bytes(png)
     assert _size(f) == (2, 1)
-    assert _first_rows(f, 1)[0] == [ROSSO, (0, 0, 0)]
+    assert _first_rows(f, 1)[0] == [RED, (0, 0, 0)]
 
 
-def _chunk(tipo: bytes, corpo: bytes) -> bytes:
-    return (struct.pack(">I", len(corpo)) + tipo + corpo
-            + struct.pack(">I", zlib.crc32(tipo + corpo) & 0xFFFFFFFF))
+def _chunk(kind: bytes, payload: bytes) -> bytes:
+    return (struct.pack(">I", len(payload)) + kind + payload
+            + struct.pack(">I", zlib.crc32(kind + payload) & 0xFFFFFFFF))
 
 
 @pytest.fixture(scope="module")
-def scatti(tmp_path_factory, firefox_binary):
+def shots(tmp_path_factory, firefox_binary):
     """One browser, four photographs, so the assertions cost nothing after."""
     from invisible_playwright import InvisiblePlaywright
 
-    out = tmp_path_factory.mktemp("scatti")
+    out = tmp_path_factory.mktemp("shots")
     srv, url = _serve()
     try:
         with InvisiblePlaywright(seed=4242, binary_path=firefox_binary,
@@ -169,14 +169,14 @@ def scatti(tmp_path_factory, firefox_binary):
             page = browser.new_context(
                 viewport={"width": 800, "height": 600}).new_page()
             page.goto(url, wait_until="load", timeout=30_000)
-            alto = page.evaluate("() => document.documentElement.scrollHeight")
+            tall = page.evaluate("() => document.documentElement.scrollHeight")
 
-            page.screenshot(path=str(out / "cima.png"))
-            page.screenshot(path=str(out / "intera.png"), full_page=True)
+            page.screenshot(path=str(out / "top.png"))
+            page.screenshot(path=str(out / "whole.png"), full_page=True)
             page.evaluate("() => window.scrollTo(0, 1000)")
             page.wait_for_timeout(300)
-            page.screenshot(path=str(out / "scorsa.png"))
-            page.screenshot(path=str(out / "ritagliata.png"),
+            page.screenshot(path=str(out / "scrolled.png"))
+            page.screenshot(path=str(out / "clipped.png"),
                             clip={"x": 0, "y": 1000, "width": 400, "height": 200})
             # ⛔ scrollTo is CLAMPED to the maximum: asking for 1400 on a
             # 1600px document in an 800px viewport lands on 800. The test
@@ -184,86 +184,86 @@ def scatti(tmp_path_factory, firefox_binary):
             # is the same mistake in miniature as the defect it covers.
             page.evaluate("() => window.scrollTo(1400, 0)")
             page.wait_for_timeout(300)
-            dove = page.evaluate("() => Math.round(window.scrollX)")
-            page.screenshot(path=str(out / "di-lato.png"))
-            largo = page.evaluate(
+            landed = page.evaluate("() => Math.round(window.scrollX)")
+            page.screenshot(path=str(out / "sideways.png"))
+            wide = page.evaluate(
                 "() => document.documentElement.scrollWidth")
-            yield out, alto, largo, dove
+            yield out, tall, wide, landed
     finally:
         srv.shutdown()
 
 
 @pytest.mark.e2e
-def test_the_page_is_the_shape_the_test_believes(scatti):
+def test_the_page_is_the_shape_the_test_believes(shots):
     """Otherwise every assertion below is about a document of another shape."""
-    _, alto, largo, _ = scatti
-    assert (largo, alto) == (1600, 4000), (
-        "the fixture page is %dx%d, not 1600x4000" % (largo, alto))
+    _, tall, wide, _ = shots
+    assert (wide, tall) == (1600, 4000), (
+        "the fixture page is %dx%d, not 1600x4000" % (wide, tall))
 
 
 @pytest.mark.e2e
-def test_an_unscrolled_screenshot_is_the_top_of_the_page(scatti):
-    out = scatti[0]
-    assert _size(out / "cima.png") == (800, 600)
-    assert _first_rows(out / "cima.png", 1)[0][400] == (255, 255, 255)
+def test_an_unscrolled_screenshot_is_the_top_of_the_page(shots):
+    out = shots[0]
+    assert _size(out / "top.png") == (800, 600)
+    assert _first_rows(out / "top.png", 1)[0][400] == (255, 255, 255)
 
 
 @pytest.mark.e2e
-def test_after_scrolling_it_photographs_where_you_scrolled_to(scatti):
+def test_after_scrolling_it_photographs_where_you_scrolled_to(shots):
     """The one that was broken, and the only test here that a size cannot pass.
 
     At scrollY 1000 the viewport starts exactly on the red band, so the top row
     is red. Before the fix this image was white: a correctly sized picture of
     the wrong place.
     """
-    out = scatti[0]
-    assert _size(out / "scorsa.png") == (800, 600)
-    riga = _first_rows(out / "scorsa.png", 1)[0]
-    assert riga[400] == ROSSO, (
+    out = shots[0]
+    assert _size(out / "scrolled.png") == (800, 600)
+    row = _first_rows(out / "scrolled.png", 1)[0]
+    assert row[400] == RED, (
         "the top of the image is %s, not the red band the viewport is sitting "
-        "on - the screenshot ignored the scroll" % (riga[400],))
+        "on - the screenshot ignored the scroll" % (row[400],))
 
 
 @pytest.mark.e2e
-def test_full_page_means_the_whole_page(scatti):
+def test_full_page_means_the_whole_page(shots):
     """It was never read by the driver, so it returned the viewport."""
-    out = scatti[0]
+    out = shots[0]
     # 1600 and not 800: the document is wider than the viewport, and taking
     # the viewport width here would be the same defect on the other axis.
-    assert _size(out / "intera.png") == (1600, 4000), (
+    assert _size(out / "whole.png") == (1600, 4000), (
         "full_page returned %s; the document is 1600x4000" % (
-            _size(out / "intera.png"),))
-    assert _first_rows(out / "intera.png", 1)[0][400] == (255, 255, 255)
+            _size(out / "whole.png"),))
+    assert _first_rows(out / "whole.png", 1)[0][400] == (255, 255, 255)
 
 
 @pytest.mark.e2e
-def test_a_clip_the_caller_gave_is_left_alone(scatti):
+def test_a_clip_the_caller_gave_is_left_alone(shots):
     """Playwright documents `clip` in page coordinates, which is what the engine
     wants, so there is nothing to translate - and the fix must not start
     translating it. Known-bad: adding the scroll offset to a caller's clip,
     which would move this crop 1000px down onto the black."""
-    out = scatti[0]
-    assert _size(out / "ritagliata.png") == (400, 200)
-    assert _first_rows(out / "ritagliata.png", 1)[0][200] == ROSSO
+    out = shots[0]
+    assert _size(out / "clipped.png") == (400, 200)
+    assert _first_rows(out / "clipped.png", 1)[0][200] == RED
 
 
 @pytest.mark.e2e
-def test_it_follows_a_sideways_scroll_too(scatti):
+def test_it_follows_a_sideways_scroll_too(shots):
     """The fix reads `window.scrollX` as well, and nothing was checking it.
 
     Found by mutation: replacing `x: box["x"]` with `x: 0` left every other
     test in this file green, because none of them scrolled sideways. A green
     suite that cannot see half of a two-line fix is measuring one line.
     """
-    out, _, _, dove = scatti
-    assert dove > 0, "the page did not scroll sideways at all"
-    assert _size(out / "di-lato.png") == (800, 600)
+    out, _, _, landed = shots
+    assert landed > 0, "the page did not scroll sideways at all"
+    assert _size(out / "sideways.png") == (800, 600)
     # The green column lives at document x 1400..1600, so in an image taken
-    # at scrollX `dove` it starts at 1400 - dove. Computed, not guessed.
-    x = 1400 - dove + 100
-    assert 0 <= x < 800, "the column is not in this viewport (scrollX=%d)" % dove
-    riga = _first_rows(out / "di-lato.png", 1)[0]
-    assert riga[x] == VERDE, (
+    # at scrollX `landed` it starts at 1400 - landed. Computed, not guessed.
+    x = 1400 - landed + 100
+    assert 0 <= x < 800, "the column is not in this viewport (scrollX=%d)" % landed
+    row = _first_rows(out / "sideways.png", 1)[0]
+    assert row[x] == GREEN, (
         "at image x=%d the colour is %s, not the green column that sits there "
         "when the viewport is at scrollX=%d - the screenshot ignored the "
-        "horizontal scroll" % (x, riga[x], dove))
+        "horizontal scroll" % (x, row[x], landed))


### PR DESCRIPTION
Found by looking, not by reading. Asked to open a README in a browser and actually look at it, I scrolled to the part I wanted and took a picture, and the picture was the top of the page: `scrollY` 3000, the target element at y=0 in the viewport, and the image showing the document's first screen.

One line. `op_screenshot` built its clip as `{x: 0, y: 0, width: innerWidth, height: innerHeight}`. The engine reads a clip in DOCUMENT coordinates, so that is not the viewport - it is the document's top-left corner, at viewport size. Two promises broke on it, both silently, both returning a valid image of the wrong place:

- **Scrolling did nothing.** An agent that scrolls and looks got the same picture every time, with nothing in the image to say so. That is what `browser_take_screenshot` does in the MCP server, and rung 3 of the ladder that server hands every model is "take a screenshot, then click on what you can see" - so the server was recommending a step that could not work.
- **`fullPage` was never read by the driver.** 800x600 on a document asked for at 800x4000.

Fixed where it comes from: the clip is computed from the page, either where the viewport actually is or how big the document actually is. A clip the CALLER supplies passes through untouched, because Playwright documents it in page coordinates already.

Six tests, and they read PIXELS. A size proves the crop has the right shape, and the defect was a right-shaped crop of the wrong place, so the fixture page has a red band at y=1000 and a green column at x=1400 and the assertions ask what colour came back. The PNG reader is thirty lines of zlib rather than adding Pillow to the dev extras so one test can read one pixel.

Six mutations, six killed. The first round had one survivor - the horizontal axis, because nothing scrolled sideways. I had labelled it as expected to survive, which is a polite way of saying half a two-axis fix was untested. It is covered now.

Two of my assertions were wrong rather than the code, and both are better for it: adding the green column made the document 1600 wide, so `full_page` correctly answered 1600x4000 while the test demanded 800x4000; and `scrollTo(1400, 0)` is clamped to 800 in an 800px viewport, so I was reading the wrong pixel. The test reads `scrollX` back and computes from it now instead of assuming.

**The vendored upstream suite could not have caught this.** It is excluded from collection by `norecursedirs`, but that is the smaller half: its `test_screenshot.py` has three tests - mask, inferring type from path, the type argument - and neither `fullPage` nor scrolling is among them.