### PR TITLE
The MCP server lives in AIHawk: the two repository links and the family bullets say so

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ without writing code, and both are one line:
 
 - **From an MCP client you already have** (Claude Code, Claude Desktop,
   Cursor): `claude mcp add stealth -- uvx invisible-playwright-mcp`. See
-  [invisible-playwright-mcp](https://github.com/feder-cr/invisible-playwright-mcp).
+  [the MCP server page](https://github.com/feder-cr/AIHawk/wiki/mcp-server).
 - **With an interface and a model included**, needing only an OpenRouter key:
   `uvx aihawk ui --openrouter-key sk-or-...`. See
   [AIHawk](https://github.com/feder-cr/AIHawk).
@@ -236,11 +236,11 @@ two around it are how most people reach it:
 
 - **[invisible_core](https://github.com/feder-cr/invisible_core)** - seed to
   fingerprint to preferences, plus proxy and geolocation. This package pins it.
-- **[invisible-playwright-mcp](https://github.com/feder-cr/invisible-playwright-mcp)**
-  - this engine as an MCP server, for any client that brings its own model.
-- **[AIHawk](https://github.com/feder-cr/AIHawk)** - an interface and a model,
-  from one command. A client of the server above, with no private path to the
-  browser.
+- **[AIHawk](https://github.com/feder-cr/AIHawk)** - this engine as an MCP
+  server (`uvx invisible-playwright-mcp`, for any client that brings its own
+  model) and, in the same package, an interface with a model included, from
+  one command. The interface is a client of the server, with no private path
+  to the browser.
 
 **The open-source neighbours**, and what each one is for.
 

--- a/docs/integrations/playwright-mcp.md
+++ b/docs/integrations/playwright-mcp.md
@@ -8,7 +8,8 @@ nav_order: 7
 # Using invisible_playwright with Microsoft's Playwright MCP
 
 **There is a server for this engine:**
-[`invisible-playwright-mcp`](https://github.com/feder-cr/invisible-playwright-mcp).
+[`invisible-playwright-mcp`](https://github.com/feder-cr/AIHawk/wiki/mcp-server),
+shipped inside AIHawk.
 One line, and it carries the seeded profile and the humanised pointer that the
 route on this page cannot:
 
@@ -115,7 +116,7 @@ knowing before you trust the session.
 ## Short answers to the questions that lead here
 
 **Is there an MCP server for this project?** Yes:
-[`invisible-playwright-mcp`](https://github.com/feder-cr/invisible-playwright-mcp),
+[`invisible-playwright-mcp`](https://github.com/feder-cr/AIHawk/wiki/mcp-server),
 `uvx invisible-playwright-mcp`. It launches through the engine, so the seeded
 profile and the humanised pointer come with it.
 


### PR DESCRIPTION
The server repository was merged into AIHawk (aihawk 0.10.0, module aihawk.mcp); the PyPI name invisible-playwright-mcp stays as a shim, so the commands on these pages are unchanged and only the links move: to the wiki page that now holds the server config blocks, settings and tools.