### PR TITLE
0.12.2: the launch counter lives on the engine's repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.12.2] - 2026-09-05
+
 ### Changed
+- **The launch counter lives on the engine's repository.** Every session now
+  declares `invisible_firefox.usage_ping.url` through `invisible-core 27.18.0`,
+  pointing at the `usage-counter` release of `firefox_antidetect_patch`, the
+  repository that builds and ships the engine. The engine's compiled default
+  says the same from the next build. Engines older than firefox-21 do not read
+  the pref and are not counted. To opt out of the ping, set
+  `invisible_firefox.usage_ping.enabled` to `False` in `extra_prefs`.
 - **The `browser launches` badge is back.** It was removed in 0.7.2 because the
   counter behind it lived on a repository that had been deleted, so the badge
   would have redrawn a frozen number every morning. The counter has lived on

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "invisible_playwright"
-version = "0.12.1"
+version = "0.12.2"
 description = "Playwright wrapper for a patched Firefox with deterministic stealth profile."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -69,7 +69,7 @@ dependencies = [
     # metadata; nothing in src/ hardcodes a second copy (tests/test_core_pin.py
     # fails if one appears). What stays invisible to install-time machinery is the
     # --no-deps / lockfile residue, and _pin.py is the only layer that sees it.
-    "invisible_core==27.17.0",
+    "invisible_core==27.18.0",
     # ⛔ playwright is NO LONGER a dependency: since the full fork, the Python
     # client lives in src/invisible_playwright/_pw/ and the Node driver in
     # src/invisible_playwright/_driver/. Reintroducing it would not visibly


### PR DESCRIPTION
The pin moves to `invisible-core 27.18.0`, which declares the launch counter's address in every session: the `usage-counter` release of `firefox_antidetect_patch`, the repository that builds and ships the engine. The engine's compiled default says the same from the next build. Engines older than firefox-21 do not read the pref and are not counted; the ping can be turned off with `invisible_firefox.usage_ping.enabled` in `extra_prefs`.

Verified from the checkout: one launch with the declared address moved that asset's download count. Version 0.12.2; the changelog carries the entry and the badge note that was under Unreleased.