### PR TITLE
Pin invisible-core 27.19.0: orphaned .tmp trees in the engine cache are swept

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.12.3] - 2026-09-06
+
+### Fixed
+- **Orphaned `.tmp-<tag>-<pid>` trees in the engine cache are swept.** Through
+  `invisible-core 27.19.0`: a download killed during `verifying` or
+  `extracting` used to leave up to the whole extracted tree behind, because
+  only a fresh download by the same pid ever removed it. `ensure_binary` now
+  removes the trees whose process is gone, on every call, and leaves alone
+  this process's own tree, a live process's tree and anything not named after
+  a pid. The MCP server 0.13.0 starts the download with the process, which made
+  a killed download an ordinary event rather than a Ctrl-C.
+
 ## [0.12.2] - 2026-09-05
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "invisible_playwright"
-version = "0.12.2"
+version = "0.12.3"
 description = "Playwright wrapper for a patched Firefox with deterministic stealth profile."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -69,7 +69,7 @@ dependencies = [
     # metadata; nothing in src/ hardcodes a second copy (tests/test_core_pin.py
     # fails if one appears). What stays invisible to install-time machinery is the
     # --no-deps / lockfile residue, and _pin.py is the only layer that sees it.
-    "invisible_core==27.18.0",
+    "invisible_core==27.19.0",
     # ⛔ playwright is NO LONGER a dependency: since the full fork, the Python
     # client lives in src/invisible_playwright/_pw/ and the Node driver in
     # src/invisible_playwright/_driver/. Reintroducing it would not visibly


### PR DESCRIPTION
A download killed during verifying or extracting used to leave up to the whole extracted tree under cache_root()/.tmp-<tag>-<pid>, because only a fresh download by the same pid ever removed it. The core now sweeps the trees whose process is gone on every ensure_binary, warm path included. The MCP server 0.13.0 starts the download with the process, which turned a killed download from a Ctrl-C into an ordinary event.

Pin moved with scripts/sync_core_pin.py after the core landed on the index. Version 0.12.3, a pin bump: nothing this package launches the browser with changed.