### PR TITLE
The browser launches badge is back, because the number behind it is live again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Changed
+- **The `browser launches` badge is back.** It was removed in 0.7.2 because the
+  counter behind it lived on a repository that had been deleted, so the badge
+  would have redrawn a frozen number every morning. The counter has lived on
+  this repository since 2026-08-19 and is counting again, so the figure the
+  badge shows is live. It is cumulative, and it undercounts: engines before
+  firefox-21 still ask the old address, and they rejoin only as they upgrade.
+
 ## [0.12.1] - 2026-09-05
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -282,5 +282,6 @@ This project is for educational purposes only. It is provided as-is, with no war
   <a href="https://github.com/feder-cr/invisible_playwright/blob/main/LICENSE"><img src="https://raw.githubusercontent.com/feder-cr/invisible_playwright/main/docs/badges/license.svg" alt="License: MIT"></a>
   <a href="https://www.python.org/downloads/"><img src="https://raw.githubusercontent.com/feder-cr/invisible_playwright/main/docs/badges/python.svg" alt="Python 3.11+"></a>
   <a href="https://github.com/feder-cr/firefox_antidetect_patch/releases"><img src="https://raw.githubusercontent.com/feder-cr/invisible_playwright/main/docs/badges/firefox.svg" alt="Firefox 151.0"></a>
+  <img src="https://raw.githubusercontent.com/feder-cr/invisible_playwright/badges/docs/badges/launches.svg" alt="browser launches">
   <a href="https://github.com/feder-cr/invisible_playwright/stargazers"><img src="https://raw.githubusercontent.com/feder-cr/invisible_playwright/badges/docs/badges/stars.svg" alt="GitHub stars"></a>
 </p>


### PR DESCRIPTION
The badge went in 0.7.2, when the counter it read lived on a repository that had just been deleted and the renderer would have redrawn a frozen number every morning. The counter has lived on this repository since 2026-08-19 and is counting again, about twenty thousand launches a day right now, so the figure is live. Cumulative, and an undercount: engines before firefox-21 carry the old address and rejoin only as their users upgrade. Changelog note under Unreleased; nothing that ships changes.