### PR TITLE
The server command is uvx aihawk

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ This page is the engine, as a Python library. There are two ways to use it
 without writing code, and both are one line:
 
 - **From an MCP client you already have** (Claude Code, Claude Desktop,
-  Cursor): `claude mcp add stealth -- uvx invisible-playwright-mcp`. See
+  Cursor): `claude mcp add stealth -- uvx aihawk`. See
   [the MCP server page](https://github.com/feder-cr/AIHawk/wiki/mcp-server).
 - **With an interface and a model included**, needing only an OpenRouter key:
   `uvx aihawk ui --openrouter-key sk-or-...`. See
@@ -237,7 +237,7 @@ two around it are how most people reach it:
 - **[invisible_core](https://github.com/feder-cr/invisible_core)** - seed to
   fingerprint to preferences, plus proxy and geolocation. This package pins it.
 - **[AIHawk](https://github.com/feder-cr/AIHawk)** - this engine as an MCP
-  server (`uvx invisible-playwright-mcp`, for any client that brings its own
+  server (`uvx aihawk`, for any client that brings its own
   model) and, in the same package, an interface with a model included, from
   one command. The interface is a client of the server, with no private path
   to the browser.

--- a/docs/ai-browser-agents-stealth.md
+++ b/docs/ai-browser-agents-stealth.md
@@ -224,7 +224,7 @@ this whole page is about.
 one. Pick on the agent loop, then fix the machine, then consider the engine.
 
 **Is there any agent route to an engine-level fingerprint?** Two, and they are not
-equivalent. `uvx invisible-playwright-mcp` launches through the engine, so the
+equivalent. `uvx aihawk` launches through the engine, so the
 seeded profile and the humanised pointer come with it. Microsoft's own Playwright
 MCP server takes a browser and an executable path, which runs the engine but
 carries no `firefox_user_prefs`, so every session on a given build shares one

--- a/docs/integrations/playwright-mcp.md
+++ b/docs/integrations/playwright-mcp.md
@@ -1,6 +1,6 @@
 ---
 title: "Using invisible_playwright with Microsoft's Playwright MCP"
-description: "There is a server for this engine, invisible-playwright-mcp. This page is for people already committed to Microsoft's playwright-mcp, and says exactly what that route costs."
+description: "There is a server for this engine, inside AIHawk: uvx aihawk. This page is for people already committed to Microsoft's playwright-mcp, and says exactly what that route costs."
 parent: "Integrations"
 nav_order: 7
 ---
@@ -8,13 +8,13 @@ nav_order: 7
 # Using invisible_playwright with Microsoft's Playwright MCP
 
 **There is a server for this engine:**
-[`invisible-playwright-mcp`](https://github.com/feder-cr/AIHawk/wiki/mcp-server),
+[`aihawk`](https://github.com/feder-cr/AIHawk/wiki/mcp-server),
 shipped inside AIHawk.
 One line, and it carries the seeded profile and the humanised pointer that the
 route on this page cannot:
 
 ```bash
-claude mcp add stealth -- uvx invisible-playwright-mcp
+claude mcp add stealth -- uvx aihawk
 ```
 
 This page is for the other case: you are already committed to Microsoft's
@@ -116,8 +116,8 @@ knowing before you trust the session.
 ## Short answers to the questions that lead here
 
 **Is there an MCP server for this project?** Yes:
-[`invisible-playwright-mcp`](https://github.com/feder-cr/AIHawk/wiki/mcp-server),
-`uvx invisible-playwright-mcp`. It launches through the engine, so the seeded
+[`aihawk`](https://github.com/feder-cr/AIHawk/wiki/mcp-server),
+`uvx aihawk`. It launches through the engine, so the seeded
 profile and the humanised pointer come with it.
 
 Microsoft's own `playwright-mcp` also accepts `--browser firefox` together with


### PR DESCRIPTION
Since aihawk 0.11.0 the MCP server is aihawk with no subcommand, so the one line a reader copies is claude mcp add stealth -- uvx aihawk, and the pages that name the server call it aihawk. Docs only.