### PR TITLE
Twelve pages stop shipping code that cannot run as pasted, and two claims catch up with their sources

### DIFF
--- a/docs/automating-email-otp-verification-login-playwright.md
+++ b/docs/automating-email-otp-verification-login-playwright.md
@@ -80,6 +80,15 @@ import re
 import ssl
 import time
 
+def extract_text(msg):
+    # the plain-text part of a possibly multipart message
+    if msg.is_multipart():
+        for part in msg.walk():
+            if part.get_content_type() == "text/plain":
+                return part.get_payload(decode=True).decode(errors="replace")
+        return ""
+    return msg.get_payload(decode=True).decode(errors="replace")
+
 def fetch_code_from_inbox(sent_at, timeout_s=60, poll_every_s=2):
     ctx = ssl.create_default_context()
     deadline = time.time() + timeout_s

--- a/docs/automating-totp-2fa-login-playwright.md
+++ b/docs/automating-totp-2fa-login-playwright.md
@@ -135,6 +135,8 @@ target application's enrollment page shows different values, in an advanced setu
 screen or in the raw `otpauth://` URI, pass them explicitly:
 
 ```python
+import hashlib
+
 totp = pyotp.TOTP(secret, digits=8, digest=hashlib.sha256, interval=60)
 ```
 

--- a/docs/aws-waf-bot-control-explained.md
+++ b/docs/aws-waf-bot-control-explained.md
@@ -50,7 +50,7 @@ A sample of named rules, quoted from AWS's own rule listing, gives a concrete se
 
 The token-reuse family is worth pausing on: it does not ask whether any single request looks automated, it asks whether one browser's proof-of-legitimacy is being shared across more devices, networks or countries than a single real session plausibly touches in five minutes. That is a detection axis with no fingerprint answer at all, honest or otherwise, because the thing being scored is reuse across sessions, not any property of one session's browser.
 
-AWS is also explicit about a category it treats differently from everything above: a maintained list of roughly 1,400 verified bots (AWS calls this "Akamai-style" verification the same idea by a different name; search engine crawlers, monitoring services, SEO tools) that Bot Control identifies and does not block, adding a `bot:verified` label plus category and organization labels instead. A newer addition, **Web Bot Authentication**, lets a bot cryptographically sign its requests against a public key directory; a verified signature (`web_bot_auth:verified`) causes the category-block and `TGT_TokenAbsent` rules to skip that request entirely, a mechanism for bots that want to identify themselves honestly and be let through rather than evade detection.
+AWS is also explicit about a category it treats differently from everything above: a maintained list of verified bots (search engine crawlers, monitoring services, SEO tools) that Bot Control identifies and does not block, adding a `bot:verified` label plus category and organization labels instead. A newer addition, **Web Bot Authentication**, lets a bot cryptographically sign its requests against a public key directory; a verified signature (`web_bot_auth:verified`) causes the category-block and `TGT_TokenAbsent` rules to skip that request entirely, a mechanism for bots that want to identify themselves honestly and be let through rather than evade detection.
 
 ## What an engine answers honestly, and what a browser cannot touch
 
