### PR TITLE
Three twin pages stop sharing a title's intent, and the pairs the tracker cleared stay put

### DIFF
--- a/docs/how-to-scrape-live-sports-scores-playwright.md
+++ b/docs/how-to-scrape-live-sports-scores-playwright.md
@@ -19,7 +19,7 @@ score using the event's own minute, not the moment you happened to scrape. Do th
 have to guess the order of.
 
 This is a narrower problem than reading a scoreboard once or pulling post-match stats.
-[Scraping sports scores and stats](how-to-scrape-sports-scores-and-stats-playwright.md)
+[Scraping sports stats and box scores](how-to-scrape-sports-scores-and-stats-playwright.md)
 covers reading the feed transport itself, switching parsers between live and finished
 formats, and holding a long session without tripping a rate check. This page assumes you
 have already solved that part and asks the harder question underneath it: once you are
@@ -297,10 +297,10 @@ latency is what paid live-data feeds are built and sold to provide.
   returns a standard Playwright `Browser`. See [Quickstart](quickstart.md) and
   [Configuration](configuration.md).
 - This project's own sibling article on the transport layer underneath a live score,
-  [scraping sports scores and stats](how-to-scrape-sports-scores-and-stats-playwright.md),
+  [scraping sports stats and box scores](how-to-scrape-sports-scores-and-stats-playwright.md),
   for reading the WebSocket or polling XHR itself.
 
-**See also:** [scraping sports scores and stats](how-to-scrape-sports-scores-and-stats-playwright.md)
+**See also:** [scraping sports stats and box scores](how-to-scrape-sports-scores-and-stats-playwright.md)
 for reading the feed transport and holding the session, [capturing XHR and API
 responses](how-to-capture-xhr-api-responses-playwright.md) for the request-level
 mechanics both articles rely on, [rate-limiting your scraper](how-to-rate-limit-your-scraper-playwright.md)

--- a/docs/how-to-scrape-map-based-local-results-playwright.md
+++ b/docs/how-to-scrape-map-based-local-results-playwright.md
@@ -1,13 +1,13 @@
 ---
-title: "How to scrape map-based local results with Playwright"
-description: "Scrape map-based local results with Playwright: drive the viewport, capture the bounds-keyed XHR per step, and tile an area through an in-region proxy."
+title: "Scrape local business results from a map with Playwright"
+description: "Scrape local business results from a map with Playwright: drive the viewport, capture the bounds-keyed XHR per step, and tile the area through an in-region identity."
 parent: "Scraping with Playwright"
 grand_parent: "Guides"
 nav_order: 49
 ---
 
 
-# How to scrape map-based local results with Playwright
+# Scrape local business results from a map with Playwright
 
 A map-based results list is not a page of rows you can paginate. It is a projection of
 whatever falls inside the current latitude and longitude bounding box, and the list only

