### PR TITLE
0.12.0: the engine moves to firefox-27, where the first launch on Windows works

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-09-04
+
+### Fixed
+- **The first launch on Windows works.** On a machine that had never run the
+  engine from that path, the first `InvisiblePlaywright(...)` exited with
+  `3221226505` (0xC0000409) before the protocol came up, and the second one
+  worked. It was Firefox's launcher process, not the browser: on a new path
+  `firefox.exe` runs as the launcher first and forwards the Juggler pipe to the
+  real browser, and it read that pipe from CRT descriptors 3 and 4, which the
+  Node.js driver provides and this client does not, since it names the handles
+  in `PW_PIPE_READ` / `PW_PIPE_WRITE`. The launcher died on `_get_osfhandle(3)`;
+  the next launch found a launcher timestamp with no browser timestamp in the
+  registry and disabled the launcher for that path, which is why it failed
+  exactly once per machine and why nothing about the cache directory mattered.
+  The engine is firefox-27, where the launcher forwards the handles it is
+  handed. Every Windows first launch since 0.8.0, the release where this client
+  replaced the Node driver, had this; the daily Windows install check had been
+  red since 2026-08-31. (#144)
+
+### Added
+- **A test for the first launch from a path Firefox has never run from**,
+  Windows only, e2e. It removes the launcher's registry values for the binary
+  under test, launches once, and checks both that the page answers and that the
+  launcher recorded a start followed by the browser's, so a success with the
+  launcher disabled, the path that always worked, does not pass. Against
+  firefox-26 it fails with the exit code above.
+
+### Internal
+- Engine pin moved to firefox-27 through `invisible-core 27.17.0`.
+
 ## [0.11.0] - 2026-09-04
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "invisible_playwright"
-version = "0.11.0"
+version = "0.12.0"
 description = "Playwright wrapper for a patched Firefox with deterministic stealth profile."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -69,7 +69,7 @@ dependencies = [
     # metadata; nothing in src/ hardcodes a second copy (tests/test_core_pin.py
     # fails if one appears). What stays invisible to install-time machinery is the
     # --no-deps / lockfile residue, and _pin.py is the only layer that sees it.
-    "invisible_core==26.17.0",
+    "invisible_core==27.17.0",
     # ⛔ playwright is NO LONGER a dependency: since the full fork, the Python
     # client lives in src/invisible_playwright/_pw/ and the Node driver in
     # src/invisible_playwright/_driver/. Reintroducing it would not visibly

--- a/tests/test_first_launch_from_a_new_path.py
+++ b/tests/test_first_launch_from_a_new_path.py
@@ -1,0 +1,102 @@
+"""The first launch from a path Firefox has never run from works on Windows.
+
+⛔ MEASURED 2026-09-04, AND THREE GATES HAD BEEN SAYING IT FOR FOUR DAYS. On
+Windows the very first launch after a fresh install exited with 3221226505
+(0xC0000409), before the protocol could be used and without printing a line;
+the second launch on the same machine worked, and every one after that. The
+daily user-install run on windows-latest was red from 2026-08-31, the release
+pipeline's Windows gate was red on the last two engines, and the full e2e
+against a fresh cache reproduced it, and nobody read them as one thing.
+
+What died was Firefox's LAUNCHER process, not the browser. On a path it has
+never run from, firefox.exe runs as the launcher first, forwards the Juggler
+pipe to the real browser process, and records that in the registry per
+executable path. The forwarding code read the pipe from CRT descriptors 3 and
+4, which is what a Node.js parent provides. This client passes the pipe as
+PW_PIPE_READ / PW_PIPE_WRITE handles and opens no descriptor 3, so
+_get_osfhandle(3) tripped the CRT's invalid-parameter handler and the launcher
+died before creating anything. On the next run Firefox found a launcher
+timestamp with no browser timestamp, disabled the launcher for that path, and
+started the browser directly. That is why it failed exactly once per machine,
+and why every experiment on the CONTENT of the cache directory came back clean:
+the state was keyed by the path and lived in the registry.
+
+This test puts the engine back in the state a stranger's machine is in, by
+removing the registry values for the binary under test, and launches once. It
+is the reproduction, made permanent. Against an engine before firefox-27 it
+fails; from firefox-27 on, the launcher forwards the handles named in the
+environment and the launch succeeds with the launcher process still enabled.
+
+Windows only: no other platform has a launcher process. e2e: it launches the
+engine. It touches HKCU for one executable path, which the launcher rewrites
+on the next launch anyway.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.skipif(sys.platform != "win32", reason="the launcher process exists only on Windows"),
+]
+
+LAUNCHER_KEY = r"Software\Mozilla\Firefox\Launcher"
+#: The values the launcher keeps per executable path, from LauncherRegistryInfo.cpp.
+LAUNCHER_VALUES = ("Image", "Launcher", "Browser", "Telemetry", "Blocklist")
+
+
+def _forget_this_path(exe: str) -> None:
+    """Delete the launcher's registry values for `exe`: the state of a machine
+    that has never run this binary from this path."""
+    import winreg
+
+    with winreg.OpenKey(winreg.HKEY_CURRENT_USER, LAUNCHER_KEY, 0, winreg.KEY_SET_VALUE) as key:
+        for suffix in LAUNCHER_VALUES:
+            try:
+                winreg.DeleteValue(key, exe + "|" + suffix)
+            except FileNotFoundError:
+                pass
+
+
+def _timestamps(exe: str) -> dict:
+    """The launcher and browser timestamps the two processes wrote, or None each."""
+    import winreg
+
+    out = {}
+    with winreg.OpenKey(winreg.HKEY_CURRENT_USER, LAUNCHER_KEY) as key:
+        for suffix in ("Launcher", "Browser"):
+            try:
+                out[suffix] = winreg.QueryValueEx(key, exe + "|" + suffix)[0]
+            except FileNotFoundError:
+                out[suffix] = None
+    return out
+
+
+def test_the_first_launch_from_a_new_path_works(firefox_binary):
+    """⛔ Both halves matter. The launch must succeed, AND the launcher process
+    must have run and created the browser: a launcher timestamp followed by a
+    later browser timestamp. A success with the launcher disabled would be the
+    second-launch path, which always worked, and would prove nothing.
+    """
+    from invisible_playwright import InvisiblePlaywright
+
+    exe = os.path.normpath(firefox_binary)
+    _forget_this_path(exe)
+
+    with InvisiblePlaywright(binary_path=exe, headless=True, seed=1) as browser:
+        page = browser.new_context().new_page()
+        page.goto("about:blank")
+        assert page.evaluate("1 + 1") == 2
+
+    stamps = _timestamps(exe)
+    assert stamps["Launcher"], "the launcher process never recorded a start, so this was not a first launch"
+    assert stamps["Browser"], (
+        "the launcher recorded a start and the browser never did: the launcher "
+        "died before creating it, which is the first-launch failure this test exists for")
+    assert stamps["Browser"] != 0, "the launcher was disabled after a failure instead of running"
+    assert stamps["Launcher"] < stamps["Browser"], (
+        "the browser timestamp predates the launcher's, so the browser that ran "
+        "was not the one this launcher created")


### PR DESCRIPTION
Moves the engine to firefox-27 through `invisible-core 27.17.0`, and adds the test that keeps #144 fixed.

On Windows the first launch from a path the browser had never run from exited with 0xC0000409 before the protocol came up, and the second worked. It was the launcher process reading the Juggler pipe from CRT descriptors this client never opens; firefox-27 forwards the handles it is handed instead. Every Windows first launch since 0.8.0 had this, and the daily Windows install check had been red since 2026-08-31.

The new test removes the launcher's registry values for the binary under test, which is the state of a machine that has never run it from that path, launches once, and checks both that the page answers and that the launcher recorded a start followed by the browser's. Against firefox-26 it fails with the exit code above; against the firefox-27 archive it passes in 8.5 s. Windows only, e2e.

Version 0.12.0, changelog entry included. Closes #144.