@@ -70,7 +70,7 @@ Several rule families sit entirely outside what any browser engine can affect. `
 
 **What is token reuse, and why does it matter?** The same proof-of-legitimacy token appearing across multiple IPs, countries, or ASNs within a five-minute window. It is a detection axis with no browser-level answer, because it scores how a token is being shared, not what any individual session's browser does.
 
-**Does Bot Control block search engines and other known-good bots?** No. AWS maintains a verified-bot list (~1,400 entries) that gets labeled and passed rather than blocked, and a newer cryptographic mechanism, Web Bot Authentication, lets a bot sign requests to prove its identity instead of being challenged.
+**Does Bot Control block search engines and other known-good bots?** No. AWS maintains a verified-bot list that gets labeled and passed rather than blocked, and a newer cryptographic mechanism, Web Bot Authentication, lets a bot sign requests to prove its identity instead of being challenged.
 
 **Does a real browser engine defeat AWS WAF Bot Control?** It answers the automation-signature and browser-consistency rules honestly, which removes that whole failure class. It has no bearing on IP/data-center signals, token-reuse-across-sessions rules, or the ML-based coordinated-activity detection, all of which operate above the level of any single browser.
 

--- a/docs/err-proxy-connection-failed-playwright.md
+++ b/docs/err-proxy-connection-failed-playwright.md
@@ -25,9 +25,10 @@ commonly over bad credentials or a destination it will not forward to.
 `ERR_PROXY_CONNECTION_FAILED` fires earlier and more broadly: the browser never
 managed to open a TCP socket to the proxy at all, whether the destination is HTTP or
 HTTPS, whether authentication was ever going to be needed, before any `CONNECT`
-exchange is possible. Chromium's own numbering reflects the ordering: `-130` for
-`ERR_PROXY_CONNECTION_FAILED`, `-111` for `ERR_TUNNEL_CONNECTION_FAILED`, a
-lower-level failure assigned a separate, earlier code on purpose.
+exchange is possible. Chromium keeps them as two distinct codes for exactly
+that reason: `-130` for `ERR_PROXY_CONNECTION_FAILED`, `-111` for
+`ERR_TUNNEL_CONNECTION_FAILED` - one failure before any `CONNECT`, one during
+it.
 
 If you see `ERR_TUNNEL_CONNECTION_FAILED`, the proxy is reachable and rejected one
 specific request. If you see `ERR_PROXY_CONNECTION_FAILED`, the proxy was never
@@ -145,7 +146,7 @@ fingerprint or engine-identity layer this project touches.
 ## Sources
 
 - Chromium's [`net/base/net_error_list.h`](https://chromium.googlesource.com/chromium/src/+/main/net/base/net_error_list.h),
-  for the exact definitions of `ERR_PROXY_CONNECTION_FAILED` (-130) and the earlier,
+  for the exact definitions of `ERR_PROXY_CONNECTION_FAILED` (-130) and the
   distinct `ERR_TUNNEL_CONNECTION_FAILED` (-111), retrieved 2026-08-30.
 - [microsoft/playwright#9437](https://github.com/microsoft/playwright/issues/9437),
   a real report of this exact error from a `server: "per-context"` proxy launch

--- a/docs/err-tunnel-connection-failed-playwright.md
+++ b/docs/err-tunnel-connection-failed-playwright.md
@@ -24,9 +24,10 @@ established` if the proxy agrees. Only then does the actual TLS handshake happen
 inside that tunnel. `ERR_TUNNEL_CONNECTION_FAILED` fires when the CONNECT exchange
 itself fails, before any TLS or HTTP traffic to the destination exists.
 
-Chromium's own error list, which Firefox-under-Playwright inherits at the network-stack
-naming level, defines it plainly: "a tunnel connection through the proxy could not be
-established." The adjacent code, `ERR_PROXY_CONNECTION_FAILED`, is earlier and
+Chromium's own error list defines it plainly: "a tunnel connection through the
+proxy could not be established." (The name is Chromium's; Firefox's network
+stack spells the same family of failures as `NS_ERROR_*` codes, and this page
+uses the Chromium name because it is the one people search for.) The adjacent code, `ERR_PROXY_CONNECTION_FAILED`, is earlier and
 different: it means the browser could not even open a TCP connection to the proxy
 itself. `ERR_TUNNEL_CONNECTION_FAILED` means the browser did reach the proxy, and the
 CONNECT for this specific destination is what failed. That distinction rules out "the

--- a/docs/how-to-scrape-class-schedules-playwright.md
+++ b/docs/how-to-scrape-class-schedules-playwright.md
@@ -193,6 +193,17 @@ responses mid-scrape](how-to-handle-403-429-backoff-mid-scrape-playwright.md).
 ```python
 from datetime import timedelta
 
+def read_row(row, week_start):
+    # the same shape as the first block, plus the week it came from
+    return {
+        "occurrence_id": row.get_attribute("data-occurrence-id"),
+        "class_name": row.locator(".class-name").inner_text(),
+        "instructor": row.locator(".instructor").inner_text(),
+        "room": row.locator(".room").inner_text(),
+        "start_time": row.get_attribute("data-start-iso"),
+        "week_start": week_start.isoformat(),
+    }
+
 def pull_weeks(page, base_url, studio, start_week, max_weeks=8):
     all_classes = []
     for week_offset in range(max_weeks):
@@ -279,8 +290,8 @@ def scrape_schedule(studio, start_week, max_weeks=4):
     with InvisiblePlaywright(seed=42) as browser:
         page = browser.new_page()
 
-        capacities = {}
-        page.on("response", lambda r: on_response(r, capacities))
+        capacities.clear()   # the module-level store the listener writes into
+        page.on("response", on_response)
 
         rows = pull_weeks(page, "https://example.com/schedule",
                            studio, start_week, max_weeks)

--- a/docs/how-to-scrape-delivery-slots-playwright.md
+++ b/docs/how-to-scrape-delivery-slots-playwright.md
@@ -194,9 +194,10 @@ changes rather than by how fast the machine can ask:
 ```python
 import time
 
