### PR TITLE
Two launch gates stop calling the removed path command

### DIFF
--- a/.github/workflows/firefox-launch-matrix.yml
+++ b/.github/workflows/firefox-launch-matrix.yml
@@ -13,7 +13,7 @@ name: firefox-launch-matrix
 # cache is content-keyed (Cache/<tag>_<version>_<buildid>/), so every cell failed
 # with NOT FOUND - a failure that looked exactly like the bug under investigation
 # and was not. Nine red cells read as "reproduced everywhere". The path now comes
-# from `python -m invisible_playwright path`, the only thing that knows it.
+# from the last line of `fetch`, the command that verifies the sealed tree.
 
 on:
   workflow_dispatch:
@@ -82,23 +82,36 @@ jobs:
           pip install .
 
       - name: Fetch the sealed binary
-        run: python -m invisible_playwright fetch
+        shell: pwsh
+        run: |
+          $fetchOutput = @(python -m invisible_playwright fetch)
+          $fetchExit = $LASTEXITCODE
+          $fetchOutput | ForEach-Object { Write-Host $_ }
+          if ($fetchExit -ne 0) {
+              exit $fetchExit
+          }
+          $ffPath = [string]($fetchOutput | Select-Object -Last 1)
+          $ffPath = $ffPath.Trim()
+          if (-not $ffPath -or -not (Test-Path $ffPath)) {
+              Write-Error "fetch reported no firefox.exe at '$ffPath'"
+              exit 1
+          }
+          "FF_PATH=$ffPath" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
 
       - name: Verify firefox.exe can launch standalone
         shell: pwsh
         run: |
-          # ASK for the path, never rebuild it. The cache directory is keyed on
-          # tag + base version + BuildID, so any string assembled here is a second
-          # copy of a naming rule that has already moved once - and when it drifts
-          # the step fails with NOT FOUND, which is indistinguishable from the
-          # launch bug this job exists to detect.
-          $ffPath = (python -m invisible_playwright path).Trim()
+          # CARRY the path from fetch, never rebuild it. The cache directory is
+          # keyed on tag + base version + BuildID, so any string assembled here
+          # is a second copy of a naming rule that has already moved once - and
+          # when it drifts the step fails with NOT FOUND, indistinguishable from
+          # the launch bug this job exists to detect.
+          $ffPath = $env:FF_PATH
           Write-Host "Package reports: $ffPath"
           if (-not $ffPath -or -not (Test-Path $ffPath)) {
-              Write-Error "firefox.exe NOT FOUND at '$ffPath' (reported by the package)"
+              Write-Error "firefox.exe NOT FOUND at '$ffPath' (reported by fetch)"
               exit 1
           }
-          "FF_PATH=$ffPath" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
           Write-Host "Launching: $ffPath --version"
           # NOTE: firefox.exe --version on Windows prints the version but may
           # return non-zero exit code (sub-process fork quirk). Check stdout.

--- a/.github/workflows/webrtc-e2e.yml
+++ b/.github/workflows/webrtc-e2e.yml
@@ -49,10 +49,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
 
-      - name: Fetch the patched Firefox binary
-        run: python -m invisible_playwright fetch
-
-      - name: Resolve binary path
+      - name: Fetch the patched Firefox binary and expose its path
         shell: bash
         run: |
           # NOT `echo "VAR=$(cmd)" >> $GITHUB_ENV`. echo exits 0 whatever the
@@ -61,9 +58,11 @@ jobs:
           # `pytest.skip("no patched binary")`, pytest exits 0, and the job is
           # green having verified nothing - which is exactly what run #1 did.
           set -euo pipefail
-          BIN="$(python -m invisible_playwright path)"
+          FETCH_OUTPUT="$(python -m invisible_playwright fetch)"
+          printf '%s\n' "$FETCH_OUTPUT"
+          BIN="$(printf '%s\n' "$FETCH_OUTPUT" | tail -n 1)"
           if [ -z "$BIN" ] || [ ! -e "$BIN" ]; then
-            echo "invisible_playwright path returned '$BIN', which is not a" >&2
+            echo "invisible_playwright fetch returned '$BIN', which is not a" >&2
             echo "file. Refusing to run a suite that would skip itself green." >&2
             exit 1
           fi

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -217,3 +217,58 @@ def test_no_test_invokes_the_cli_with_arguments_it_rejects():
         "these tests invoke the CLI with arguments its own parser refuses, so "
         "they exit 2 wherever they actually run:\n  " + "\n  ".join(problems)
         + "\nThe surface is `fetch` and `version`, and `fetch` takes nothing.")
