### PR TITLE
0.11.0 in the changelog, a wait test that takes its binary, and a version gate that asks the right question

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -214,6 +214,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # The gate diffs the tree against the tag of the published
+          # version; a shallow clone has no tags and cannot tell.
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,38 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-09-04
+
+### Fixed
+- **A screenshot photographs where the page is.** The clip was
+  `{x: 0, y: 0, width: innerWidth, height: innerHeight}`, and that clip is in
+  document coordinates: not the window, but the top corner of the page at the
+  window's size. An agent that scrolled and looked got the same image every
+  time, and nothing in the image says so. `full_page` was not read at all:
+  800x600 came back where 800x4000 was asked for. (#136)
+- **Two manual workflows stop calling the removed `path` command.** Both
+  called `python -m invisible_playwright path`, a subcommand removed when the
+  CLI became `fetch` plus `version`. The Windows launch matrix failed in all
+  three cells before reaching its launch probe, and the WebRTC gate had not run
+  since the removal. The existing parser gate scanned Python tests only, so
+  neither call site was in its perimeter; there is now one that reads the
+  workflows too. Thanks to @SamadhiFire for finding and fixing it. (#141)
+
+### Added
+- **A check that asks the index whether the version a change proposes is
+  still free**, on pull requests. This release exists partly because that
+  check found its own repository in the state it exists to prevent: 0.10.0 was
+  on the index while main sat on 0.10.0 with fifteen commits on top of the
+  tag, the screenshot fix among them. A release from there would have
+  published nothing and reported success, because the publish workflow treats
+  an already-present version as a deliberate no-op, which is right for a
+  re-pushed tag and indistinguishable from somebody forgetting to bump. (#142)
+
+### Documentation
+- Twelve pages stop shipping code that cannot run as pasted, tool metadata is
+  out of the shipped screenshots, and the front page names the agent layer
+  that sits on this engine. (#137, #138, #139, #140)
+
 ## [0.10.0] - 2026-09-03
 
 ### Added

--- a/tests/test_version_is_not_taken.py
+++ b/tests/test_version_is_not_taken.py
@@ -1,4 +1,5 @@
-"""The version a change proposes must not already be on the index.
+"""The version a change proposes must not already be on the index, unless
+nothing that ships has moved since it was published.
 
 ⛔ MEASURED 2026-09-04, AND NOTHING SAW IT. `aihawk 0.4.0` was published at
 23:47. Over the following hours main gained two more changes - verbs for the
@@ -25,9 +26,22 @@ somebody bumps, which is a normal resting state and not a defect, so a check
 that ran there would be red for a reason nobody can act on - and a gate that is
 red at rest is a gate people learn to skip.
 
-The trade this makes, stated rather than discovered: the first pull request
-after a release has to carry a version bump. That matches how this repository
-already works, since the change that earns a release is the change that bumps.
+⛔ AND "NEW CONTENT" MEANS WHAT THE INDEX SERVES, which the first version of
+this file got wrong on its first day. It refused every pull request whose
+version was published, and the first two after a release were the ledger the
+publish workflow opens by itself and the changelog entry for that release. A
+version bump on either would be a lie: nothing that ships had moved. The
+question the gate asks now is the one it always meant. Since the tag of the
+published version, has anything changed that goes into the wheel - the package
+tree the build backend names, or `pyproject.toml`? The ledger, the changelog,
+the tests, the workflows and the docs alter nothing anybody installs, so they
+pass without a bump; a change under the package does not.
+
+That needs the tag in the checkout, so the `version` CI job fetches the full
+history. A version that is on the index with no tag in the clone is refused
+outright rather than guessed at. The outcomes are free, taken-but-unmoved,
+taken-and-moved, and cannot-tell, and only the third is a defect while the
+fourth is a broken bench.
 
 Enabled by IPW_CHECK_VERSION, which the `version` CI job sets itself, so it
 cannot silently skip the way it does in a local run.
@@ -35,6 +49,8 @@ cannot silently skip the way it does in a local run.
 from __future__ import annotations
 
 import os
+import pathlib
+import subprocess
 import urllib.error
 import urllib.request
 
@@ -42,19 +58,59 @@ import pytest
 
 PACKAGE = "invisible-playwright"
 
+#: The tag that published the release BEFORE the current line of work. From it
+#: to here the package moved by definition, which makes it the live known-bad
+#: for the diff half: a check that has only ever said "unmoved" is not a check.
+PREVIOUS_RELEASE_TAG = "v0.10.0"
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
 pytestmark = pytest.mark.skipif(
     not os.environ.get("IPW_CHECK_VERSION"),
     reason="set IPW_CHECK_VERSION=1 to ask the index (one network call)",
 )
 
 
-def _declared_version() -> str:
-    import pathlib
+def _pyproject() -> dict:
     import tomllib
 
-    root = pathlib.Path(__file__).resolve().parents[1]
-    data = tomllib.loads((root / "pyproject.toml").read_text(encoding="utf-8"))
-    return data["project"]["version"]
+    return tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+
+
+def _declared_version() -> str:
+    return _pyproject()["project"]["version"]
+
+
+def _shipped_roots() -> tuple[str, ...]:
+    """What the wheel carries, read from where the build backend declares it
+    rather than typed here, so a moved package moves the gate with it."""
+    packages = _pyproject()["tool"]["hatch"]["build"]["targets"]["wheel"]["packages"]
+    return tuple(p.rstrip("/") + "/" for p in packages) + ("pyproject.toml",)
+
+
+def _shipped(paths) -> list[str]:
+    """The subset of `paths` that goes into the wheel.
+
+    Pure on purpose: the known-bad below feeds it a list, no repository needed.
+    """
+    roots = _shipped_roots()
+    return [p for p in paths if any(p == r or p.startswith(r) for r in roots)]
+
+
+def _changed_since(tag: str):
+    """Every path that differs between `tag` and the tree, or None when git
+    cannot say: the tag is not in this checkout, or this is not a checkout.
+
+    ⛔ None is not an empty list. An absent tag scored as "nothing changed"
+    would pass exactly the case this file exists to refuse.
+    """
+    try:
+        out = subprocess.run(
+            ["git", "diff", "--name-only", tag],
+            cwd=ROOT, capture_output=True, text=True, check=True).stdout
+    except (subprocess.CalledProcessError, OSError):
+        return None
+    return [line.strip() for line in out.splitlines() if line.strip()]
 
 
 def _on_the_index(version: str):
@@ -82,21 +138,33 @@ def test_the_declared_version_is_not_already_published():
 
     if present is None:
         pytest.skip("the index did not answer; neither present nor absent")
+    if not present:
+        return
 
-    assert not present, (
-        "pyproject declares %s and the index already serves it, so a release "
-        "from here publishes nothing: publish.yml sees the version, reports "
-        "'already on the index. No-op, not a failure', and everything below it "
-        "is skipped. Bump the version." % version)
+    changed = _changed_since("v" + version)
+    if changed is None:
+        pytest.fail(
+            "pyproject declares %s and the index already serves it, but the tag "
+            "v%s is not in this checkout, so whether the package moved since "
+            "cannot be told. Fetch the tags: the version job checks out with "
+            "fetch-depth 0 for this reason." % (version, version))
+
+    moved = _shipped(changed)
+    assert not moved, (
+        "pyproject declares %s, the index already serves it, and %d file(s) "
+        "that go into the wheel changed since v%s: %s. A release from here "
+        "publishes nothing: publish.yml sees the version, reports 'already on "
+        "the index. No-op, not a failure', and everything below it is skipped. "
+        "Bump the version." % (version, len(moved), version, ", ".join(moved[:8])))
 
 
 def test_the_check_can_tell_a_taken_version_from_a_free_one():
     """⛔ The known-bad input, run against the live index rather than a mock.
 
-    A check that has only ever said "free" is not a check. `0.1.0` was published
-    is not coming back, so it is a stable stand-in for the
-    thing this gate must catch, and a version far past anything real stands in
-    for the state it must allow.
+    A check that has only ever said "free" is not a check. `0.3.5` was
+    published and is not coming back, so it is a stable stand-in for the thing
+    this gate must catch, and a version far past anything real stands in for
+    the state it must allow.
     """
     taken = _on_the_index("0.3.5")
     free = _on_the_index("99.99.99")
@@ -106,3 +174,34 @@ def test_the_check_can_tell_a_taken_version_from_a_free_one():
 
     assert taken is True, "the check cannot see a version that IS published"
     assert free is False, "the check calls an unpublished version taken"
+
+
+def test_the_check_can_tell_a_shipped_change_from_one_that_does_not_ship():
+    """⛔ The known-bad for the diff half, with no repository involved.
+
+    The ledger, the changelog, a test, a workflow and a doc must not count. A
+    file under the package and `pyproject.toml` must. And a sibling of the
+    package whose name merely starts the same way must not.
+    """
+    package = _shipped_roots()[0]
+    quiet = [
+        "PUBLISHED.json", "CHANGELOG.md", "README.md", "docs/index.md",
+        "tests/test_version_is_not_taken.py", ".github/workflows/ci.yml",
+        package.rstrip("/") + "_notes.md",
+    ]
+    loud = [package + "__init__.py", package + "deep/inside.py", "pyproject.toml"]
+
+    assert _shipped(quiet) == []
+    assert _shipped(quiet + loud) == loud
+
+
+def test_the_diff_half_sees_a_release_that_did_move_the_package():
+    """The live known-bad: from the previous release's tag to here the package
+    moved, so the shipped set is non-empty. Skipped, not passed, when the tag
+    is not in this clone."""
+    changed = _changed_since(PREVIOUS_RELEASE_TAG)
+    if changed is None:
+        pytest.skip("%s is not in this checkout" % PREVIOUS_RELEASE_TAG)
+    assert _shipped(changed), (
+        "no shipped file differs from %s, so the diff half sees nothing"
+        % PREVIOUS_RELEASE_TAG)

--- a/tests/test_wait_for_timeout.py
+++ b/tests/test_wait_for_timeout.py
@@ -71,7 +71,7 @@ def test_the_server_reads_the_key_the_client_actually_sends():
 
 @pytest.mark.e2e
 @pytest.mark.parametrize("requested", [1000, 3000])
-def test_the_wait_takes_the_time_it_was_asked_for(requested):
+def test_the_wait_takes_the_time_it_was_asked_for(requested, firefox_binary):
     """A key that matches and a wait that happens are two claims.
 
     The floor is generous on purpose: this asserts that time passed at all,
@@ -81,7 +81,11 @@ def test_the_wait_takes_the_time_it_was_asked_for(requested):
     """
     from invisible_playwright import InvisiblePlaywright
 
-    with InvisiblePlaywright(seed=1, headless=True) as browser:
+    # The binary comes from the harness, like every other e2e here. Resolving
+    # one from the seal instead ignores INVPW_BINARY_PATH, and under a local
+    # seal, which has no published assets, it cannot resolve at all.
+    with InvisiblePlaywright(seed=1, headless=True,
+                             binary_path=firefox_binary) as browser:
         ctx = browser.new_context()
         page = ctx.new_page()
         page.goto("data:text/html,<p>wait</p>")


### PR DESCRIPTION
Three things the full e2e against a local build reported today, none of them the build.

The changelog test walks the index and found 0.11.0 published and undocumented: the release page carried the notes, the file did not. The entry is the release page, minus a paragraph that belonged to 0.10.0 (the release page is corrected too).

The two `wait_for_timeout` tests built `InvisiblePlaywright` without `binary_path`, so they resolved an engine from the seal while every other e2e took the one the harness points at. Under a published seal nothing shows; under a local seal, which has no published assets, they cannot resolve at all.

And the version gate refused this very pull request, along with #143, the ledger the publish workflow opens by itself: both carry the published version, and a bump on either would be a lie. The gate now asks whether anything that goes into the wheel changed since the tag of the published version, and passes when nothing did. Known-bad inputs: a pure classifier fed the files that must not count and the ones that must, the previous release's tag, and locally a comment appended under the package, which turns it red naming the file.