-with sync_playwright() as p:
-    browser = p.firefox.launch()
-    page = browser.new_context().new_page()
+from invisible_playwright import InvisiblePlaywright
+
+with InvisiblePlaywright(seed=7) as browser:
+    page = browser.new_page()
     for postcode in POSTCODES:
         set_postcode(page, postcode)
         rows.extend(read_all_weeks(page))

--- a/docs/how-to-scrape-insurance-quotes-playwright.md
+++ b/docs/how-to-scrape-insurance-quotes-playwright.md
@@ -229,7 +229,7 @@ with InvisiblePlaywright(seed=42) as browser:
             page.get_by_role("button", name="Get my quote").click()
         results.append(caught.value.json())
         page.close()
-        page.wait_for_timeout(rng.randint(4000, 11000))
+        time.sleep(rng.randint(4, 11))   # the page is closed; pause off it
 ```
 
 The pause between profiles is doing the same job the pause between clicks does

--- a/docs/how-to-scrape-live-sports-scores-playwright.md
+++ b/docs/how-to-scrape-live-sports-scores-playwright.md
@@ -163,7 +163,9 @@ around it. Validate the pairing, not the direction.
 
 ```python
 def apply_update(history, new_reading):
-    if history and new_reading["home"] < history[-1]["home"]:
+    # scores read off a page are strings, and "10" < "9" lexicographically:
+    # compare as numbers or every two-digit score reads as a decrease
+    if history and int(new_reading["home"]) < int(history[-1]["home"]):
         # a drop with no explanation is suspicious; a drop next to a review flag is not
         if not new_reading.get("var_review"):
             print("unexplained score decrease, flag for review:", new_reading)

--- a/docs/how-to-scrape-newsletter-archives-playwright.md
+++ b/docs/how-to-scrape-newsletter-archives-playwright.md
@@ -255,6 +255,8 @@ for a better date on newer issues, fetch each issue page, resolve its links thro
 cache, and merge the result into a keyed store instead of a flat list.
 
 ```python
+import feedparser
+
 def run(base_url, feed_url, browser):
     page = browser.new_page()
     context = page.context
@@ -281,7 +283,8 @@ def run(base_url, feed_url, browser):
         record.update(title_fields(page))
         record["resolved_links"] = [
             resolve_redirect(context, href, cache)
-            for href in page.locator("article a, .campaign-body a").all_attribute_values("href")
+            for href in page.locator("article a, .campaign-body a").evaluate_all(
+                "els => els.map(e => e.getAttribute('href'))")
             if href
         ]
         rows = merge_row(rows, record)

--- a/docs/how-to-scrape-recipe-data-playwright.md
+++ b/docs/how-to-scrape-recipe-data-playwright.md
@@ -150,7 +150,7 @@ VULGAR = {
     "⅓": "1/3", "⅔": "2/3",
     "⅛": "1/8", "⅜": "3/8", "⅝": "5/8", "⅞": "7/8",
 }
-DASHES = "‐‑‒--−"   # hyphen variants and minus sign
+DASHES = "\u2010\u2011\u2012\u2013\u2014-\u2212"   # hyphen variants, en/em dash, minus
 
 def normalise(text):
     text = text.replace("\xa0", " ").replace("⁄", "/")

--- a/docs/how-to-scrape-software-changelogs-playwright.md
+++ b/docs/how-to-scrape-software-changelogs-playwright.md
@@ -41,6 +41,10 @@ nearly always capped at the most recent entries.
 import re
 from invisible_playwright import InvisiblePlaywright
 
+# detect_shape leans on parse_version, defined in the "reading versions"
+# section below: when composing the page's blocks into one script, that
+# block goes above this one.
+
 def detect_shape(page):
     """Report every shape the page offers and let the caller choose."""
     feed = page.locator('link[rel="alternate"][type*="xml"]').first

--- a/docs/how-to-scrape-sortable-tables-playwright.md
+++ b/docs/how-to-scrape-sortable-tables-playwright.md
@@ -107,12 +107,14 @@ markup: a client-side sort produces no request at all, only a repaint, while a
 server-side sort fires a request you can catch mid-click.
 
 ```python
+from playwright.sync_api import TimeoutError as PlaywrightTimeout
+
 with page.expect_response(lambda r: r.request.method == "GET", timeout=2000) as caught:
     try:
         page.get_by_role("columnheader", name="Price").click()
         response = caught.value
         server_side = "sort" in response.url or "order" in response.url