--- a/docs/how-to-scrape-map-based-search-playwright.md
+++ b/docs/how-to-scrape-map-based-search-playwright.md
@@ -263,7 +263,7 @@ return the same item more than once by design.
   [mouse](https://playwright.dev/python/docs/api/class-mouse) methods used here, all of
   which are stock, documented Playwright.
 
-**See also:** [capturing XHR and API responses](how-to-capture-xhr-api-responses-playwright.md)
+**See also:** [scraping local business results from a map](how-to-scrape-map-based-local-results-playwright.md) for the local-listing half of this shape, where the exit region has to match the area you are mapping, [capturing XHR and API responses](how-to-capture-xhr-api-responses-playwright.md)
 for the interception pattern this page points at the box request,
 [WebGL renderer strings](webgl-renderer-strings.md) for the graphics surface a map reads,
 and [the detection checklist](playwright-detected-as-bot.md) for when a clean fingerprint

--- a/docs/how-to-scrape-product-reviews-playwright.md
+++ b/docs/how-to-scrape-product-reviews-playwright.md
@@ -246,7 +246,7 @@ the widget in a real browser.
 - Our notes on deep single-session walks and why a seed-stable fingerprint keeps one
   identity across many sequential loads to the same endpoint.
 
-**See also:** [how to scrape reviews and ratings](how-to-scrape-reviews-and-ratings-playwright.md)
+**See also:** [how to scrape star ratings](how-to-scrape-reviews-and-ratings-playwright.md)
 for the star-rating and "read more" fields on each row, [how to scrape paginated pages with
 Playwright](how-to-scrape-paginated-pages-playwright.md) for the general page-turn pattern,
 [how to scrape infinite scroll pages](how-to-scrape-infinite-scroll-playwright.md) for review

--- a/docs/how-to-scrape-reviews-and-ratings-playwright.md
+++ b/docs/how-to-scrape-reviews-and-ratings-playwright.md
@@ -1,18 +1,21 @@
 ---
-title: "How to scrape reviews and ratings with Playwright"
-description: "Scrape star ratings hidden in aria-label or CSS fill-width, expand every per-review Read more, and page the load more XHR to its natural end with Playwright."
+title: "How to scrape star ratings with Playwright"
+description: "Scrape star ratings with Playwright: read the score from aria-label or CSS fill-width instead of the text, expand every per-review Read more, and page the load-more XHR to its natural end."
 parent: "Scraping with Playwright"
 grand_parent: "Guides"
 nav_order: 39
 ---
 
 
-# How to scrape reviews and ratings with Playwright
+# How to scrape star ratings with Playwright
 
-To scrape reviews and ratings with Playwright, read the star rating from its
+To scrape star ratings with Playwright, read the rating from its
 `aria-label` or CSS fill-width instead of its text, click each per-review "Read more"
 before you extract the body, and page the "load more" XHR until the DOM count stops
-rising. Those are the three fields a review page hides, and each one has a specific fix.
+rising. Those are the three fields a rating widget hides, and each one has a specific
+fix. This page is about the RATING surfaces; the review text itself, the tabbed
+widget that hides it and its own pagination are on
+[scraping product reviews](how-to-scrape-product-reviews-playwright.md).
 
 Review pages are built to be read by a person and to resist being read by a program,
 and they do it with the two fields you actually came for. The star rating is almost

--- a/docs/how-to-scrape-sports-scores-and-stats-playwright.md
+++ b/docs/how-to-scrape-sports-scores-and-stats-playwright.md
@@ -1,15 +1,15 @@
 ---
-title: "How to scrape sports scores and stats with Playwright"
-description: "Scrape live sports scores and stats with Playwright: read the score feed over a WebSocket, click each stat tab to trigger its XHR, and hold one long session."
+title: "How to scrape sports stats and box scores with Playwright"
+description: "Scrape sports stats and box scores with Playwright: read the data feed over its WebSocket, click each stat tab to trigger its XHR, and keep live and historical tables on separate parsers."
 parent: "Scraping with Playwright"
 grand_parent: "Guides"
 nav_order: 50
 ---
 
 
-# How to scrape sports scores and stats with Playwright
+# How to scrape sports stats and box scores with Playwright
 
-**To scrape sports scores and stats with Playwright, read the data feed instead of
+**To scrape sports stats and box scores with Playwright, read the data feed instead of
 the rendered widget: subscribe to the WebSocket (or the polling XHR) that carries the
 score, click each stat tab to trigger the request that loads its panel, route live and
 finished-match data to separate parsers, and hold one seed-pinned session at a human


### PR DESCRIPTION
## Summary

The cannibalization audit flagged three Critical pairs among the new scrape pages: twins whose titles aimed at the same query while their bodies already taught different things. The fix is the cheap, safe kind: the slugs never move, the titles catch up with the content.

- `how-to-scrape-reviews-and-ratings-playwright` is now **"How to scrape star ratings with Playwright"** - its body was always about the rating surfaces (aria-label, CSS fill-width, read-more, load-more), and its twin keeps the review-text ground.
- `how-to-scrape-sports-scores-and-stats-playwright` is now **"How to scrape sports stats and box scores with Playwright"** - it was already the transport-and-stats half (WebSocket feed, stat tabs, historical tables) and even declared the split in its own intro; the live-semantics twin keeps "live sports scores".
- `how-to-scrape-map-based-local-results-playwright` is now **"Scrape local business results from a map with Playwright"** - the local-listing, region-identity half; the generic viewport-gridding twin keeps "map-based search".

Descriptions, H1s and openings follow the new titles; every reciprocal anchor on the twins is updated, and the one missing twin link (map-based-search had none) is added.

The rest of the audit's flags on this wiki were resolved by the rank tracker rather than by edits: the detected-as-bot/script-blocked and detectable/leave-traces pairs each rank on DIFFERENT queries (#6+#1 and #2+#1), which is multi-SERP coverage doing its job, and every remaining pair has at least one untracked side - no evidence, no touch.

## Test plan

- [x] Slugs unchanged - zero URL moves, zero redirects needed
- [x] english-only clean, dash scan clean on all six touched pages, forbidden-names clean on the range
- [x] Every twin pair now cross-links in both directions with anchors matching the new titles

Generated with Claude Code
