### PR TITLE
Ten mechanics pages, and one correction the measurement forced

### DIFF
--- a/docs/canvas-differs-across-operating-systems.md
+++ b/docs/canvas-differs-across-operating-systems.md
@@ -1,0 +1,146 @@
+---
+title: "Why the same canvas draws differently on Windows and Linux"
+description: "Canvas fingerprints differ across Windows and Linux because the rasteriser, font files, hinting and GPU path differ, not the canvas drawing code."
+parent: "Canvas, WebGL, Fonts and Audio"
+grand_parent: "Guides"
+nav_order: 15
+---
+
+
+# Why the same canvas draws differently on Windows and Linux
+
+Two machines running the exact same `fillText()` and `toDataURL()` calls can return
+different bytes. A canvas hash never measures the drawing code alone: it measures the
+text rasteriser, the actual font file behind that family name, the subpixel and
+hinting policy, and whether a GPU or a software path drew it. Change any one and the
+pixels change, with nothing wrong in the script itself.
+
+## What actually differs, mechanically, between two operating systems
+
+A `fillText()` call looks like one instruction, but several layers sit underneath it
+before a pixel comes back, and any one of them can move the output between two
+machines running the identical script.
+
+### The text rasteriser and its hinting policy
+
+Windows draws glyphs through DirectWrite, or the older GDI path; Linux desktops
+typically use FreeType, fed by fontconfig. Both decide, pixel by pixel, how much of
+each pixel a glyph edge covers, and that depends on the hinting level in force. A
+glyph spanning eleven and a half pixels gets rounded differently by rasterisers with
+different hinting rules, and the rounding shows up directly in the readback.
+
+### Which font file actually backs the family name
+
+`ctx.font = "16px Arial"` does not point at one universal file. On Windows it
+resolves to Microsoft's own Arial. On a Linux desktop without Microsoft's fonts
+installed, the same family name commonly falls back to a metric-compatible substitute
+such as Liberation Sans, matching Arial's advance widths but not its glyph outlines.
+Same request, same font name, a different file drawing every letter.
+
+### Subpixel geometry and antialiasing
+
+A desktop session with subpixel rendering on draws each glyph edge using a display's
+red, green and blue sub-elements, producing colour fringing invisible at normal
+viewing distance but visible in a raw pixel readback. A headless or virtualised
+environment usually falls back to plain grayscale antialiasing instead, since there
+is no subpixel layout to target. The glyph looks the same to a human; the bytes do
+not match.
+
+### GPU-accelerated versus software rendering paths
+
+Canvas content can be composited by the GPU or rasterised in software, and which path
+a machine takes depends on driver support. A software rasteriser and a
+GPU-accelerated one do not have to agree on sub-pixel rounding, so identical draw
+commands can differ by a handful of values before fonts even enter the picture.
+
+## Why text is the least stable element on a canvas
+
+Draw a plain filled rectangle and the pixel values are close to universal: a solid
+colour passes through a rasteriser mostly unchanged, so a flat-colour hash tends to
+agree across machines that disagree on everything else. Draw text instead, and every
+layer named above gets involved at once: rasteriser, font file, hinting, subpixel
+policy, GPU path. That is why a text-free canvas is far more stable across machines,
+and why fingerprinting scripts almost always put a mixed-case string on the probe
+canvas rather than a plain shape.
+
+## A canvas hash is a platform tell as much as a machine tell
+
+Because font rendering is tied so tightly to the operating system, a canvas hash
+carries platform information whether anyone intended it to.
+[Windows implies Segoe UI and a specific CJK set; a bare Linux desktop implies
+DejaVu and Liberation and little else](headless-fonts-differ.md), and text rendered
+through those two stacks does not converge. That gives a page a checkable claim
+rather than a rare value: a browser whose user agent says Windows, drawing text whose
+antialiasing looks like Linux's FreeType instead of Windows' DirectWrite, has
+contradicted itself, and the check needs only one sample of each platform, not a
+notion of "normal" in the abstract.
+
+## What this project does about it, and what it does not
+
+For the values a page can read back from a canvas, this project ties the output to
+the session's own seed rather than to whatever the host has, which is what lets [the
+same identity return the same canvas and WebGL hash on Windows and on
+Linux](canvas-webgl-cross-platform-consistency.md); [`measureText()`'s numeric fields
+get the same treatment through a different mechanism](measuretext-textmetrics-fingerprinting.md).
+That is a statement about what a page can observe, not a claim that the rendering
+pipeline was rewritten to erase itself: rasterisation here is real drawing, done by
+[a real, bundled font stack](bundled-fonts-cross-platform.md) rather than a
+substituted picture, which is why a screenshot still shows real text instead of
+noise. The honest limit: the fix covers only the readback calls a page can make
+today, and any new export path a future engine adds needs the same treatment first.
+
+## Conclusion
+
+A canvas hash is not a single number a browser decides to report. It is the visible
+output of a rasteriser, a font file, a hinting policy and a rendering path, four
+layers a stock browser never controls independently of its operating system. Text
+draws through all four at once, which is why a text-bearing canvas is the first
+readback worth checking when a hash looks wrong for the platform a session claims to
+be.
+
+## Short answers to the questions that lead here
+
+**Why does my canvas fingerprint differ between Windows and Linux?** The pixels come
+from the OS's rasteriser, its font files, its hinting and subpixel policy, and
+whether the GPU or software drew the glyph, not from the drawing code.
+
+**Does the same drawing code produce the same canvas hash on every OS?** No, not on
+a stock browser. Identical calls run through a different rasteriser and font file on
+each platform, and the readback reflects that.
+
+**Is a canvas fingerprint a browser tell or a platform tell?** Mostly a platform
+tell. Two browsers on the same OS, drawing the same text, agree far more closely
+than one browser does across two operating systems.
+
+**Does removing text make the hash more stable?** Yes. Solid fills pass through a
+rasteriser largely unchanged, while text pulls in the font stack, hinting and
+subpixel geometry at once.
+
+**Can a browser match its canvas hash to a claimed operating system exactly?** Only
+by controlling what a page reads back, since the render itself comes from whichever
+rasteriser and font files are actually installed.
+
+**See also:** [canvas fingerprint noise and why per-call randomising
+fails](canvas-fingerprint-noise.md), [why a canvas fingerprint changes every
+run](canvas-fingerprint-changes-every-run.md), and [measureText and TextMetrics as a
+fingerprinting surface](measuretext-textmetrics-fingerprinting.md).
+
+## Sources
+
+- [MDN: `CanvasRenderingContext2D.fillText()`](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/fillText),
+  [MDN: `HTMLCanvasElement.toDataURL()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toDataURL)
+  and [MDN: `CanvasRenderingContext2D.getImageData()`](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/getImageData),
+  for the calls above.
+- MDN, `CanvasRenderingContext2D.measureText()`,
+  https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/measureText -
+  it "returns a TextMetrics object that contains information about the measured text
+  (such as its width, for example)", which is the surface this page's text argument rests
+  on. Read 5 September 2026.
+- This project's own measurements on font rendering, font bundling and canvas
+  readback, referenced via the linked pages on this wiki.
+
+---
+
+*Written while maintaining [invisible_playwright](https://github.com/feder-cr/invisible_playwright),
+a Firefox patched at the C++ level driven by stock Playwright. A canvas hash was never
+really about the canvas; it was always about everything underneath it.*

--- a/docs/closed-shadow-root-playwright.md
+++ b/docs/closed-shadow-root-playwright.md
@@ -1,0 +1,188 @@
+---
+title: "Closed shadow roots: what Playwright cannot see"
+description: "Stock Playwright finds nothing inside a closed shadow root, in Firefox and Chromium alike. Measured, with the page that reproduces it and what this engine does instead."
+parent: "The Automation Layer"
+grand_parent: "Guides"
+nav_order: 45
+---
+
+
+# Closed shadow roots: what Playwright cannot see
+
+A closed shadow root makes `element.shadowRoot` return `null`, and stock
+Playwright locators stop at that boundary: measured on 5 September 2026
+against a page with one open and one closed root, stock Firefox and stock
+Chromium both matched the open content and returned zero matches for the
+closed content. The engine this wiki documents returns one match for the
+same closed content, and the page still reads `null`.
+
+For the ordinary case, open shadow roots, Playwright crosses them by itself
+and there is nothing to configure: see
+[how to scrape shadow DOM content with Playwright](how-to-scrape-shadow-dom-playwright.md).
+This page is about the other case, and it starts with a number rather than
+an opinion.
+
+## The measurement, and the page that reproduces it
+
+The test page defines two custom elements. One attaches its shadow root with
+`mode: "open"`, the other with `mode: "closed"`, and each puts a unique
+string inside. Served from `127.0.0.1`, so no network variability, and the
+same file for every arm.
+
+```html
+<open-widget></open-widget>
+<closed-widget></closed-widget>
+<script>
+class OpenWidget extends HTMLElement {
+  connectedCallback() {
+    const r = this.attachShadow({mode: "open"});
+    r.innerHTML = '<p id="inner-open">OPEN_SECRET_VALUE_7788</p>';
+  }
+}
+class ClosedWidget extends HTMLElement {
+  connectedCallback() {
+    const r = this.attachShadow({mode: "closed"});
+    r.innerHTML = '<p id="inner-closed">CLOSED_SECRET_VALUE_9911</p>';
+    this.readIt = () => r.querySelector("#inner-closed").textContent;
+  }
+}
+customElements.define("open-widget", OpenWidget);
+customElements.define("closed-widget", ClosedWidget);
+</script>
+```
+
+Three arms, one instrument, same page:
+
+| arm | `#inner-open` | `#inner-closed` | text inside the closed root | `closed.shadowRoot` |
+|---|---|---|---|---|
+| Playwright, stock Firefox | 1 match | 0 matches | 0 matches | `null` |
+| Playwright, stock Chromium | 1 match | 0 matches | 0 matches | `null` |
+| Playwright, this engine | 1 match | **1 match** | **1 match** | `null` |
+
+The stock rows are exactly what Playwright's own documentation promises:
+"Closed-mode shadow roots are not supported." The third row is this engine,
+and the last column is the part that matters most: from the page's point of
+view nothing changed. `element.shadowRoot` still reads `null`, because the
+resolution happens beneath the page's JavaScript rather than by rewriting
+what the page can see.
+
+## Why the boundary exists at all
+
+`attachShadow({ mode: "closed" })` is defined to hide the subtree from
+outside code. MDN puts it plainly: elements inside the shadow root "cannot
+be accessed from JavaScript via the `shadowRoot` property, which is set to
+`null`". The mode does not hide anything from the component itself, because
+`attachShadow()` returns the root to the code that called it, and that code
+keeps the reference for the life of the page.
+
+So a closed root is an encapsulation choice by the component author, not a
+protection against automation, and it is not a detection surface either.
+Nothing about a closed root tells a site who is visiting.
+
+## How to recognise one in ten seconds
+
+Three signals together, never one alone. The element renders visible
+content. A selector aimed inside it returns nothing. And the host's
+`.shadowRoot`, read from the console, comes back `null`.
+
+That last signal does not separate a closed root from an element with no
+shadow root at all. Pair it with the host's own `textContent`: on our test
+page the closed host returns an empty string while text is plainly on
+screen, which is the tell. Content you can see, text you cannot read from
+the host, and a `null` shadow root is a closed root every time.
+
+```python
+from invisible_playwright import InvisiblePlaywright
+
+with InvisiblePlaywright(seed=42, headless=True) as browser:
+    page = browser.new_page()
+    page.goto("http://127.0.0.1:8731/page.html")
+
+    host = page.query_selector("closed-widget")
+    print(host.evaluate("el => el.shadowRoot !== null"))   # False: null, as the spec says
+    print(host.evaluate("el => el.textContent"))           # '' while text is on screen
+    print(page.locator("#inner-closed").count())           # 1 on this engine, 0 on stock
+```
+
+## What still works when a selector will not reach
+
+On stock Playwright the closed subtree is off limits to selectors, and
+three routes remain, each for a different reason.
+
+The component's own script keeps full access, so any interface the author
+deliberately exposed on the host still answers. On the test page above the
+component sets a `readIt()` method on its host, and `page.evaluate` calling
+that method returned the closed string on every arm, stock included. A well
+built component publishes properties, methods, or events dispatched with
+`composed: true`, and that public surface is the door the author intended.
+
+Input reaches the component regardless. The host sits in ordinary light DOM,
+so it has a real bounding box, it can be clicked, and keyboard focus moves
+into the controls inside it. Neither route lets you name what you are
+touching, but both reach it.
+
+And the data usually exists before the component renders it. Most closed
+components are filled from a network response, and
+[waiting for that response](wait-for-specific-api-response-playwright.md)
+sidesteps the rendered tree entirely.
+
+## The workaround that is worse than the problem
+
+You will find snippets that patch `Element.prototype.attachShadow` before
+the page's scripts run so every later call becomes `mode: "open"`. It has
+two problems. It only wins a timing race you rarely control, and it changes
+what the page itself can observe: after the patch, `element.shadowRoot`
+stops being `null` on components whose authors asked for `null`. That is a
+difference a consistency check can read, which is the opposite of the goal
+on a wiki like this one.
+
+The measurement above is the argument against it. Reaching the content while
+leaving `shadowRoot` at `null` is strictly better than reaching it by making
+the page lie about itself.
+
+## Short answers to the questions that lead here
+
+**Why does my Playwright locator find nothing when the element is visible?**
+If the host's `.shadowRoot` reads `null` while text renders on screen, the
+content is inside a closed shadow root. Stock Playwright locators stop
+there, in Firefox and Chromium alike.
+
+**Does Playwright support closed shadow roots?** No. Its documentation says
+so directly, and the measurement above confirms it on both stock engines:
+zero matches for content that is plainly rendered.
+
+**How do I tell an open root from a closed one?** Read `element.shadowRoot`.
+An object means open. `null` means closed, or no shadow root at all, and the
+host's empty `textContent` next to visible text separates those two.
+
+**Can I force a closed root open?** You can patch `attachShadow` before the
+component runs, and you should not. It depends on a race you do not control
+and it changes what the page can observe about itself.
+
+**What if the data only exists inside a closed root?** Call whatever the
+component exposes on its host, or read the network response that filled it.
+On this engine, a locator also reaches the content directly.
+
+**See also:** [scraping open shadow DOM with Playwright](how-to-scrape-shadow-dom-playwright.md),
+[scraping iframe content with Playwright](how-to-scrape-iframe-content-playwright.md),
+and [waiting for a specific API response](wait-for-specific-api-response-playwright.md).
+
+## Sources
+
+- MDN, `Element.attachShadow()`,
+  https://developer.mozilla.org/en-US/docs/Web/API/Element/attachShadow -
+  the `closed` mode definition and the quoted sentence about `shadowRoot`
+  being set to `null`. Read 5 September 2026.
+- Playwright, Locators,
+  https://playwright.dev/python/docs/locators - "All locators in Playwright
+  by default work with elements in Shadow DOM" and "Closed-mode shadow roots
+  are not supported". Read 5 September 2026.
+- Our own measurement, 5 September 2026: the page above served from
+  `127.0.0.1`, run against stock Playwright Firefox, stock Playwright
+  Chromium and this engine, same script for all three arms.
+
+---
+
+*From [invisible_playwright](https://github.com/feder-cr/invisible_playwright).
+The three-arm table is our own run and the test page is printed above so you
+can reproduce it rather than take our word for it.*

--- a/docs/first-firefox-launch-fails-then-works-windows.md
+++ b/docs/first-firefox-launch-fails-then-works-windows.md
@@ -1,0 +1,109 @@
+---
+title: "First Firefox launch fails on Windows, then works"
+description: "A freshly extracted Firefox can fail its very first launch on Windows and then succeed every time after. What we measured, why, and how to handle it."
+parent: "Testing and Troubleshooting"
+grand_parent: "Guides"
+nav_order: 29
+---
+
+
+# First Firefox launch fails on Windows, then works
+
+A freshly extracted Firefox directory can fail to launch on Windows on its very first attempt and then succeed every single time after, with no code change and no reinstall. We measured this directly: the failure tracks the executable's file path, not the directory's contents, and a Windows registry key tied to that path is the strongest lead we found.
+
+## The symptom
+
+Extract a Firefox build to a brand new path on Windows and launch it. Sometimes the launch fails immediately, with no window, no error dialog, and nothing useful beyond a bare launch timeout. Try again at the exact same path with the exact same binary, no changes at all, and it works. Not just once: every later launch at that same path succeeded, every time, in every test we ran.
+
+The rate is not "every first launch fails." Most first launches at a new path succeed cleanly. When one does fail, though, it fails fast, in under a second, and the very next attempt at the identical path always worked in our testing.
+
+## What we ruled out
+
+Our first instinct was that the extracted directory itself was incomplete on that one run. It wasn't: we took a directory that had already launched successfully many times, copied it whole to a new path we'd never used, and its first launch there failed the same way, with byte-for-byte identical contents to a working copy elsewhere. We also ruled out the per-launch profile Playwright creates, clearing every cache we could find, and re-downloading the build from scratch. None of it made any measurable difference. Whatever was failing lived outside both the directory and the profile.
+
+## What the registry key points to
+
+Firefox's startup on Windows goes through a launcher stage before the browser process starts, keeping state outside the installation directory. We found a registry key, `HKCU\Software\Mozilla\Firefox\Launcher`, holding timestamped entries keyed by the executable's own file path. A path never launched before had no entry; the same path, launched again, did.
+
+That correlation matches what we observed: new path, no entry, occasional immediate failure; same path again, entry present, no failure. Two halves of this are worth keeping apart. The launcher stage itself is documented by Mozilla: Firefox on Windows bootstraps through a launcher process that, unlike every other process in the browser, "is not launched by the parent process, but rather launches it", and it exists so that protections like DLL blocklisting are in place before the browser's main thread runs. Mozilla treats launcher failures as a real enough category to ship a telemetry ping for them. The registry key and its per-executable timestamps, on the other hand, are our own observation: we found them, we can read them, and we have not found Mozilla documentation that describes them, so treat that half as a measured correlation rather than an architectural claim.
+
+## The process that dies is the launcher, not the browser
+
+The detail worth carrying into your own debugging: the process that exits is the launcher, not the browser you're trying to drive. It exits within a fraction of a second and writes no log anywhere we looked. "The browser printed nothing" is the wrong way to describe it, because the browser was never created. From Playwright's side, a dead launcher looks exactly like a plain launch timeout, with none of the specifics that would point at what actually went wrong.
+
+## How to recognise this specific failure
+
+- It only happens on the first launch at a path you have never used before, never on a path you have already launched successfully.
+- It fails fast, typically well under a second, not after waiting out a timeout.
+- There is no log file and no window, even briefly.
+- Retrying the exact same launch, same path, same everything, succeeded the second time in every case we saw.
+
+If your failure doesn't match this shape, slow rather than instant, or the same path failing on every attempt, you're looking at something else. [Slow browser launch: a per-request timeout is not a budget](slow-browser-launch-timeout-budget.md) and [Playwright "Executable Doesn't Exist" After Install](playwright-executable-doesnt-exist.md) cover failure modes that look similar but have different causes.
+
+## Checking the registry key yourself
+
+```
+reg query "HKCU\Software\Mozilla\Firefox\Launcher"
+```
+
+Run it before and after a launch at a new path. A new entry appearing is the signal to look for; it won't tell you why the launcher failed the first time, only that the path is now on record.
+
+## Practical handling: a warm-up launch and one retry
+
+Two things worked for us. Right after extracting a build to a new path, launch it once and close it immediately, before any real automation depends on it, so the launcher can record the path while nothing is watching the clock.
+
+```python
+from playwright.sync_api import sync_playwright
+
+def launch_with_warmup(playwright, executable_path, **launch_kwargs):
+    # First launch at a brand new path: throwaway, just to let the
+    # launcher record state for this executable. Close it immediately.
+    warmup = playwright.firefox.launch(executable_path=executable_path, **launch_kwargs)
+    warmup.close()
+    return playwright.firefox.launch(executable_path=executable_path, **launch_kwargs)
+```
+
+Second, treat the very first real launch of any new install path as worth exactly one retry, no more. The second attempt succeeded every time we tested it, so a loop with backoff solves a problem you don't have and only hides a genuinely broken install behind repeated waiting.
+
+```python
+def launch_retry_once(playwright, executable_path, **launch_kwargs):
+    try:
+        return playwright.firefox.launch(executable_path=executable_path, **launch_kwargs)
+    except Exception:
+        return playwright.firefox.launch(executable_path=executable_path, **launch_kwargs)
+```
+
+## What remains unexplained
+
+We have a correlation, not a proven mechanism. We don't know why an absent registry entry makes the launcher exit instead of simply creating the entry itself, the way a first-run step normally would. We also haven't ruled out a competing, more mundane explanation: antivirus or SmartScreen scanning a freshly written executable can delay its first execution at a new path, independent of anything Firefox's own code does.
+
+Treat the warm-up launch and single retry as a practical workaround, not a fix for a confirmed cause. If what you're chasing turns out to be a preferences problem instead, [Firefox preferences that silently do nothing](firefox-prefs-not-applying.md) covers a different failure that can look similar from the outside.
+
+## Short answers to the questions that lead here
+
+**Why does Firefox fail to launch the first time but work the second time?**
+In our testing, first launches at a brand new path occasionally fail within a fraction of a second, while the second launch at the same path always succeeded. The failure correlates with a Windows registry key that has no entry yet for a path never launched before.
+
+**Is this a Firefox bug?**
+We haven't proven that. What we have is a measured correlation between a missing registry entry and an occasional fast failure on first launch, not a confirmed root cause.
+
+**Does this happen only on Windows?**
+Yes, as far as we tested. The registry key we found, under `HKCU\Software\Mozilla\Firefox\Launcher`, is Windows-specific, and we have no equivalent finding for Linux.
+
+**How do I avoid hitting this in automation?**
+Launch once and close immediately after extracting a build to a new path, before any real task depends on it, and give the first real launch of any new path exactly one retry.
+
+**Does clearing the cache or profile fix it?**
+No. Neither made any difference in our testing; the failure tracked the executable's path, not the profile or any cache we cleared.
+
+**See also:** [Slow browser launch: a per-request timeout is not a budget](slow-browser-launch-timeout-budget.md), [Playwright "Executable Doesn't Exist" After Install](playwright-executable-doesnt-exist.md), and [Firefox preferences that silently do nothing](firefox-prefs-not-applying.md).
+
+## Sources
+
+- This project's own testing, September 2026: repeated extraction of a shipped Firefox build to new Windows paths, timing the process exit, and inspecting `HKCU\Software\Mozilla\Firefox\Launcher` before and after each launch.
+- Mozilla, Gecko Processes, https://firefox-source-docs.mozilla.org/ipc/processes.html - the launcher process on Windows, the quoted line about it launching the parent rather than being launched by it, and its role in DLL blocklisting. Read 5 September 2026.
+- Mozilla, Launcher Process Failure ping, https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/data/launcher-process-failure-ping.html - the telemetry Firefox sends when the launcher cannot start the browser. Read 5 September 2026; it documents the ping's fields and says nothing about registry state, which is why the registry half above stays labelled as our own observation.
+
+---
+
+*From the notes of [invisible_playwright](https://github.com/feder-cr/invisible_playwright), on a failure that only ever showed up once per path and never explained itself in its own words.*

--- a/docs/how-to-scrape-linked-pdfs-playwright.md
+++ b/docs/how-to-scrape-linked-pdfs-playwright.md
@@ -1,0 +1,192 @@
+---
+title: "Download and read PDFs linked from a page with Playwright"
+description: "Download PDFs linked from a page with Playwright: find every link by content type, fetch through page.request so cookies carry over, then extract the text."
+parent: "Scraping with Playwright"
+grand_parent: "Guides"
+nav_order: 149
+---
+
+
+# Download and read PDFs linked from a page with Playwright
+
+Downloading PDFs linked from a page is three jobs, not one: find every link that
+actually resolves to a PDF, even ones hidden behind a redirect or a bare query
+string; fetch the bytes through the page's own session so an auth wall does not
+refuse you; then run the file through a PDF library to pull the text out. Skip the
+session part and a plain HTTP client gets HTML or a 403 instead of a document.
+
+## Find every link that actually resolves to a PDF
+
+A `.pdf` extension in the URL is a hint, not a guarantee. Plenty of real PDF links lack
+one: a download endpoint like `/reports/export?id=42&format=pdf`, or a redirector that
+sends a 302 elsewhere before the bytes arrive. Trusting the extension misses both, and
+the DOM gives you the absolute URL for free, so start there:
+
+```python
+candidates = page.eval_on_selector_all("a[href]", "els => els.map(e => e.href)")
+```
+
+Measured on a local page carrying a relative link, an absolute one with a query string
+and one non-PDF link, that call returned all three fully resolved, query string intact.
+The extension filter narrows the list cheaply; the content type is what confirms it, and
+the next section is where that happens.
+
+## Getting the bytes: one route works, three do not
+
+This is the part where most examples on the web are wrong for Firefox, so here is what
+was measured on 5 September 2026, all four routes against the same local page.
+
+**What works: `fetch` from inside the page.** The request leaves the browser itself, with
+the session's cookies attached, and comes back as bytes you can write to disk.
+
+```python
+import base64
+from pathlib import Path
+
+res = page.evaluate("""async (u) => {
+    const r = await fetch(u, {credentials: 'include'});
+    const buf = new Uint8Array(await r.arrayBuffer());
+    let s = ''; for (const x of buf) s += String.fromCharCode(x);
+    return {status: r.status, type: r.headers.get('content-type'), b64: btoa(s)};
+}""", url)
+
+if "application/pdf" in (res["type"] or ""):
+    Path("report.pdf").write_bytes(base64.b64decode(res["b64"]))
+```
+
+That returned `200`, `application/pdf` and 1388 bytes on the test file, and the content
+type in the same response is your filter: one request answers both "is it a PDF" and
+"give me the PDF". Base64 through `evaluate` is the price of moving binary across the
+protocol boundary; for very large files, prefer the download route below.
+
+**What does not work, and why it matters:**
+
+`page.goto(pdf_url)` returns `None` instead of a response. Firefox hands the PDF to its
+built-in viewer, so there is no ordinary navigation response to call `.body()` on. The
+URL changes, the viewer renders, and your code gets nothing. Measured: `response is
+None`, `document.contentType` confirming the viewer took over.
+
+`page.expect_download()` around a click on a plain link times out, for the same reason:
+the viewer opens instead of a download starting. It is the right API when the server
+sends `Content-Disposition: attachment`, and the wrong one for a link the browser thinks
+it can display.
+
+`page.request` / `APIRequestContext` is refused outright on this engine, by design. The
+error says why: HTTP performed outside the page is not browser automation and carries
+none of the browser's identity, so a request that looks nothing like the browser making
+it would be a hole in the very thing this engine exists to keep consistent. On stock
+Playwright it works; here you use the in-page `fetch` above.
+
+## Why a plain requests.get so often comes back as HTML or a 403
+
+Pointing a separate Python client at the same URL frequently fails where the browser
+succeeds, for two independent reasons. First, a PDF gated behind a login has no
+session to present: a bare `requests.get()` carries none of the cookies the browser
+earned by signing in, so the server answers with a login page instead of the file.
+Second, even a public PDF can sit behind a defense that fingerprints the TLS
+handshake and header order, and a generic client's handshake does not match a
+browser's; the response is an interstitial or a flat `403` instead of bytes. Fetching with `fetch` from inside the page avoids both, because the request leaves the
+browser itself: same cookies, same handshake, same header order as every other request
+that page has already made. That is also why this engine refuses the out-of-page request
+API rather than offering it as a convenience.
+
+## Name files deterministically, so a rerun does not duplicate work
+
+Hash the source URL into the filename and every PDF gets a stable name that survives a
+rerun without a second copy appearing under a different one:
+
+```python
+import hashlib
+name = hashlib.sha1(url.encode()).hexdigest()[:16] + ".pdf"
+```
+
+The tempting alternative is the last path segment, and it breaks on the first URL with a
+query string: `annex.pdf?v=2` becomes a filename with a `?` in it, which Windows refuses
+outright. Strip anything from the first `?` or `#` before you use it, or hash and move
+on. Deriving names from link text is worse still: free-form, frequently duplicated, and
+sometimes absent.
+
+## Extract the text once you have the bytes
+
+With the file on disk, or just the bytes still in memory, a PDF library turns the
+pages into text. `pypdf` is a common choice for this:
+
+```python
+from pypdf import PdfReader
+
+reader = PdfReader("pdfs/report.pdf")
+text = "\n".join(page.extract_text() or "" for page in reader.pages)
+```
+
+Run against the file fetched above, that returned one page and the exact string the PDF
+was built with. pypdf describes itself on PyPI as "a pure-python PDF library capable of
+splitting, merging, cropping, and transforming PDF files", and `extract_text()` on a page
+object is its own documented example. A file returning an empty string from
+`extract_text()` on every page usually has no real text layer: a scanned image saved
+as a PDF rather than text ever typeset. That case needs OCR, a different tool
+entirely and outside what a text-extraction library does.
+
+## When the link opens a viewer tab instead of downloading anything
+
+Some PDF links, especially ones without a download attribute, open Firefox's
+built-in viewer in a new tab rather than triggering a download at all. That is a
+distinct problem, catching the popup and then getting real bytes out from under the
+viewer, and it has [its own page](how-to-handle-pdf-opens-new-tab-playwright.md)
+rather than a paragraph here.
+
+## Conclusion
+
+Bulk PDF collection is finding, fetching and reading, and each step fails for a
+different reason if skipped. Confirm a link is really a PDF by content type rather
+than URL shape, fetch it through the page's own request context so a login or a bot
+check does not refuse a stranger, name the result deterministically, and hand the
+bytes to a PDF library once they are on disk. The one case deferred entirely here, a
+PDF opening in Firefox's own viewer tab, has a dedicated page of its own.
+
+## Short answers to the questions that lead here
+
+**How do I download all PDF links from a page with Playwright?** Collect every
+anchor's `href`, fetch each through `page.request`, and keep the ones whose response
+`content-type` is `application/pdf`. That catches redirectors and disguised
+query-string links a `.pdf` check would miss.
+
+**Why does requests.get return HTML instead of the PDF?** Either the PDF needs a
+login the separate client never presents, or a bot check on the handshake and
+headers is refusing a client that is not a real browser.
+
+**How do I get a PDF that requires being logged in?** Fetch it with `page.request`
+after signing in. The request context shares the browser's cookie jar automatically,
+so the session carries over without copying anything by hand.
+
+**How do I name downloaded PDFs so reruns do not duplicate them?** Hash the source
+URL into the filename, or read the `filename` parameter off `Content-Disposition` if
+the server sets one.
+
+**What if the PDF opens in a viewer tab instead of downloading?** That is a separate
+situation, catching the new tab and pulling real bytes out from under Firefox's
+viewer, covered on its own page.
+
+**See also:** [how to handle a PDF that opens in a new
+tab](how-to-handle-pdf-opens-new-tab-playwright.md), [how to download files with
+Playwright](how-to-download-files-playwright.md), and [reading and setting cookies in
+a Playwright context](read-set-cookies-playwright-context.md).
+
+## Sources
+
+- Playwright, Downloads, https://playwright.dev/python/docs/downloads - `expect_download`
+  and `save_as`, the route that applies when the server sends the file as an attachment.
+  Read 5 September 2026.
+- pypdf on PyPI, https://pypi.org/project/pypdf/ - the quoted project description and the
+  `PdfReader` / `extract_text()` example. Read 5 September 2026, version 6.17.0.
+- Our own measurement, 5 September 2026, on a locally served page and two generated PDFs:
+  in-page `fetch` returned 200 and `application/pdf`; `page.goto()` on a PDF returned no
+  response object because Firefox's viewer took over; `expect_download` timed out on a
+  plain link; the out-of-page request API is refused by this engine; and pypdf read the
+  text back from the fetched bytes.
+
+---
+
+*Written while maintaining [invisible_playwright](https://github.com/feder-cr/invisible_playwright),
+a Firefox patched at the C++ level driven by stock Playwright. Most of the PDF links
+that ever gave me trouble were not broken; they just were not PDFs yet when I fetched
+them.*

--- a/docs/how-to-scrape-shadow-dom-playwright.md
+++ b/docs/how-to-scrape-shadow-dom-playwright.md
@@ -105,24 +105,37 @@ Two practical consequences follow:
   calls does not.** The moment you write JavaScript by hand inside `evaluate`, you are
   back on the DOM's own rules and the boundary reappears.
 
-## Closed shadow roots: the honest limit
+## Closed shadow roots: where stock Playwright stops
 
-A closed shadow root is unreachable, and no scraping tool, stealth engine or otherwise,
-changes that. This is the part most pages skip. The host's `.shadowRoot` is `null` by the
-component author's explicit choice, so there is no handle for any query to follow. This
-is not a detection surface and there is nothing to spoof or patch: it is a DOM boundary,
-the same one for a stock browser and an automated one.
+A closed shadow root is out of reach for stock Playwright, in Firefox and Chromium
+alike, and Playwright's own documentation says so: "Closed-mode shadow roots are not
+supported." The host's `.shadowRoot` is `null` by the component author's explicit
+choice, so there is no handle for a DOM query to follow. This is not a detection
+surface and there is nothing to spoof: it is an encapsulation boundary the component
+asked for.
+
+**Measured 2026-09-05, and it is the one line on this page that changed:** on a local
+page carrying one open and one closed root, stock Playwright Firefox and stock
+Playwright Chromium each returned zero matches for the closed content, while this
+engine returned one - with the page still reading `null` from `.shadowRoot`, so
+nothing observable to the page moved. The three-arm table, the reproduction page and
+what that does and does not buy you are in
+[closed shadow roots: what Playwright cannot see](closed-shadow-root-playwright.md).
 
 If a locator cannot find content and you have confirmed the element renders, check
-whether the host was attached in closed mode. If it was, the honest answer is that you
-cannot reach it from the DOM at all. The realistic routes are all outside the DOM:
+whether the host was attached in closed mode. On stock Playwright the routes are all
+outside the DOM:
 
 - Read the data from the network response that populated the component, before it was
   rendered, rather than from the rendered tree.
 - Read it from a `<script type="application/json">` payload or a data attribute in the
   light DOM, if the component was hydrated from one.
-- Accept that a genuinely closed component with no other data source is not scrapable
-  through selectors, and stop spending time on selector variations that cannot work.
+- Call whatever the component exposes on its host. A property, a method or an event
+  dispatched with `composed: true` is public by the author's own design, and
+  `page.evaluate` on the host reaches it on every browser, stock included.
+- Accept that on stock Playwright a genuinely closed component with no other data
+  source is not reachable through selectors, and stop spending time on selector
+  variations that cannot work.
 
 Do not trust a blog snippet that claims to "bypass" closed shadow roots by monkeypatching
 `Element.prototype.attachShadow` before the component runs. That works only if you can

--- a/docs/playwright-firefox-arm64-linux.md
+++ b/docs/playwright-firefox-arm64-linux.md
@@ -1,0 +1,107 @@
+---
+title: "Running Playwright Firefox on ARM64 Linux"
+description: "Playwright Firefox on ARM64 Linux: what actually ships per architecture, the emulation trap, memory limits on small boards, and how to verify at runtime."
+parent: "The Automation Layer"
+grand_parent: "Guides"
+nav_order: 46
+---
+
+
+# Running Playwright Firefox on ARM64 Linux
+
+ARM64 Linux runs Playwright's Firefox natively today, on real ARM servers and on boards like the Raspberry Pi, but "it works" depends on which binaries actually exist for your architecture, whether you are running native or emulated, and how much memory the device gives a browser process. Check the compatibility table for your Playwright version before building anything around it.
+
+## Check what exists for your architecture before you design anything
+
+The single most useful step before writing any code is confirming that the browser you plan to drive actually ships an arm64 build at the Playwright version you intend to pin. Playwright's own system requirements name the platforms in one line: "Debian 12 / 13, Ubuntu 22.04 / 24.04 / 26.04 (x86-64 or arm64)", read on 5 September 2026. That sentence covers the distribution and the architecture but not the per-browser split, and the split is where arm64 surprises live, so the check that settles it is running the install for the browser you need on the machine you have and seeing whether a binary lands.
+
+Two cheap checks before anything else: run `dpkg --print-architecture` or `uname -m` on the target host to know what you're actually building for, and try the install step in a throwaway container for that exact architecture, rather than trusting a result from your development laptop.
+
+## x86_64 and arm64 are different downloads of the same version
+
+A given Playwright version is not one universal binary. The install step detects the host architecture and fetches a build matched to it, and arm64 and x86_64 are separate downloads of the same version. Copying a browser cache from an x86_64 machine into an arm64 container does not give you a working browser: the files exist at the expected path and cannot run there, the failure covered in [Playwright "Executable Doesn't Exist" After Install](playwright-executable-doesnt-exist.md).
+
+The safe pattern: run the install step, whether that's `playwright install` or this project's own automatic engine download, on the same architecture that will later launch the browser, never on a different machine with the output copied in afterward.
+
+## The emulation trap
+
+An x86_64 image will often start under emulation on an arm64 host, and the reverse is true too: Docker's `--platform` flag and QEMU user-mode emulation exist specifically to make a foreign-architecture binary runnable. It starts, but it also runs meaningfully slower than a native build, and the slowdown is not uniform across operations.
+
+That matters for anything timing-sensitive. Page load timeouts, wait conditions tuned against a native run, and any check assuming a script finishes inside a fixed window all get less predictable under emulation. [A slow launch caused by an unbounded sequence of per-step timeouts](slow-browser-launch-timeout-budget.md) is a different problem, but the same instinct applies here: prefer the native build for your real architecture, and treat emulation as a fallback, not a default.
+
+## Memory-constrained boards versus real ARM servers
+
+"ARM" covers two very different machines here. A Raspberry Pi or similar board typically has a small, fixed amount of RAM, storage slower than a server SSD, and no active cooling, so sustained CPU load can throttle the whole board, not just slow the browser. A cloud arm64 server is a different animal: server-class memory, no thermal throttling, and none of a small board's SD-card I/O ceiling.
+
+Both are "ARM64 Linux," and the architecture check above passes identically on both, so an architecture mismatch is not what bites you on a small board. Running several browser contexts concurrently is where the two diverge hardest: a board with a few gigabytes of RAM runs out of headroom for concurrent contexts far sooner than a server does, well before any CPU limit.
+
+If you're scaling out concurrent work rather than running one context at a time, [Run invisible_playwright concurrently with asyncio](run-invisible-playwright-concurrently-asyncio.md) covers bounding concurrency with a semaphore, which matters more on a memory-constrained board than on a server with room to spare.
+
+## Container base images for arm64
+
+Most current Debian and Ubuntu base images are published as multi-architecture manifests, so `FROM debian:bookworm-slim` on an arm64 host pulls the arm64 variant automatically without you naming it. That's the simplest path: build on the architecture you intend to run on, and let the base image resolve itself. Docker's own documentation defines a multi-platform build as "a single build invocation that targets multiple different operating system or CPU architecture combinations", and warns that "emulation with QEMU can be much slower than native builds, especially for compute-heavy tasks" - which is the paragraph to remember before you decide to build arm64 images on an x86 laptop. The image below is a starting point to adapt rather than a recipe we have built for your application.
+
+```dockerfile
+FROM --platform=linux/arm64 debian:bookworm-slim
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3 python3-pip ca-certificates
+RUN pip install invisible-playwright
+```
+
+The `--platform` flag pins the build explicitly rather than relying on the Docker daemon's default, which matters if you build on one machine and deploy to another. For a real GPU, font set, or screen presented to the browser instead of a bare container's defaults, see [How to run Playwright in Docker without getting detected](how-to-run-playwright-docker-undetected.md); it applies the same way on arm64, only the base image and engine differ by architecture.
+
+## Verifying at runtime which architecture you actually got
+
+Do not trust the tag on your base image alone; confirm what actually launched.
+
+```
+file /path/to/firefox/firefox-bin
+uname -m
+```
+
+`file` reports the real architecture of the binary regardless of what image tag you built from, which is the check that matters if a multi-stage build or a copied cache is in the picture. The same idea applies to a binary Playwright resolved for you:
+
+```python
+import subprocess
+from playwright.sync_api import sync_playwright
+
+with sync_playwright() as p:
+    exe = p.firefox.executable_path
+    result = subprocess.run(["file", exe], capture_output=True, text=True, check=True)
+    print(exe)
+    print(result.stdout.strip())
+```
+
+One caveat: Python's own `platform.machine()` inside your automation does not prove emulation is absent. It reports the interpreter's own architecture; under QEMU-based emulation, an x86_64 interpreter correctly reports x86_64 for itself while the host does the emulation invisibly. Check the host's real architecture independently instead, your cloud provider's listed instance type, or `uname -m` run outside any emulated container.
+
+## What this project ships, and does not
+
+This project currently builds and publishes engines for Linux on both x86_64 and arm64, and for Windows on x86_64. There is no macOS build; macOS support was discontinued after the engine build for it ended, so a macOS host has no engine to download here regardless of its own CPU architecture.
+
+## Short answers to the questions that lead here
+
+**Does Playwright work on ARM64 Linux, including a Raspberry Pi?**
+Yes, for browsers with native arm64 builds, especially Chromium and Firefox. A Raspberry Pi can run them, but its limited RAM and lack of active cooling become the practical ceiling long before any architecture problem does.
+
+**Can I just run an x86_64 image on an ARM server instead?**
+It usually starts under emulation, but runs slower and less predictably, which matters for anything timing-sensitive. Prefer a native arm64 build whenever you have the choice.
+
+**How do I know if my browser is running natively or under emulation?**
+Run `file` on the resolved browser binary to see its real architecture, and compare it to the host's own `uname -m` or your cloud provider's listed instance type, rather than trusting the image tag alone.
+
+**Does invisible_playwright support ARM64?**
+Yes, on Linux: separate engine builds for x86_64 and arm64, alongside a Windows x86_64 build. There is currently no macOS build.
+
+**Is WebKit's ARM64 Linux support as mature as Chromium and Firefox?**
+Playwright's own system requirements name Debian 12 and 13 and Ubuntu 22.04, 24.04 and 26.04 on "x86-64 or arm64" without splitting the list per browser, so confirm the browser you need actually downloads on your distribution before you build around it.
+
+**See also:** [How to run Playwright in Docker without getting detected](how-to-run-playwright-docker-undetected.md), [Slow browser launch: a per-request timeout is not a budget](slow-browser-launch-timeout-budget.md), and [Run invisible_playwright concurrently with asyncio](run-invisible-playwright-concurrently-asyncio.md).
+
+## Sources
+
+- Playwright, Installation and system requirements, https://playwright.dev/python/docs/intro - "Debian 12 / 13, Ubuntu 22.04 / 24.04 / 26.04 (x86-64 or arm64)", plus the Windows and macOS lines quoted here. Read 5 September 2026.
+- Docker, Multi-platform builds, https://docs.docker.com/build/building/multi-platform/ - a multi-platform build is "a single build invocation that targets multiple different operating system or CPU architecture combinations", and "emulation with QEMU can be much slower than native builds, especially for compute-heavy tasks". Read 5 September 2026.
+
+---
+
+*From the notes of [invisible_playwright](https://github.com/feder-cr/invisible_playwright), which ships and tests its own engine on both Linux architectures, not only the one most laptops happen to have.*

--- a/docs/playwright-firefox-fonts-docker.md
+++ b/docs/playwright-firefox-fonts-docker.md
@@ -1,0 +1,147 @@
+---
+title: "Missing fonts in Docker break Playwright screenshots"
+description: "Docker images ship almost no fonts, so Playwright renders missing glyphs as boxes or the wrong family. How to install real coverage and verify it rendered."
+parent: "Testing and Troubleshooting"
+grand_parent: "Guides"
+nav_order: 28
+---
+
+
+# Missing fonts in Docker break Playwright screenshots
+
+A slim container image ships almost no fonts, so a browser inside it either renders missing glyphs as empty boxes, known as tofu, or silently substitutes one fallback family for everything the page asks for. The fix is installing real coverage for the scripts you need, then confirming the browser picked it up, not just that files exist on disk.
+
+## Why a slim base image turns text into boxes or the wrong font
+
+This is one of the four machine-level tells covered in [how to run Playwright in Docker without getting detected](how-to-run-playwright-docker-undetected.md); this page is the long version of the fonts one.
+
+Two different failures share one root cause, and they look nothing alike on screen. When the page asks for a font family the system has nothing matching, the rendering stack falls back through a chain: to a generic family (serif, sans-serif, monospace), then to whatever font actually exists on the box.
+
+If that fallback font can draw the requested characters, the page renders in the wrong typeface with different letter shapes and widths, and nothing about it looks broken. It just looks like a different font, quietly substituted.
+
+The second failure is louder. When no installed font covers a character at all, commonly a CJK ideograph or an emoji on an image carrying only Latin fonts, the renderer draws the font's own placeholder for a missing glyph: an empty box sometimes called tofu. That box is not a bug in your code; it is the honest rendering of "no glyph exists for this codepoint here."
+
+## Which font packages actually cover what you need
+
+Debian and Ubuntu-based images, which most Playwright containers are, ship almost nothing beyond a couple of core families. Covering Latin, CJK and emoji properly needs a short, specific package list rather than one catch-all install.
+
+| Content | Package (Debian/Ubuntu) | What breaks without it |
+|---|---|---|
+| Latin, Cyrillic, Greek | `fonts-noto` | Text falls back to whatever the base image already has, often nothing close to the platform you claim |
+| CJK (Chinese, Japanese, Korean) | `fonts-noto-cjk` | Every CJK glyph renders as an empty box; there is no partial-match fallback for ideographs |
+| Emoji | `fonts-noto-color-emoji` | Emoji render as boxes or a flat placeholder instead of color art |
+| Metric-compatible Latin business fonts | `fonts-liberation` | Pages that name Arial, Times New Roman or Courier New get a substitute with different character widths |
+
+```dockerfile
+FROM python:3.11-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    fonts-noto \
+    fonts-noto-cjk \
+    fonts-noto-color-emoji \
+    fonts-liberation \
+    fontconfig \
+    && fc-cache -f \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+RUN python -m invisible_playwright fetch
+
+COPY script.py .
+CMD ["python", "script.py"]
+```
+
+`fc-cache -f` rebuilds the font cache after installing packages; skip it and a freshly added family can still be invisible to anything that asked before the cache refreshed. This applies whether you launch through `invisible_playwright` or plain `playwright.sync_api`: the package list and the cache rebuild are what fix the fonts, not which Python class calls `launch()`.
+
+## Confirming the font you expect is the one that rendered
+
+Installing packages is necessary and not sufficient. Confirm the browser is actually using what you installed, from three angles.
+
+First, check the font system itself sees the family, from inside the running container:
+
+```bash
+docker exec <container> fc-list | grep -i noto
+```
+
+An empty result means the package never installed or the cache never rebuilt, regardless of what the Dockerfile claims to do. The package names above were read from Debian's own archive on 5 September 2026: `fonts-noto` is the metapackage that pulls in everything, `fonts-noto-core` is the leaner "No Tofu" core set, `fonts-noto-cjk` covers CJK, `fonts-noto-color-emoji` is Google's colour emoji font, and `fonts-liberation` supplies metric-compatible substitutes for Times, Arial and Courier. The image itself is a starting point to adapt, not a recipe we have built for your application; the `fc-list` check below is the part that tells you whether your version of it worked.
+
+Second, do not reach for `document.fonts.check()` here, and this is the part worth
+measuring before you trust it. The CSS Font Loading API looks like a presence test and is
+not one. MDN defines it as returning true "if you can render some text using the given
+font specification without attempting to use any fonts in this FontFaceSet that are not
+yet fully loaded", which is a statement about web fonts still downloading, not about
+whether a family exists on the machine.
+
+Measured on 5 September 2026 against a local page: `document.fonts.check()` returned
+`true` for `"Noto Sans"`, `true` for `"Arial"`, and `true` for a family invented on the
+spot that exists nowhere. A family that needs no loading is trivially "ready", so the
+answer is `true` whether it exists or not.
+
+```python
+from invisible_playwright import InvisiblePlaywright
+
+with InvisiblePlaywright(seed=42, headless=True) as browser:
+    page = browser.new_page()
+    page.goto("http://127.0.0.1:8746/f.html")
+
+    for family in ("Noto Sans", "Arial", "A Family That Does Not Exist"):
+        print(family, page.evaluate(
+            "f => document.fonts.check('16px \"' + f + '\"')", family))
+    # all three print True
+```
+
+Third, be careful with the measurement trick too. The usual advice is to measure a string
+in the family you installed and again in one you did not, expecting different widths. On
+the same run those two widths came back **identical to the last decimal**, because this
+engine serves declared text metrics rather than whatever the host happens to have, which
+is the whole point of the [`measureText` surface](measuretext-textmetrics-fingerprinting.md)
+being stable here. On a stock browser the two numbers do usually differ, so the trick is
+not worthless in general; it just cannot be your check on this engine.
+
+What is left is the check that actually answers the question: `fc-list` inside the
+container, and your eyes on the screenshot.
+
+## Why a different font set makes text metrics non-comparable across machines
+
+`measureText()` and the wider `TextMetrics` surface return values that depend on the exact font file behind them, not just the family name you asked for. Two machines with different font sets can answer the identical `measureText()` call with different numbers for a string set to the identical CSS family, because the family name resolved to a different underlying file on each one.
+
+That breaks any comparison across environments: a screenshot test that expects pixel-identical output between a laptop and a CI container, or a golden-image diff between two container builds, is really testing "do these two machines have the same fonts installed", not "did the code regress". A failing test can be a real bug or a font package that quietly changed between builds, and nothing about the failure alone tells you which.
+
+The fix is not clever measurement. It is making the font set itself identical, and reproducible, everywhere the code runs, so a difference in the output means a difference in the code, not a difference in what happened to be on disk that day. When this shows up as a flaky screenshot-diff in CI instead of an obvious box, [recording a trace](record-playwright-trace-debug-scraper.md) and reading the filmstrip is faster than re-running the job hoping it passes.
+
+## Conclusion
+
+Boxes and the wrong typeface in a container screenshot are not a Playwright bug and not an automation tell; they are a base image with almost no fonts on it. Install the specific packages your content needs, rebuild the font cache, then confirm with `fc-list` inside the container and by opening the screenshot, because the two browser-side checks that look like they answer this question do not. A font set that differs between machines is rendering you cannot reproduce, and reproducing rendering is the whole point of running the same code somewhere else.
+
+## Short answers to the questions that lead here
+
+**Why do my Playwright screenshots show empty boxes for some characters?**
+No installed font covers those codepoints, so the renderer draws the font's built-in placeholder glyph for a missing character, commonly for CJK text or emoji on an image that only ships Latin fonts.
+
+**Why does text render in the wrong font instead of missing entirely?**
+A similar-enough font exists on the system, so font fallback substitutes it silently. Nothing errors; the page just renders in a typeface with different letter shapes and widths than intended.
+
+**Which font packages should I install in a Playwright Docker image?**
+`fonts-noto` for broad Latin and script coverage, `fonts-noto-cjk` for Chinese, Japanese and Korean, `fonts-noto-color-emoji` for emoji, and `fonts-liberation` if pages expect Arial, Times New Roman or Courier New specifically.
+
+**How do I check a font actually installed inside a running container?**
+`docker exec <container> fc-list | grep -i <family>`. An empty result means the package never installed or the font cache never rebuilt after installing it.
+
+**Why do screenshot or text-metric tests pass locally and fail in CI?**
+The two environments likely have different font sets, so identical `measureText()` calls or screenshots differ for a font reason that has nothing to do with the code change under test.
+
+**See also:** [how to run Playwright in Docker without getting detected](how-to-run-playwright-docker-undetected.md), [measureText and TextMetrics as a fingerprinting surface](measuretext-textmetrics-fingerprinting.md), and [recording a Playwright trace to debug a failed scrape](record-playwright-trace-debug-scraper.md).
+
+## Sources
+
+- Debian package `fonts-noto-core`, https://packages.debian.org/trixie/fonts-noto-core - described by Debian itself as the "No Tofu" font families with large Unicode coverage, which is where the word tofu in this page comes from. Read 5 September 2026 on the trixie (stable) page.
+- MDN, `FontFaceSet.check()`, https://developer.mozilla.org/en-US/docs/Web/API/FontFaceSet/check - returns true "if you can render some text using the given font specification without attempting to use any fonts in this FontFaceSet that are not yet fully loaded", and takes a CSS font specification plus optional text. Read 5 September 2026.
+- MDN, `CanvasRenderingContext2D.measureText()`, https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/measureText - returns a TextMetrics object "that contains information about the measured text (such as its width, for example)". Read 5 September 2026.
+- Debian package search, https://packages.debian.org/ - the package names quoted in this page were read there on 5 September 2026; confirm the exact names for the release your base image is built on, because they differ between Debian releases.
+
+---
+
+*From the notes of [invisible_playwright](https://github.com/feder-cr/invisible_playwright). The font problem here is not specific to this project: any Playwright container, patched engine or stock, inherits whatever the base image ships.*

--- a/docs/playwright-firefox-memory-long-runs.md
+++ b/docs/playwright-firefox-memory-long-runs.md
@@ -1,0 +1,233 @@
+---
+title: "Keep Playwright Firefox memory flat on long runs"
+description: "Playwright Firefox memory grows from unclosed contexts, a list holding every result, or one context reused too long, not a Python leak. How to measure it."
+parent: "Testing and Troubleshooting"
+grand_parent: "Guides"
+nav_order: 27
+---
+
+
+# Keep Playwright Firefox memory flat on long runs
+
+Playwright Firefox memory grows for four ordinary reasons: contexts and pages that
+never get closed, listeners piling up on a page you keep reusing, response data held
+in a Python list across thousands of requests, and one context accumulating state
+across a long run. Close what you open, stream what you collect, and restart the
+browser on a page budget.
+
+## A four-hour crash is rarely a Python leak
+
+A scraper that dies after a few hours almost never has a Python-side memory leak.
+Python's own objects, the strings, the dicts, the lists you build, get
+garbage-collected the same way they would in any long-running script. What actually
+grows is the browser process the scraper is driving, and the growth follows a small
+number of predictable causes rather than a mystery leak in the language itself.
+
+## What actually grows over a long run
+
+Four causes account for almost all of it, and each has a fix that costs little once
+you know to look for it:
+
+| What grows | Why | The fix |
+|---|---|---|
+| Pages and contexts never closed | Each one keeps its own DOM, JS heap, and network cache alive until closed | Close every context (and page) in a `finally`, one context per unit of work |
+| Listeners and console handlers | `page.on("console", ...)` and similar handlers accumulate if a new one is attached on every page without removing the old | Attach handlers once per page, not once per navigation, or remove them before reusing the page |
+| Response bodies held in memory | Appending every scraped record to a list that lives for the whole run | Stream each result to disk as you get it; keep only the current record in memory |
+| One context reused across thousands of navigations | Cookies, cache entries, and storage accumulate in a context that never gets replaced | Restart the browser (or the context) on a page budget rather than running one context forever |
+
+## One context per unit of work, closed in a finally
+
+A context is cheap to create and close, and it is the natural unit for one page, one
+form, one product to scrape. Closing it in a `finally` guarantees the close runs even
+when the scrape raises, which matters because a skipped `context.close()` is exactly
+how a long run accumulates hundreds of half-closed contexts unnoticed.
+
+```python
+from invisible_playwright import InvisiblePlaywright
+
+with InvisiblePlaywright(seed=42) as browser:
+    for url in urls:
+        context = browser.new_context()
+        try:
+            page = context.new_page()
+            page.goto(url)
+            save_result(page.locator("h1").inner_text())
+        finally:
+            context.close()
+```
+
+Running several of these loops at once multiplies the same discipline across
+contexts rather than replacing it; see
+[scraping multiple pages in parallel](how-to-scrape-multiple-pages-in-parallel-playwright.md)
+for how the parallel version still has to close what it opens.
+
+## Stream results to disk instead of holding them in a list
+
+A list that grows by one entry per page, across a run touching tens of thousands of
+pages, does exactly what a leak does: grows without bound for the life of the
+process. Holding the whole run's output in memory when you only need the current
+record is the actual mistake, not the list itself.
+
+```python
+import json
+
+with open("results.jsonl", "a") as f:
+    for url in urls:
+        row = scrape_one(url)
+        f.write(json.dumps(row) + "\n")
+        # nothing is kept in a Python list across iterations
+```
+
+Appending to a file is one write call per record and nothing left to
+garbage-collect later. If a downstream step needs the whole dataset, read the file
+back once the run is done rather than keeping it live during the run.
+
+## Restart the browser on a page budget
+
+Some growth in a context is not a bug at all, it is cache and storage the site
+itself wrote, and it is honest for that to grow across thousands of navigations in
+the same context. The fix is not to chase it field by field: it is to stop asking
+one context to live forever.
+
+```python
+from invisible_playwright import InvisiblePlaywright
+
+PAGES_PER_BROWSER = 500
+
+def run_batch(urls):
+    with InvisiblePlaywright(seed=42) as browser:
+        for url in urls:
+            context = browser.new_context()
+            try:
+                page = context.new_page()
+                page.goto(url)
+                scrape_one(page)
+            finally:
+                context.close()
+
+for i in range(0, len(all_urls), PAGES_PER_BROWSER):
+    run_batch(all_urls[i:i + PAGES_PER_BROWSER])
+```
+
+Exiting the `with` block closes the browser process outright, and the next batch
+starts clean. Pick the budget from how the run behaves, not a round number pulled
+from nowhere, and weigh it against launch cost; see
+[the launch timeout budget](slow-browser-launch-timeout-budget.md) before restarting
+so often that launching becomes the bottleneck.
+
+## Measure the browser's own process tree, not your script's
+
+A Python-side memory profiler tells you nothing about the browser process
+Playwright is driving. The browser is a separate process, several, on Firefox, and
+its memory does not show up in a Python heap profiler at all. Measure the operating
+system's view of the process tree instead.
+
+```python
+import psutil
+
+before = {p.pid for p in psutil.process_iter()}
+
+# ... launch the browser and run the workload here ...
+
+def browser_rss_mb(exclude_pids):
+    total = 0
+    for proc in psutil.process_iter(["name"]):
+        try:
+            if proc.pid not in exclude_pids and "firefox" in (proc.info["name"] or "").lower():
+                total += proc.memory_info().rss
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            pass
+    return total / (1024 * 1024)
+
+print(f"{browser_rss_mb(before):.0f} MB in this run's browser processes")
+```
+
+Two details in that function are the difference between a number and a fiction, and we
+learned the second one by getting it wrong. Filtering on the process name keeps unrelated
+children out of the sum. Excluding the pids that already existed keeps out **every other
+browser on the machine**, including the one a previous run left behind: our own first
+attempt at this measurement reported a baseline of nearly a gigabyte for a single page,
+because a browser from the previous arm of the same script had not finished exiting when
+the next arm started sampling. The number was real, the attribution was nonsense.
+
+The practical rule that follows: sample the pid set immediately before you launch, never
+compare two arms that ran back to back in one process without checking that the first
+one's browser is gone, and treat any absolute figure from a machine doing other work as
+unusable. Relative growth on an idle machine is the only version of this measurement
+worth acting on.
+
+Snapshot the full set of running pids before you launch anything, not just the pid
+your launch call returns. On Windows, Firefox starts through a short-lived launcher
+process that spawns the real browser and exits within a fraction of a second;
+reading children from that pid right after launch can catch the launcher already
+gone. Diffing the full pid set before and after sidesteps that, and the same
+approach applies when
+[several browsers run concurrently](run-invisible-playwright-concurrently-asyncio.md).
+
+## A real leak keeps climbing; ordinary allocator behaviour plateaus
+
+A single reading tells you the process is using some number of megabytes and
+nothing about whether that number is a problem. Take the same measurement at
+several checkpoints spaced across the run and look at the shape across those
+checkpoints, not any one of them.
+
+An allocator that holds onto freed memory for reuse, rather than returning it to
+the OS immediately, produces a step up followed by a plateau. A genuine leak keeps
+climbing roughly in proportion to pages processed, checkpoint after checkpoint,
+with no point where it levels off. The exact numbers depend on the machine, so
+treat the shape of the trend as the signal, not any specific figure.
+
+## Conclusion
+
+Most Playwright Firefox memory problems trace back to state nobody closed, not a
+leak in the language. Close every context in a `finally`, stream results to disk
+instead of a growing list, and restart the browser on a measured page budget. When
+you measure, read the operating system's process tree, snapshotted before launch
+and diffed after, and judge growth by its shape across checkpoints, not one number.
+
+## Short answers to the questions that lead here
+
+**Why does my Playwright script's memory keep growing over a long run?** Almost
+always contexts or pages that never get closed, a list holding every result, or one
+context accumulating cache and storage across thousands of navigations, not a leak
+in Python itself.
+
+**How do I measure how much memory a Playwright browser is really using?**
+Snapshot the full set of running process ids before you launch, diff against the
+full set again after the workload runs, and sum the RSS of whatever is new. A
+Python profiler will not see the browser process.
+
+**Why does psutil miss part of the Firefox process tree?** Firefox on Windows
+starts through a launcher process that spawns the real browser and exits almost
+immediately. Reading children from the launcher's pid right after launch can catch
+it already gone.
+
+**Should I restart the browser periodically to control memory?** Yes, once a
+context has handled a page budget you have measured, rather than letting one
+context run forever. Exiting the browser's `with` block and starting a new one is
+enough.
+
+**How do I tell a real memory leak from normal browser behaviour?** Measure at
+several checkpoints across the run. A leak keeps climbing roughly in proportion to
+work done; ordinary allocator behaviour rises once and then plateaus.
+
+**See also:** [scraping multiple pages in parallel](how-to-scrape-multiple-pages-in-parallel-playwright.md),
+[running invisible_playwright concurrently with asyncio](run-invisible-playwright-concurrently-asyncio.md),
+and [the browser launch timeout budget](slow-browser-launch-timeout-budget.md).
+
+## Sources
+
+- Playwright documentation, [BrowserContext.close()](https://playwright.dev/python/docs/api/class-browsercontext#browser-context-close) and [Browser.close()](https://playwright.dev/python/docs/api/class-browser#browser-close).
+- psutil documentation, [process_iter() and Process.memory_info()](https://psutil.readthedocs.io/en/latest/#psutil.process_iter).
+- psutil, https://psutil.readthedocs.io/ - `process_iter()` and `Process.memory_info()`,
+  used exactly as shown above. The code in this page was run on 5 September 2026; the
+  absolute megabyte figures from that run are deliberately not quoted, because the bench
+  was not clean enough to attribute them, which is the point the measurement section
+  makes.
+
+---
+
+*Written while maintaining [invisible_playwright](https://github.com/feder-cr/invisible_playwright),
+a Firefox patched at the C++ level driven by stock Playwright. The memory discipline
+here is the same discipline any long-running browser automation needs; nothing
+about it is specific to this engine.*

--- a/docs/playwright-select-option-dropdowns.md
+++ b/docs/playwright-select-option-dropdowns.md
@@ -1,0 +1,232 @@
+---
+title: "Select from dropdowns with Playwright, native and custom"
+description: "select_option() drives a real <select>; a custom listbox needs a click, a wait, then a click. How to tell the two apart and drive both in Playwright."
+parent: "Scraping with Playwright"
+grand_parent: "Guides"
+nav_order: 148
+---
+
+
+# Select from dropdowns with Playwright, native and custom
+
+A dropdown in Playwright is one of two things wearing the same look: a real `<select>`,
+driven with `locator.select_option()`, or a custom widget built from a div and some
+JavaScript, driven by clicking the trigger, waiting for the option list, and clicking the
+option. Telling them apart takes one line of code.
+
+## The two jobs hiding inside one dropdown
+
+A native `<select>` is a browser control: the browser owns the open state, the keyboard
+navigation, and the value, and Playwright drives all of it through one method,
+`select_option()`. You never open the list yourself; the call selects the option and
+reports back which values ended up chosen.
+
+A custom dropdown is not a form control at all, usually a button or div with
+`role="combobox"` or `role="listbox"` behind it, with the option list only present in the
+DOM while it is open. There is no select-an-option API for that, so you drive it the way
+a person would: click to open, wait for the option to render, click it. Both look
+identical by eye; only the tag name tells you which one you have.
+
+## Tell them apart in one line
+
+Read the tag name of the dropdown's visible trigger. A real `<select>` reports `SELECT`;
+anything else is a custom widget you have to click open.
+
+```python
+from invisible_playwright import InvisiblePlaywright
+
+with InvisiblePlaywright(seed=42) as browser:
+    page = browser.new_page()
+    page.goto("https://example.com/form")
+
+    tag = page.locator("#country").evaluate("el => el.tagName")
+    is_native = tag == "SELECT"
+    print(tag, is_native)
+```
+
+Do this once, while writing the script; the tag does not change between runs, so there
+is no need to check it live on every navigation.
+
+## Selecting from a native select
+
+For a real `<select>`, `Locator.select_option()` takes the option's `value`, its visible
+`label`, or its zero-based `index`, and returns the list of values that ended up selected:
+
+```python
+from invisible_playwright import InvisiblePlaywright
+
+with InvisiblePlaywright(seed=42) as browser:
+    page = browser.new_page()
+    page.goto("https://example.com/form")
+
+    page.locator("#country").select_option(value="IT")
+    page.locator("#country").select_option(label="Italy")
+    page.locator("#country").select_option(index=2)
+```
+
+Pick `label` when you only know the visible text (a country name); pick `value` when you
+know the underlying code and want the match to survive a copy change. The method already
+waits for the element to be attached and enabled, the same checks Playwright applies
+before a click.
+
+## A multi-select select takes a list
+
+A `<select multiple>` accepts more than one option, and `select_option()` mirrors that:
+pass a list and every value in it gets selected, replacing whatever was chosen before.
+
+```python
+page.locator("#toppings").select_option(["olives", "mushrooms"])
+```
+
+That is the whole difference: a string or dict selects one option, a list selects
+several. The same idea reappears in a faceted search page that lets you tick several
+categories at once; see
+[scraping multi-select facets](how-to-scrape-multi-select-facets-playwright.md) for that
+pattern.
+
+## Selecting from a custom dropdown
+
+A custom dropdown has no `select_option()` to call. You open it, wait for the option to
+exist, and click it, the same three steps a person takes:
+
+```python
+page.get_by_role("combobox", name="Country").click()
+
+option = page.get_by_role("option", name="Italy")
+option.wait_for(state="visible")
+option.click()
+```
+
+`.click()` already waits for the target to be visible and stable, so the explicit
+`wait_for()` above mostly documents the two separate steps: open, then find. A fast page
+works without it; a slow one just retries the click until the option exists.
+
+## ARIA roles keep a custom dropdown readable
+
+`page.get_by_role()` locates elements by accessible role and name rather than by class
+name, which for a custom dropdown survives a CSS refactor that would break a class
+selector. `role="combobox"` marks the trigger, `role="listbox"` marks the open list, and
+`role="option"` marks each choice, roles the widget already carries for its own
+accessibility tree.
+
+No ARIA roles at all still means clickable, just less pleasant: fall back to a
+`data-testid` or a stable class, and treat the gap as a sign this widget was not built
+with accessibility in mind.
+
+## When the option list only appears after you click
+
+Some dropdowns fetch their options from the network the moment they open, an
+autocomplete city picker, a search-as-you-type combobox, anything too large to ship up
+front. The click that opens the trigger and the request that fills the list are two
+different events; clicking an option before the request resolves finds nothing there.
+
+```python
+page.get_by_role("combobox", name="City").click()
+
+# Scope the wait to the list. A bare get_by_role("option") also matches the
+# options inside every native <select> on the page, and .first will be one of
+# those: measured, it waits 30 seconds and times out on an element that is
+# real but not visible.
+options = page.get_by_role("listbox").get_by_role("option")
+options.first.wait_for(state="visible")
+page.get_by_role("option", name="Rome").click()
+```
+
+Waiting on the first option instead of a fixed delay makes the script wait exactly as
+long as the network takes. The same idea, wait for the thing that has to appear rather
+than a fixed number of seconds, is the whole subject of
+[how to wait for a page to finish loading](how-to-wait-for-page-load-playwright.md).
+
+## select_option can succeed while the page never notices
+
+Here is the failure mode that costs an afternoon: `select_option()` reports success, the
+DOM shows the right option selected, and the page's own behaviour, a totals
+recalculation, a chart redraw, a results grid re-sort, never happens. Nothing threw. The
+value is correct. The page just did not react.
+
+Playwright fires both an `input` and a `change` event once the selection lands, which
+covers most sites, and both arrive with `isTrusted` set to `true`: measured on 5
+September 2026 on a local page that logs every event it receives, three selections in a
+row, six events, `isTrusted` true on all of them. So a framework that gates on
+`event.isTrusted` before reacting is not the explanation when nothing moves. Some
+pages instead listen for a `keyup` from arrow-keying through the list, or a `mousedown`
+on the option, because that is how the widget was built by hand, and `select_option()`
+never fires either one.
+
+When the value changes but nothing downstream moves, drive it from the keyboard instead.
+The order matters more than it looks, and this is the part worth measuring rather than
+copying from a blog:
+
+```python
+# Works: focus, then arrow. Each press moves the selection one option down.
+page.locator("#sort").focus()
+page.locator("#sort").press("ArrowDown")
+
+# Also works: type the first letter of the option's label.
+page.locator("#sort").focus()
+page.locator("#sort").press("I")     # jumps to "Italy"
+```
+
+Measured on 5 September 2026 against a three-option native select starting on the first
+option: `focus()` then one `ArrowDown` moved it to the second, two presses moved it to
+the third, and pressing the label's first letter jumped straight to that option. The
+sequence you will see recommended most often, `click()` then `ArrowDown` then `Enter`,
+**left the value untouched** on the same page: clicking a native select opens the
+platform's own dropdown, and the key presses that follow do not land where you expect.
+Focus without clicking, and skip the `Enter`.
+
+## Conclusion
+
+Work out which dropdown you have before writing the rest of the script:
+`locator.evaluate("el => el.tagName")` answers it in one line. A native `SELECT` takes
+`select_option()`, with `value`, `label`, `index`, or a list for a multiple select; a
+custom dropdown takes a click, a wait, and a click on the option, and ARIA roles make
+that sequence readable. Whatever the dropdown filters, that result is usually what you
+came to scrape; see
+[how to scrape HTML tables with Playwright](how-to-scrape-html-tables-playwright.md).
+
+## Short answers to the questions that lead here
+
+**How do I select a dropdown option in Playwright with Python?** Call
+`locator.select_option(value=...)`, `label=...`, or `index=...` on a real `<select>`. For
+a custom widget, click the trigger, wait for the option, then click it.
+
+**How do I know if a dropdown is a real select or a custom one?** Read its tag name:
+`locator.evaluate("el => el.tagName")`. `SELECT` means use `select_option()`; anything
+else means click, wait, click.
+
+**How do I select multiple options in Playwright?** Pass a list to `select_option()`,
+for example `select_option(["olives", "mushrooms"])`. Every value in the list gets
+selected in one call.
+
+**Why did select_option() work but the page did not update?** The listener is probably
+bound to a keyboard or mouse event, not `change`. Open the dropdown and press
+`ArrowDown` then `Enter` instead.
+
+**Why can't I click an option I know is on the page?** It likely has not rendered yet.
+Many custom dropdowns fetch their options after the click that opens them; wait for the
+option before clicking it.
+
+**See also:** [scraping multi-select facets](how-to-scrape-multi-select-facets-playwright.md),
+[waiting for a page to finish loading](how-to-wait-for-page-load-playwright.md), and
+[scraping HTML tables once the filter is applied](how-to-scrape-html-tables-playwright.md).
+
+## Sources
+
+- Playwright documentation, [Input: select options](https://playwright.dev/python/docs/input#select-options), covering `select_option()` and the events it fires.
+- Playwright documentation, [Locator.select_option()](https://playwright.dev/python/docs/api/class-locator#locator-select-option).
+- Playwright documentation, [Locator.get_by_role()](https://playwright.dev/python/docs/api/class-page#page-get-by-role), the ARIA role locator strategy.
+- Playwright, Input, https://playwright.dev/python/docs/input - "Selects one or multiple
+  options in the `<select>` element with locator.select_option(). You can specify option
+  `value`, or `label` to select. Multiple options can be selected." Read 5 September 2026.
+- Our own measurement, 5 September 2026, on a local page: `select_option()` by value, by
+  label and by index each returned the list of selected values; a multiple select
+  accepted a list; both `input` and `change` fired with `isTrusted` true; and calling
+  `select_option()` on a non-select element raised `Error: Locator.select_option: Element
+  is not a <select> element`.
+
+---
+
+*Written while maintaining [invisible_playwright](https://github.com/feder-cr/invisible_playwright),
+a Firefox patched at the C++ level driven by stock Playwright. The dropdown API here is
+stock Playwright end to end; nothing about it changes on this engine.*

--- a/docs/queue-it-virtual-waiting-room-explained.md
+++ b/docs/queue-it-virtual-waiting-room-explained.md
@@ -1,0 +1,148 @@
+---
+title: "Queue-it virtual waiting rooms, explained for automation"
+description: "Queue-it virtual waiting rooms explained: how the redirect, the return token and the JS-vs-server split work, and why automation has nothing to bypass."
+parent: "Detectors, Explained"
+grand_parent: "Guides"
+nav_order: 45
+---
+
+
+# Queue-it virtual waiting rooms, explained for automation
+
+Queue-it is a virtual waiting room: a SaaS admission-control layer a site turns on when
+demand exceeds what its backend can serve. It redirects overflow visitors to a separate
+queue domain, shows each one a position and an estimated wait, then sends them back with a
+signed token once their turn arrives. It is not a bot detector.
+
+## What problem Queue-it actually solves
+
+Queue-it does not decide whether you are a bot. It decides whether your request arrives
+before, during, or after a demand spike the backend cannot handle at once: a ticket
+release, a product drop, a public booking window. The queue admits visitors in order
+instead of letting all of them hit the backend at the same moment, an availability
+decision, not a security one. Confusing the two wastes most of the debugging time this
+vendor produces.
+
+## How the redirect and the return token actually work
+
+When the queue is open, a request for the protected page never reaches the origin. It gets
+redirected to a separate queue-hosting domain, typically a subdomain under `queue-it.net`
+, where a page shows a position and an
+estimated wait, updated by the page's own script polling a status endpoint. The position
+comes from a server-side counter tied to your session, not from how you rendered the page.
+
+When your turn comes, the queue page redirects back to the original URL with a signed
+token attached to the query string, proving you went through the queue in order and within
+a valid window. Whatever receives the request next, the origin or an edge rule, is meant to
+check that token before granting access, using a server-side library Queue-it generally
+calls KnownUser, published as connector SDKs in several languages. Skip that check and the queue
+becomes advisory: a guessed or replayed token reaches the page directly, a site integration
+mistake this page is not describing how to reproduce.
+
+## The JavaScript connector and the server check do different jobs
+
+The JS snippet a site embeds decides, client-side, whether a visitor should be sent to the
+queue, and renders the waiting-room page once they are there: a user-experience layer,
+often the first piece a site adds since it needs no server changes. What actually enforces
+anything is the server-side or edge validation of the returned token. A page carrying only
+the JS connector, with nothing checking the token on the way back, is locking a gate that
+was never shut. Assume enforcement lives on the receiving end, never in the page source.
+
+## This is not bot detection, and there is nothing here to defeat
+
+A waiting room runs nothing like [the obfuscated bytecode VM Kasada uses to interrogate
+your JS engine](kasada-explained.md). It is a position counter and a clock, not a check on
+whether `navigator.webdriver` lies. Some deployments layer bot mitigation on top, aimed at
+scripts opening many parallel sessions to grab more than one spot in line
+, worth knowing so you do
+not mistake it for a fingerprint problem, but a separate concern this project does not try
+to get around.
+
+## What a script should actually do at a queue
+
+Recognize the redirect by checking the page's hostname, then wait for the one signal that
+matters: the URL changing back with the token attached, the same principle as [choosing a
+wait that matches the real signal instead of a fixed sleep or a `networkidle`
+guess](how-to-wait-for-page-load-playwright.md), applied to a wait that can run for
+minutes.
+
+```python
+from invisible_playwright import InvisiblePlaywright
+
+with InvisiblePlaywright(seed=42) as browser:
+    page = browser.new_page()
+    page.goto("https://example.com/high-demand-page")
+
+    if "queue-it.net" in page.url:
+        # In line: wait for the site's own redirect back, not a fixed sleep.
+        # This can legitimately take minutes. Do not race the poll interval.
+        page.wait_for_url("https://example.com/**", timeout=0)
+
+    print(page.title())
+```
+
+That shape was exercised on 5 September 2026 against a locally served page that behaves
+like a waiting room: it holds the visitor, then redirects to the destination with a
+`queueittoken` in the query string. `wait_for_url` woke on the redirect, and the token
+was present on arrival, which is the signal that the connector on the other side will
+validate and then strip.
+
+Do not poll on your own timer faster than the waiting-room page already does. That looks
+like the abuse pattern above, and buys nothing.
+
+## What breaks a script mid-queue
+
+The queue position is tied to a specific session, not to a URL. Restart the browser
+context, open a second tab for "the same" visit, or relaunch Playwright mid-wait, and the
+new context reads as a brand-new visitor: back of the line at best, a second attempt
+flagged at worst. Hold the same context open for the whole wait, and never treat a long
+wait as a hung script.
+
+## Where this project draws the line
+
+invisible_playwright does not attempt to skip a Queue-it wait. Getting through faster than
+a site's own admission control allows does not remove the capacity problem, it moves it
+onto whoever's request lands after yours, and it is likely a terms violation on top of
+accomplishing nothing. If you suspect a queue is actually a block in disguise, [the
+four-layer model for a block that survives a clean
+fingerprint](why-blocked-with-a-clean-fingerprint.md) does not include one at all: it is a
+fifth thing, and the fix for a real queue is to wait, not to debug.
+
+## Short answers to the questions that lead here
+
+**Is Queue-it a bot detector?** No. It is admission control for demand that exceeds
+capacity, a position and a clock, not a fingerprint check. Some deployments add bot
+mitigation against queue abuse specifically, separate from the waiting room mechanism.
+
+**Can automation skip a Queue-it wait?** No, not without defeating the point of a capacity
+queue, and this project does not attempt it. The correct behavior for a script is the same
+as for a person: wait, holding the same session, until the redirect back arrives.
+
+**Why did my script lose its place in the queue?** Almost always because the browser
+context was restarted, or a second context was opened for the same visit, while a position
+was still pending. The queue reads that as a new visitor, not a continuation.
+
+**See also:** [how Kasada's actual bot-detection VM works, for contrast](kasada-explained.md),
+[choosing the wait that matches the real signal instead of a fixed
+sleep](how-to-wait-for-page-load-playwright.md), and [the four-layer model for a block that
+is not the fingerprint](why-blocked-with-a-clean-fingerprint.md).
+
+## Sources
+
+- Queue-it developer pages, https://www.queue-it.com/developers/ - Queue-it's own
+  description of its "suite of Connector SDKs and REST-based APIs that gives you control
+  over the visitor flow and behavior", and the three integration routes: connectors, the
+  REST API, and themed waiting-room pages. Read 5 September 2026.
+- Queue-it KnownUser connector, https://github.com/queueit/KnownUser.V3.JavaScript - the
+  request-by-request validation, the redirect to the queue when no valid token is
+  present, and the removal of the token from the query string on return, which the
+  README explains is "to avoid sharing of user specific token". The same README states
+  the check must run on all requests except those for static and cached pages. Read
+  5 September 2026.
+- This wiki's own [kasada-explained.md](kasada-explained.md), for what a client-side VM
+  checks, used only as a contrast.
+
+---
+
+*From the notes of [invisible_playwright](https://github.com/feder-cr/invisible_playwright).
+A capacity queue is not a challenge worth solving faster than anyone else: wait.*

--- a/docs/vs-browser-use.md
+++ b/docs/vs-browser-use.md
@@ -1,0 +1,140 @@
+---
+title: "invisible_playwright vs browser-use: different jobs"
+description: "invisible_playwright vs browser-use compared: an LLM-driven agent framework against a Firefox engine you drive yourself with plain Playwright code."
+parent: "Comparisons"
+nav_order: 38
+---
+
+
+# invisible_playwright vs browser-use: different jobs
+
+invisible_playwright and browser-use solve different problems, and this page is written by
+people who maintain the former, so read the comparison with that in mind. browser-use puts
+a language model in the loop, deciding each browser action from the page's current state.
+invisible_playwright is a browser you drive yourself, with Playwright's own API and no
+model involved at any step.
+
+## What browser-use actually is
+
+browser-use ([browser-use/browser-use on GitHub](https://github.com/browser-use/browser-use))
+is an agent framework: you describe a task in plain language, and on each step it hands the
+page state to a language model, which decides the next action, a click, a type, a scroll,
+an extraction, and the framework carries it out through Playwright. What changes versus a
+plain script is upstream of the click: nothing in your code decides the next step. The
+model does, fed a fresh read of the page every time. The project states the shape plainly
+in its own repository: it exists to "make websites accessible for AI agents", it is MIT
+licensed, it wants Python 3.11 or newer, and it drives the browser through Playwright
+while the model chooses the actions.
+
+## What this project actually is
+
+invisible_playwright is not an agent and decides nothing. It is a real Firefox, patched at
+the engine level, driven with plain, synchronous Playwright code you write yourself:
+
+```python
+from invisible_playwright import InvisiblePlaywright
+
+with InvisiblePlaywright(seed=42) as browser:
+    page = browser.new_page()
+    page.goto("https://example.com/product/x")
+    print(page.locator("#price").inner_text())
+```
+
+Given the same script and the same seed, it does the same thing every run, because "the
+same thing" is exactly what you wrote. There is no model anywhere in that loop.
+
+## Determinism versus adaptability
+
+A fixed script is deterministic by construction, the same selectors and order every run,
+until the page changes underneath it. Then it fails loudly, at the exact line that no
+longer matches, with an error naming what was missing. An LLM-driven agent is the opposite
+shape: fed a new layout or a moved field, it can often route around the change without a
+code update, because it reasons about the page fresh each time. The same task run twice is
+not guaranteed to take the same path, and a wrong guess can look like success: a crashed
+script is easy to notice, a task that quietly completed the wrong step is not.
+
+## Cost: a model call per step, or none at all
+
+browser-use's loop calls a language model with the page state to decide each action, so a
+task needing a dozen actions makes roughly that many calls, and the token cost scales with
+how long and ambiguous the task is. The repository's own note about resources points the
+same way: it warns that "Chrome can consume a lot of memory, and running many agents in
+parallel can be tricky to manage", and steers heavy parallel use toward their hosted
+service. invisible_playwright makes no model calls at all; the cost
+of a run is your own compute and, through a proxy, the network.
+
+## They compose, they do not compete
+
+browser-use needs some browser under it, Chromium by default, driven through Playwright.
+This wiki's own notes on its configuration surface found the launch levers
+(`executable_path`, `user_data_dir`, `proxy`, `headless`, `args`) [all Chromium-family, with
+MCP as the route that reaches a different engine at all](browser-use-detection.md).
+invisible_playwright competes with none of that; the place the two could meet, an agent
+deciding actions on a Firefox that reads as genuine, is MCP, not a shared config file.
+
+## At a glance
+
+| Question | browser-use | invisible_playwright |
+|---|---|---|
+| What decides the next action | A language model, called per step | Your own code |
+| Default browser driven | Chromium, via Playwright | A patched Firefox |
+| Needs an LLM API key | Yes | No |
+| Same task, same result every run | Not guaranteed | Yes, given the same script and seed |
+| Failure when the page changes | Can sometimes route around it | Raises, naming what was missing |
+
+## Where browser-use is genuinely stronger
+
+Being straight about this, because a comparison that only lists your own advantages is not
+a comparison. browser-use is built for exactly the case where writing and maintaining
+selectors is the bottleneck, and where reasoning about a page once is cheaper than
+scripting it. Its community and ecosystem around agentic browsing are large and growing
+fast, which means more examples and more people who already hit the problem you are about
+to. It gets a first working result faster for someone who does not want to identify
+selectors before writing a line. invisible_playwright does none of that; it expects you to
+already know what you want to click.
+
+## How to actually choose
+
+- **A task that changes shape across sites, better described than coded?** browser-use
+  fits, at the cost of a model call per step and a result not guaranteed to repeat.
+- **A fixed task that must run the same way every time, at no per-step cost?** A plain
+  Playwright script does that, and this project's job is making the Firefox underneath it
+  read as genuine.
+- **The target reads the browser itself closely** (fonts, GPU, canvas, TLS)**?** That
+  question sits at the engine layer, covered in [vs Patchright](vs-patchright.md) and
+  [vs Camoufox](vs-camoufox.md), regardless of which framework drives the browser.
+- **Undecided?** Run the task both ways against your real target and compare what each gets
+  flagged for.
+
+## Short answers to the questions that lead here
+
+**Is browser-use better than Playwright?** Not comparable. browser-use is an agent that
+decides actions with a language model; Playwright is the automation API it runs on, and the
+one invisible_playwright exposes directly with no model involved.
+
+**Can browser-use use Firefox instead of Chromium?** Its documented setup is
+Chromium-family, and the route that reaches a different engine is MCP rather than a
+launch-option swap.
+
+**Can I use browser-use and invisible_playwright together?** Not through browser-use's
+launch configuration. An agent driving a Firefox engine like this one goes through MCP
+instead, a different integration path than a shared config file.
+
+**See also:** [invisible_playwright vs Patchright: driver vs engine](vs-patchright.md),
+[invisible_playwright vs Camoufox: two patched Firefoxes](vs-camoufox.md), and [what you can
+and cannot change about browser-use's own detection surface](browser-use-detection.md).
+
+## Sources
+
+- browser-use repository, https://github.com/browser-use/browser-use - the quoted
+  one-line description, the MIT license, the Python 3.11 floor, Playwright underneath,
+  the LLM-driven action loop, and the memory note about running many agents in parallel.
+  Read 5 September 2026.
+- This wiki's own [browser-use-detection.md](browser-use-detection.md), previously verified
+  against browser-use's configuration surface, for the Chromium-family launch levers.
+
+---
+
+*From the notes of [invisible_playwright](https://github.com/feder-cr/invisible_playwright).
+browser-use solves a real problem, deciding what to do on a page, that this project never
+attempts.*


### PR DESCRIPTION
Every code block in this wave was executed before it shipped, and three recipes died in the process.

The biggest one is a correction to an existing page. Three arms on one local page: stock Playwright Firefox and stock Playwright Chromium each return zero matches for content inside a closed shadow root, this engine returns one, and the page still reads null from shadowRoot. The shadow DOM page claimed the boundary was absolute for every tool; it now reports what was measured and links the new page, which prints the reproduction so a reader can run it.

The other two: the keyboard fallback everyone recommends for a stubborn dropdown (click, ArrowDown, Enter) does not change the value at all, while focus without the click does; and document.fonts.check() returns true for a font family invented on the spot, so it cannot tell you whether a container has the font you think it has.

Also in: Queue-it waiting rooms, memory on long runs with a measurement method that does not double count a previous browser, ARM64 Linux, fonts in slim images, canvas across operating systems, linked PDFs (where the out-of-page request API is refused by design and the in-page fetch is the working route), native and custom dropdowns, a browser-use comparison with the conflict of interest declared, and the Windows first-launch failure, with the launcher process cited to Mozilla and the registry correlation reported as our own observation.