-    except TimeoutError:
+    except PlaywrightTimeout:   # playwright.sync_api.TimeoutError, not the builtin
         server_side = False   # no matching request fired: this is a client-side sort
 ```
 

--- a/docs/how-to-scrape-warranty-terms-playwright.md
+++ b/docs/how-to-scrape-warranty-terms-playwright.md
@@ -148,6 +148,8 @@ Warranty pages change over time, and the page you read today shows the current r
 Pull the revision date the page states for itself and carry it as part of the row, so anything comparing a scraped term against a purchase date can check whether the two actually line up.
 
 ```python
+from datetime import datetime
+
 REVISION_RE = re.compile(
     r"(?:last updated|effective|revised)[:\s]+([A-Za-z]+ \d{1,2}, \d{4})",
     re.IGNORECASE,
@@ -162,7 +164,10 @@ def covers_purchase(document_date, purchase_date):
     # or postdate a given purchase, so treat it as unknown, not as current.
     if document_date is None:
         return None
-    return document_date <= purchase_date
+    # the regex hands back "Month D, YYYY" as text; parse before comparing,
+    # because "April 2, 2026" <= "March 1, 2020" is true as strings
+    parsed = datetime.strptime(document_date, "%B %d, %Y").date()
+    return parsed <= purchase_date
 ```
 
 A page with no visible revision date is common, and the honest answer in that case is "unknown," not a silent assumption that today's text always applied. Related dates and durations parsed elsewhere on the same page benefit from the same discipline; the mechanics for turning loose date and price text into comparable values are in [cleaning scraped prices and dates](how-to-clean-scraped-prices-and-dates-playwright.md).

--- a/docs/playwright-element-click-intercepted.md
+++ b/docs/playwright-element-click-intercepted.md
@@ -1,6 +1,6 @@
 ---
 title: "Playwright \"Subtree Intercepts Pointer Events\""
-description: "Something else is sitting on top of the element you asked Playwright to click. Reaching for force:true clicks through it instead of finding out what it is, and that gap is itself a real-user difference."
+description: "Something else is sitting on top of the element you asked Playwright to click. Reaching for force:true fires blind at the same spot instead of finding out what is there, and that gap is itself a real-user difference."
 parent: "Testing and Troubleshooting"
 grand_parent: "Guides"
 nav_order: 22
@@ -46,20 +46,20 @@ regardless of what is on top. It makes the error disappear and it does not make 
 obstruction disappear. Two things follow from that, and the second one matters
 specifically for a browser-automation project built around looking like a real user.
 
-First, mechanically: a forced click can land on an element that a real pointer physically
-cannot reach, because the thing intercepting it is still there and still rendered on top.
-Playwright's synthetic event bypasses the browser's own hit-testing to reach the
-underlying element directly. A real mouse click at that same screen coordinate would hit
-the overlay, not your target - so forcing the click doesn't just skip a check, it
-performs an interaction no person using that page could physically produce. Whatever
-handler fires as a result runs in a state the real UI was never designed to reach through
-a pointer at all.
+First, mechanically: `force` skips the check, not the browser. Playwright
+still delivers a real click at your target's coordinates, the browser's
+hit-testing still applies, and whatever sits on top at that point is what
+receives it. You have not reached your element; you have clicked the overlay
+blind. Whatever handler fires belongs to the obstruction - or to nothing -
+while your script carries on believing the button was pressed, which is how a
+forced click turns one visible failure into a silent wrong path.
 
-Second, and this is the part worth internalizing rather than skipping past: an action
-that cannot happen via a real cursor at that point in time is itself a signal, on any
-page instrumented to notice it. A click handler that fires without the coordinate ever
-having been reachable by a real pointer, or without the overlay's own dismiss logic
-having run first, is exactly the kind of behavioral inconsistency a page can check for
+Second, and this is the part worth internalizing rather than skipping past:
+clicking blind into an overlay is itself a tell, on any
+page instrumented to notice it. A cookie banner that gets clicked on its
+backdrop instead of its buttons, a modal whose own dismiss logic never ran
+before the flow continued underneath,
+is exactly the kind of behavioral inconsistency a page can check for
 independent of any browser fingerprint. `force: true` does not just risk clicking the
 wrong thing; it risks producing an interaction shape no genuine user session would ever
 generate.

--- a/docs/playwright-element-not-attached-to-dom.md
+++ b/docs/playwright-element-not-attached-to-dom.md
@@ -58,12 +58,12 @@ DOM at the moment the action runs rather than trusting whatever it found earlier
 ```python
 # fragile: element_handle is a snapshot, and a re-render invalidates it
 handle = page.query_selector("button.submit")
-await some_state_changing_call()
+some_state_changing_call()
 handle.click()          # may throw "not attached" if a re-render swapped the node
 
 # robust: the locator re-queries the live DOM at click time
 locator = page.locator("button.submit")
-await some_state_changing_call()
+some_state_changing_call()
 locator.click()          # resolves fresh, right before acting
 ```
 
@@ -93,7 +93,7 @@ assume React or Vue is the culprit:
 1. **Confirm you are using a `Locator`, not a stored `ElementHandle`.** This alone
    resolves most reports.
 2. **Search your code for `.element_handle()` or `element_handle=True`.** Anywhere a
-   handle is extracted and held past the next `await`, it can go stale.
+   handle is extracted and held past the next state-changing call, it can go stale.
 3. **Open a trace and step through the action.** Playwright's trace viewer shows the DOM
    at each step, so you can see the re-render happen rather than infer it.
 4. **Check whether the target is a framework component with a changing `key`.** A list

--- a/docs/vs-camoufox.md
+++ b/docs/vs-camoufox.md
@@ -12,8 +12,13 @@ invisible_playwright and Camoufox both compile Firefox from source and set the f
 in C++, so neither is stealthier in the abstract. The real difference is how each produces
 the identity: Camoufox rotates a fresh, plausible device per session, while
 invisible_playwright derives every field deterministically from one seed, so a failing run
-can be replayed exactly. Camoufox currently covers more surfaces, notably geolocation and
-`Intl`.
+can be replayed exactly. Camoufox covers more surfaces, notably geolocation and
+`Intl` - with one caveat its own README now states plainly (checked
+2026-09-04): after about a year's gap in maintenance, the project reports its
+detection results "have gone down in performance due to the base Firefox
+version and newly discovered fingerprint inconsistencies", and development has
+since resumed. The surface list still stands; the freshness behind it is what
+that note is about.
 
 Most comparisons in this space are between things that are not comparable: a page-level
 script against a patched binary, or a Chromium tool against a Firefox one. This one is
@@ -152,7 +157,9 @@ reading about.
 
 Working from the above rather than from claims:
 
-- **Need geolocation, or non-English `Intl` correctness?** Camoufox, today.
+- **Need geolocation, or non-English `Intl` correctness?** Camoufox covers
+  them and this project does not; weigh that against the maintenance-gap
+  note above, which is Camoufox's own.
 - **Need to replay a failing run exactly?** A seeded derivation gives you that by
   construction.
 - **Need a font surface that is identical on a container and a desktop?** The bundled


### PR DESCRIPTION
## Summary

A full editorial re-pass over the corpus (every page reviewed against the house rubric, volatile claims fact-checked against primary sources) surfaced seventeen findings; this PR fixes them all. Twelve are the worst class a how-to site can carry: code blocks that cannot run as pasted.

- Missing definitions and imports: `extract_text` now defined in the OTP inbox poller; `hashlib` imported in the TOTP override; `feedparser` imported in the newsletter-archive composer; `read_row` defined in the class-schedule walker (and the response listener's two signatures reconciled to one).
- Wrong API or semantics: `Locator.all_attribute_values` (does not exist) replaced with `evaluate_all`; `except TimeoutError` was catching the builtin instead of `playwright.sync_api.TimeoutError`, so the client-side-sort fallback could never fire; `wait_for_timeout` was being called on a page that had just been closed; a bare `sync_playwright()` block on the delivery-slots page now uses the engine like every other block in the corpus.
- Silent-wrong comparisons: live-sports scores and warranty revision dates were compared as strings ("10" < "9", and April sorts before March); both now parse before comparing.
- The recipe page's `DASHES` constant promised en-dash normalization its own characters did not deliver; it now covers U+2013/U+2014, spelled as escapes so the sample is copy-safe.
- Mechanism corrections: the click-intercepted page described `force:true` as bypassing hit-testing to reach the element underneath - it does the opposite: the click is delivered at the coordinates and the overlay receives it, which is a stronger version of the page's own argument. The tunnel-error page no longer claims Firefox inherits Chromium's error names. The proxy-error page's "-130 is earlier than -111" numerology is gone. The AWS WAF page loses a garbled parenthetical and an unverifiable bot-list count.
- Fact-check catches (primary sources, 2026-09-04): the Camoufox comparison now carries the maintenance-gap status note Camoufox's own README states, quoted and dated, in both the narrative and the how-to-choose list.

## Test plan

- [x] Every page reviewed in full by the audit pass; each fix re-read in context
- [x] english-only clean, zero em/en dashes across all docs, invisible-marks scan clean (681 files)
- [x] Forbidden-names clean on the pushed range
- [x] No page deleted, no links changed, wiki structure untouched

Generated with Claude Code