+
+
+@pytest.mark.unit
+def test_no_workflow_invokes_the_cli_with_arguments_it_rejects():
+    """A manual workflow is still executable code, even when normal CI is green.
+
+    Measured 2026-09-04: two workflows still invoked the removed ``path``
+    subcommand a month after the CLI became ``fetch`` + ``version``.  The
+    Windows launch matrix failed in all three cells before reaching its launch
+    probe; the manual WebRTC gate had not run since the removal.  The existing
+    sibling scans Python tests only, so neither call site was in its perimeter.
+
+    Parse literal workflow invocations against the real parser.  Shell syntax
+    starts at the first punctuation token and is not part of the CLI argv.
+    Comment-only lines are excluded so this explanation cannot flag itself.
+    """
+    import re
+    import shlex
+
+    parser = cli.build_parser()
+    root = Path(__file__).resolve().parents[1]
+    workflows = root / ".github" / "workflows"
+    call = re.compile(r"python\s+-m\s+invisible_playwright\s+(.+)")
+    shell_punctuation = {"|", "||", "&", "&&", ";", ")", ">", ">>"}
+
+    problems = []
+    for path in sorted(workflows.glob("*.y*ml")):
+        for line_number, line in enumerate(
+            path.read_text(encoding="utf-8", errors="replace").splitlines(), 1
+        ):
+            if line.lstrip().startswith("#"):
+                continue
+            match = call.search(line)
+            if match is None:
+                continue
+            lexer = shlex.shlex(
+                match.group(1), posix=True, punctuation_chars="|&;()<>")
+            lexer.whitespace_split = True
+            args = []
+            for token in lexer:
+                if token in shell_punctuation:
+                    break
+                args.append(token)
+            try:
+                parser.parse_args(args)
+            except SystemExit as exit_:
+                if exit_.code:
+                    problems.append(
+                        f"{path.name}:{line_number} -> {args}")
+
+    assert not problems, (
+        "these workflows invoke the CLI with arguments its own parser refuses, "
+        "so the jobs fail before reaching the assertion they exist to run:\n  "
+        + "\n  ".join(problems)
+        + "\nThe surface is `fetch` and `version`, and `fetch` takes nothing.")


### PR DESCRIPTION
## What failed  `path` was deliberately removed when the CLI became `fetch` + `version`, and `fetch` took over printing the verified engine path. Two manual gates still called the old command:  - `firefox-launch-matrix.yml` failed all three Windows cells at "Verify firefox.exe can launch standalone" in [run 31170439722](https://github.com/feder-cr/invisible_playwright/actions/runs/31170439722), before either Firefox probe ran. - `webrtc-e2e.yml` last ran before the command was removed, so its next manual run would fail while resolving the binary.  The existing parser gate scans Python tests only, which is why normal CI remained green.  ## What changed  - Capture `fetch` stdout once in each workflow and carry its final, verified path through `GITHUB_ENV`. - Preserve the native command's non-zero exit status and refuse an empty or nonexistent reported path. - Add a workflow CLI gate that parses every literal invocation against the real parser instead of maintaining another list of valid commands.  ## Verification  The regression test was run before the workflow edits and failed with exactly:  - `firefox-launch-matrix.yml:95 -> ['path']` - `webrtc-e2e.yml:64 -> ['path']`  After the edits:  - `pytest tests/test_cli.py -q`: 11 passed - default `pytest -q`: 552 passed, 3 skipped, 212 deselected - pre-push `pytest -q`: 552 passed, 3 skipped, 212 deselected - CI Ruff selection (`F821,F811,F601`): passed - PowerShell and Bash capture paths were exercised locally, including non-zero command propagation - `git diff --check`: passed  No browser download is needed for the regression test. The manual workflows remain the end-to-end checks for their respective sealed binaries. 
## Manual workflow runs from this branch

Both changed path hand-offs passed on real GitHub runners:

- [firefox-launch-matrix run 33856191324](https://github.com/SamadhiFire/invisible_playwright/actions/runs/33856191324): `fetch`, path validation, and standalone `firefox.exe --version` passed on Windows 2022, 2025, and latest. All three then reached the previously masked reporter snippet and failed because the browser exited during protocol startup without output.
- [webrtc-e2e run 33856154719](https://github.com/SamadhiFire/invisible_playwright/actions/runs/33856154719): `fetch` and path validation passed; the tests ran as 1 passed / 1 skipped, after which the existing no-skip floor correctly refused the run.

The red conclusions are downstream assertions these manual gates exist to expose, not failures in the changed steps. Before this patch the Windows matrix stopped at the removed CLI command, and the WebRTC gate could not reach its tests at all.