### PR TITLE
Pin invisible-core 29.19.0: the engine is firefox-29, which has the screencast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Changed
+- **The engine is `firefox-29`, through `invisible-core 29.19.0`.** It carries
+  the screencast that `page.screencast.start(on_frame=...)` needs, so the
+  feature shipped in 0.13.0 now has an engine that answers it, and the
+  full-window frame no longer carries the Windows resize border. Nothing
+  else moves: the pin follows the seal.
+
 ## [0.13.0] - 2026-09-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.13.1] - 2026-09-06
+
 ### Changed
 - **The engine is `firefox-29`, through `invisible-core 29.19.0`.** It carries
   the screencast that `page.screencast.start(on_frame=...)` needs, so the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "invisible_playwright"
-version = "0.13.0"
+version = "0.13.1"
 description = "Playwright wrapper for a patched Firefox with deterministic stealth profile."
 readme = "README.md"
 requires-python = ">=3.11"
@@ -69,7 +69,7 @@ dependencies = [
     # metadata; nothing in src/ hardcodes a second copy (tests/test_core_pin.py
     # fails if one appears). What stays invisible to install-time machinery is the
     # --no-deps / lockfile residue, and _pin.py is the only layer that sees it.
-    "invisible_core==27.19.0",
+    "invisible_core==29.19.0",
     # ⛔ playwright is NO LONGER a dependency: since the full fork, the Python
     # client lives in src/invisible_playwright/_pw/ and the Node driver in
     # src/invisible_playwright/_driver/. Reintroducing it would not visibly


### PR DESCRIPTION
page.screencast.start() shipped in 0.13.0 against a sealed engine that could not answer it. invisible-core 29.19.0 is on the index and its seal points at firefox-29, which carries the screencast and crops the Windows resize border out of a full-window frame. The pin follows the seal; nothing else moves. Version 0.13.1.