### PR TITLE
The 0.13.0 changelog heading is dated by the upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
-## [0.13.0] - 2026-09-06
+## [0.13.0] - 2026-09-05
 
 ### Added
 - **`page.screencast.start(on_frame=...)` streams JPEG frames of the browser


### PR DESCRIPTION
PyPI records the 0.13.0 upload on 2026-09-05 UTC and the changelog heading said the 6th, the local date after midnight. The release e2e compares the two and went red on exactly that, with 208 tests green around it.