### PR TITLE
The engine's front page now names the agent that sits on it

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -22,6 +22,10 @@ the thing it describes, and several of them record something we got wrong first.
 - **[Integrations](integrations/)** - running this inside Scrapy, Crawlee, Robot
   Framework, CodeceptJS, test runners and Playwright MCP, including which frameworks
   it does not fit and why.
+- **[The agent on top](https://github.com/feder-cr/AIHawk/wiki)** - this engine also
+  drives [AIHawk](https://github.com/feder-cr/AIHawk), an AI agent you instruct in
+  plain language; its wiki covers the agent layer the way this one covers the
+  browser: comparisons, blocked agents, and task guides.
 
 ## If you don't know where to start
 

--- a/docs/why-blocked-with-a-clean-fingerprint.md
+++ b/docs/why-blocked-with-a-clean-fingerprint.md
@@ -188,6 +188,9 @@ supply a clean IP, human pacing, and session reuse for the layers a browser cann
 **See also:** [the full detection checklist in working order](playwright-detected-as-bot.md),
 [how to test whether the browser itself is the problem](how-to-test-bot-detection.md), and
 [rate limiting your scraper so volume stops being the signal](how-to-rate-limit-your-scraper-playwright.md).
+If the traffic is produced by an AI agent rather than a script, the pacing and
+retry layers have their own failure modes, mapped on the AIHawk wiki:
+[why does my AI agent get blocked?](https://github.com/feder-cr/AIHawk/wiki/why-does-my-ai-agent-get-blocked)
 
 ---
 


### PR DESCRIPTION
## Summary

Two surgical links from the engine wiki to the agent wiki, in the two places an agent-audience reader actually lands.

The front page's "Where to go" list gains one bullet naming AIHawk as the agent this engine drives, pointing at its wiki the same way the AIHawk wiki's "layer underneath" section points here - the two properties now reference each other in both directions instead of one.

The clean-fingerprint page (one of the set's strongest) gains one sentence in its See-also: a reader whose traffic comes from an AI agent loop gets sent to the agent-layer map on the AIHawk wiki, where the pacing and retry failure modes live since the perimeter split.

Seven lines total, no template pattern, no other pages touched.

## Test plan

- [x] check_english_only.py clean; zero em-dashes; forbidden-names scanner clean (671 files)
- [x] Both target pages exist live on the AIHawk wiki (verified this session)
- [x] git show --stat read: 2 files, 7 insertions

Generated with Claude Code
