### PR TITLE
The two sibling one-liners run through uvx again

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,14 +54,13 @@ Supported platforms: **Windows x86_64**, **Linux x86_64 / arm64**. macOS is no l
 ### If you would rather prompt than script
 
 This page is the engine, as a Python library. There are two ways to use it
-without writing code:
+without writing code, and both are one line:
 
 - **From an MCP client you already have** (Claude Code, Claude Desktop,
-  Cursor): `pip install invisible-playwright-mcp`, then
-  `claude mcp add --scope user stealth -- invisible-playwright-mcp`. See
+  Cursor): `claude mcp add stealth -- uvx invisible-playwright-mcp`. See
   [invisible-playwright-mcp](https://github.com/feder-cr/invisible-playwright-mcp).
 - **With an interface and a model included**, needing only an OpenRouter key:
-  `pip install aihawk`, then `aihawk ui --openrouter-key sk-or-...`. See
+  `uvx aihawk ui --openrouter-key sk-or-...`. See
   [AIHawk](https://github.com/feder-cr/AIHawk).
 
 Same engine underneath, and the second is a client of the first.

--- a/docs/ai-browser-agents-stealth.md
+++ b/docs/ai-browser-agents-stealth.md
@@ -224,7 +224,7 @@ this whole page is about.
 one. Pick on the agent loop, then fix the machine, then consider the engine.
 
 **Is there any agent route to an engine-level fingerprint?** Two, and they are not
-equivalent. `invisible-playwright-mcp` launches through the engine, so the
+equivalent. `uvx invisible-playwright-mcp` launches through the engine, so the
 seeded profile and the humanised pointer come with it. Microsoft's own Playwright
 MCP server takes a browser and an executable path, which runs the engine but
 carries no `firefox_user_prefs`, so every session on a given build shares one


### PR DESCRIPTION
Owner decision, 2026-09-06, after a survey of comparable projects: pip refuses outside a virtual environment on current Debian and Ubuntu, and on Windows a Store Python leaves pip scripts off the PATH, so the one route that works for every reader is uv. Reverts the pip form of this block from earlier today; the sibling pages say the same.