### PR TITLE
Twenty new scraping guides, chosen from the ranking data

### DIFF
--- a/docs/how-to-scrape-bank-interest-rates-playwright.md
+++ b/docs/how-to-scrape-bank-interest-rates-playwright.md
@@ -1,0 +1,143 @@
+---
+title: "How to scrape bank interest rates with Playwright"
+description: "Scrape published deposit and lending rates with Playwright: resolve the footnotes that change the rate, keep the balance tiers separate, and record the effective date the bank prints."
+parent: "Scraping with Playwright"
+grand_parent: "Guides"
+nav_order: 164
+---
+
+
+# How to scrape bank interest rates with Playwright
+
+To scrape published rates, capture the **footnote with the number**. A rate table on a
+bank site is a set of headline figures whose real meaning lives in the small print
+underneath: an introductory period, a balance tier, a requirement to hold another product,
+a rate that drops after twelve months. The headline without its footnote is not a
+simplification, it is a different number.
+
+The second structural fact is tiering. One product usually has several rates, one per
+balance band, and the page shows the best one in large type. A scrape that takes the large
+type produces a table where every bank looks like its best case.
+
+This page covers resolving footnote markers to their text, reading tiers as rows, and
+keeping the effective date the bank publishes.
+
+## Resolve the marker to the text, at capture time
+
+Footnote markers are superscripts that point at a list further down the page. Follow the
+pointer while you have the DOM:
+
+```python
+from invisible_playwright import InvisiblePlaywright
+
+RESOLVE = """
+() => {
+  const notes = {};
+  document.querySelectorAll('.footnotes li[id]').forEach(li => {
+    notes[li.id] = li.textContent.trim();
+  });
+  return Array.from(document.querySelectorAll('table.rates tbody tr')).map(tr => {
+    const cells = Array.from(tr.querySelectorAll('td')).map(td => td.textContent.trim());
+    const marks = Array.from(tr.querySelectorAll('sup a[href^="#"]'))
+      .map(a => notes[a.getAttribute('href').slice(1)])
+      .filter(Boolean);
+    return { cells, footnotes: marks };
+  });
+}
+"""
+
+with InvisiblePlaywright(seed=42) as browser:
+    page = browser.new_page()
+    page.goto("https://example-bank.com/savings/rates")
+    page.wait_for_selector("table.rates tbody tr")
+    rows = page.evaluate(RESOLVE)
+```
+
+Doing this in one evaluation matters because the markers and the notes are in different
+parts of the document, and resolving them later from two separately captured lists means
+matching on an id you may not have kept.
+
+## Tiers are rows, and the tier bounds are part of the rate
+
+```python
+import re
+
+TIER = re.compile(r"(?P<lo>[\d,]+)\s*(?:to|-|and above|\+)?\s*(?P<hi>[\d,]+)?", re.I)
+
+def parse_tier(text):
+    m = TIER.search(text.replace("$", "").replace("£", ""))
+    if not m:
+        return {"tier_text": text}
+    return {
+        "tier_text": text,
+        "min_balance": int(m.group("lo").replace(",", "")),
+        "max_balance": int(m.group("hi").replace(",", "")) if m.group("hi") else None,
+    }
+```
+
+A null `max_balance` means the top band, which is open ended. Keep `tier_text` as well,
+because banks write bands in ways this regex will not always survive, and the original
+string is what lets you tell a parse failure from an unusual product.
+
+## APR and APY are not interchangeable
+
+Deposit products publish an annual yield that includes compounding; lending products
+publish an annual rate that includes fees, under names that vary by country. The two are
+not comparable and the page often shows both:
+
+```python
+    row["rate_kind"] = header_for(column_index)     # "APY", "APR", "AER", "nominal"
+```
+
+Take the label from the column header rather than assuming. Storing every percentage in a
+column called `rate` merges two different quantities, and the error is invisible until
+someone compares a savings account to a loan and gets a sensible-looking answer.
+
+## Effective date, and the fact that these pages are cached hard
+
+Banks print an effective date, and it is the closest thing to a timestamp the data has:
+
+```python
+    node = page.query_selector(".rates-effective, .as-of-date")
+    row["effective_text"] = node.inner_text().strip() if node else None
+    row["captured_at"] = time.time()
+```
+
+Keep both, for the same reason as any live-status scrape: the page you fetched today may
+be serving a rate table from last week, and the effective date is the only field that
+reveals it. If the effective date has not moved in weeks while a central bank has, the
+page is stale rather than the rates being unchanged.
+
+## Products live behind a selector
+
+Larger banks put rates behind a product picker, a region picker, or both, with no URL
+change. Set them explicitly and record them:
+
+```python
+    page.select_option("select#region", "CA")
+    page.select_option("select#product", "TFSA")
+    page.wait_for_selector("table.rates tbody tr")
+    row["region"] = "CA"
+    row["product"] = "TFSA"
+```
+
+Rates genuinely differ by region within the same bank, and a table captured without the
+region column cannot be compared with itself next month. Where the region is inferred from
+the visitor rather than selected, that is
+[geotargeted content](how-to-scrape-geotargeted-content-playwright.md) and the exit
+becomes part of the query.
+
+## Read the published rate, and nothing behind a login
+
+Everything above is the public rate card, which banks publish deliberately and update on a
+schedule. The parts behind authentication are account data belonging to a person, and the
+reasoning in
+[why automating login is riskier than reusing a session](automating-login-vs-session-reuse.md)
+applies with the extra weight that financial institutions treat automated access to
+accounts as a security event, correctly.
+
+Public rate cards change daily at most, usually less. A daily pass is generous, the pacing
+in [rate limiting your own scraper](how-to-rate-limit-your-scraper-playwright.md) applies,
+and storing the history in
+[a SQLite database](how-to-scrape-into-a-database-playwright.md) gives you the one thing
+the bank's own page never shows: what the rate used to be.

--- a/docs/how-to-scrape-conference-agendas-playwright.md
+++ b/docs/how-to-scrape-conference-agendas-playwright.md
@@ -1,0 +1,137 @@
+---
+title: "How to scrape conference agendas with Playwright"
+description: "Scrape conference schedules with Playwright: read a grid with parallel tracks without losing the track, resolve the event timezone once, and follow the session pages for speakers and abstracts."
+parent: "Scraping with Playwright"
+grand_parent: "Guides"
+nav_order: 162
+---
+
+
+# How to scrape conference agendas with Playwright
+
+To scrape an agenda, read the schedule as a **grid of tracks over time** rather than as a
+list of sessions, and resolve the timezone once for the whole event. A conference agenda
+is one of the few web tables where position carries meaning: the column a session sits in
+is its track, and the rows above and below it are what it clashes with.
+
+A list-shaped scrape loses that. It gives you every session with a start time and no way
+to answer the only question most people have, which is what runs against what.
+
+This page covers reading the grid with its track intact, handling the timezone properly,
+and following through to the session pages where the speakers and abstracts live.
+
+## Read the column, because the column is the track
+
+Grid layouts put the track in a header, not in each cell. Read the header once, then map
+each session to the column it occupies:
+
+```python
+from invisible_playwright import InvisiblePlaywright
+
+GRID = """
+() => {
+  const tracks = Array.from(document.querySelectorAll('.schedule-grid .track-header'))
+    .map(h => h.textContent.trim());
+  return Array.from(document.querySelectorAll('.schedule-grid .session')).map(s => {
+    const col = Number(getComputedStyle(s).getPropertyValue('grid-column-start')) || null;
+    return {
+      title: s.querySelector('.session-title')?.textContent.trim() || null,
+      start: s.dataset.start || null,
+      end: s.dataset.end || null,
+      href: s.querySelector('a')?.getAttribute('href') || null,
+      track: col && tracks[col - 1] ? tracks[col - 1] : (s.dataset.track || null),
+    };
+  });
+}
+"""
+
+with InvisiblePlaywright(seed=42) as browser:
+    page = browser.new_page()
+    page.goto("https://example-conf.com/schedule")
+    page.wait_for_selector(".schedule-grid .session")
+    sessions = page.evaluate(GRID)
+```
+
+Reading `grid-column-start` from computed style is the trick that makes CSS-grid agendas
+tractable. The DOM order of sessions in these layouts is frequently meaningless, because
+the grid places them, so column position is the only reliable link between a session and
+its track header.
+
+Where the site uses a data attribute for the track, prefer it and skip the geometry. Check
+both, because a redesign will switch between them.
+
+## The timezone belongs to the event, not to you
+
+Agendas print local times without zones almost universally. Resolve the event's zone once
+and attach it, rather than letting each row inherit whatever your machine thinks:
+
+```python
+    tz = page.eval_on_selector(
+        "meta[name='event-timezone'], .event-timezone",
+        "e => e.content || e.textContent.trim()",
+    ) if page.query_selector("meta[name='event-timezone'], .event-timezone") else None
+    row["event_timezone"] = tz          # e.g. "Europe/Lisbon"
+```
+
+When the page does not say, take it from the venue city and record that you inferred it.
+An agenda stored in naive local time is usable; one silently converted to your machine's
+zone is a schedule that is wrong by hours for everyone who reads it later, and there is
+nothing in the data that reveals the error.
+
+Hybrid and online events make this worse by publishing two schedules, one in venue time
+and one in the viewer's, sometimes switched by a toggle. Pin the toggle explicitly and
+record which one you read.
+
+## Sessions are stubs; the detail page has the substance
+
+The grid cell carries a title and a time. Speakers, abstract, room and level live on the
+session page:
+
+```python
+def session_detail(page, href):
+    page.goto(href)
+    page.wait_for_selector(".session-detail")
+    return {
+        "abstract": page.inner_text(".session-abstract"),
+        "room": page.inner_text(".session-room") if page.query_selector(".session-room") else None,
+        "speakers": [{
+            "name": s.query_selector(".speaker-name").inner_text().strip(),
+            "affiliation": (s.query_selector(".speaker-affiliation").inner_text().strip()
+                            if s.query_selector(".speaker-affiliation") else None),
+        } for s in page.query_selector_all(".speaker")],
+    }
+```
+
+Keep speakers as a list of objects rather than a joined string. A comma-separated field
+looks fine until a name contains a comma, and academic affiliations contain commas
+constantly.
+
+## Multi-day tabs and the day you did not read
+
+Agendas split by day, behind tabs that swap the grid without changing the URL. The failure
+is quiet: you scrape one day and get a complete-looking dataset:
+
+```python
+    for tab in page.query_selector_all(".day-tabs [role='tab']"):
+        day = tab.inner_text().strip()
+        tab.click()
+        page.wait_for_selector(".schedule-grid .session")
+        for s in page.evaluate(GRID):
+            s["day"] = day
+```
+
+This is the same mechanic as any
+[tab or accordion panel](how-to-scrape-accordion-and-tab-content-playwright.md), and the
+same rule applies: click the control, wait for the content, do not guess a URL.
+
+## Agendas change until the morning of the event
+
+Schedules are edited constantly in the final weeks: rooms move, speakers cancel, sessions
+swap slots. If the change history matters to you, keep each capture whole with its
+timestamp rather than updating rows in place, and diff captures later. If it does not,
+a daily pass in the fortnight before the event, and one after it, is enough.
+
+Either way this is a small site with a spiky audience, so keep to the pacing in
+[rate limiting your own scraper](how-to-rate-limit-your-scraper-playwright.md) and prefer
+running outside the conference hours themselves, when the site is serving the people
+actually at the event.

--- a/docs/how-to-scrape-construction-permits-playwright.md
+++ b/docs/how-to-scrape-construction-permits-playwright.md
@@ -1,0 +1,131 @@
+---
+title: "How to scrape construction permit records with Playwright"
+description: "Scrape municipal permit portals with Playwright: drive the postback search forms these systems use, page through result sets that only exist in a session, and keep the permit status history."
+parent: "Scraping with Playwright"
+grand_parent: "Guides"
+nav_order: 159
+---
+
+
+# How to scrape construction permit records with Playwright
+
+To scrape a permit portal, drive its **search form** and stay in the session it gives you.
+These systems are almost always server-rendered enterprise software, where the results
+page is a postback rather than a URL, page two is a form submission, and a link copied out
+of the browser returns a session-expired notice ten minutes later.
+
+That single property decides the whole design. You cannot build a list of URLs and fetch
+them in parallel. You drive one session in order, and you make it resumable, because a
+run over a year of permits takes long enough that something will interrupt it.
+
+This page covers filling the search the way the form expects, walking result pages that
+only exist inside a session, and capturing a permit's status history rather than its
+current state.
+
+## Fill the search in the order the form expects
+
+Permit searches are usually date-range plus type, and the fields depend on each other:
+
+```python
+from invisible_playwright import InvisiblePlaywright
+
+with InvisiblePlaywright(seed=42) as browser:
+    page = browser.new_page()
+    page.goto("https://permits.example.gov/search")
+
+    page.select_option("select#permitType", "BUILDING")
+    page.fill("input#dateFrom", "01/01/2026")
+    page.fill("input#dateTo", "01/31/2026")
+    page.click("input#btnSearch")
+    page.wait_for_selector("#resultsGrid tr, .no-records")
+```
+
+Select the type before the dates where the form reloads on change. Many of these pages
+issue a postback when a dropdown changes, which clears fields filled before it, so the
+order that works is the order a person would use: the thing that reshapes the form first,
+the details after.
+
+If the date fields are pickers that ignore typed values, treat them as
+[date-picker calendars](how-to-scrape-date-picker-calendar-playwright.md) and click the
+days.
+
+## Page two is a form submission, not a URL
+
+```python
+    def next_page(page):
+        link = page.query_selector("a#nextPage:not(.disabled)")
+        if not link:
+            return False
+        first_before = page.inner_text("#resultsGrid tr:nth-child(1)")
+        link.click()
+        page.wait_for_function(
+            "prev => document.querySelector('#resultsGrid tr').innerText !== prev",
+            arg=first_before,
+        )
+        return True
+```
+
+Waiting for the first row to change is the reliable signal. Waiting for a navigation
+returns immediately on a page that never navigates, and waiting a fixed time either wastes
+seconds or reads the previous page. The general shape is the one in
+[scraping paginated pages](how-to-scrape-paginated-pages-playwright.md), with the extra
+constraint that here you genuinely cannot skip ahead.
+
+Narrow the query rather than paging deeply. Most portals cap results, often silently, at a
+few hundred rows. A month at a time with an explicit row count check is more work and
+returns the whole set:
+
+```python
+    total = page.inner_text(".result-count")     # "1 to 25 of 412"
+```
+
+Compare the total against what you collected and fail loudly on a mismatch. A silent cap
+is the most common way these datasets end up missing a third of a year.
+
+## Capture the status history, not just the current status
+
+A permit moves through review stages, and the interesting questions are about duration:
+how long between application and issue, where files stall, which reviewers are backed up.
+The detail page usually carries this as a table:
+
+```python
+def permit_detail(page, href):
+    page.click(f"a[href='{href}']")
+    page.wait_for_selector("#permitDetail")
+    stages = []
+    for tr in page.query_selector_all("#statusHistory tbody tr"):
+        cells = [td.inner_text().strip() for td in tr.query_selector_all("td")]
+        stages.append({"stage": cells[0], "date": cells[1], "outcome": cells[2] if len(cells) > 2 else None})
+    return stages
+```
+
+If the portal only shows a current status, capture it with your run timestamp and build
+the history yourself across runs. That is slower to become useful, and it is the only way
+to get duration data out of a system that does not publish it.
+
+## Make the run resumable, because it will be interrupted
+
+A session-bound sequential crawl over months of records is exactly the job that dies at
+70%. Write each page as you go and record where you were:
+
+```python
+    checkpoint = {"type": "BUILDING", "from": "01/01/2026", "to": "01/31/2026", "page": 7}
+```
+
+Then a restart re-runs the search and pages forward to the checkpoint rather than starting
+over. The pattern and its edge cases are in
+[resuming an interrupted scrape](how-to-resume-an-interrupted-scrape-playwright.md), and
+[retrying failed requests](how-to-retry-failed-requests-playwright.md) covers the
+transient failures that make it necessary.
+
+## These are public records, and they contain people
+
+Permit data is published deliberately, and it is genuinely useful: construction activity,
+contractor patterns, neighbourhood change. It also contains owner names and addresses,
+which are personal data in most jurisdictions regardless of being publicly displayed.
+
+Take the fields your question needs rather than the whole record by default, keep the
+retention deliberate, and check whether the jurisdiction already publishes a bulk export.
+Many do, on an open data portal, and pulling a file is better for everyone than paging a
+search form for a week. The technique for those is in
+[scraping open data portals](how-to-scrape-open-data-portals-playwright.md).

--- a/docs/how-to-scrape-court-dockets-playwright.md
+++ b/docs/how-to-scrape-court-dockets-playwright.md
@@ -1,0 +1,125 @@
+---
+title: "How to scrape court docket listings with Playwright"
+description: "Scrape public court dockets with Playwright: work case by case rather than by enumeration, capture the docket entries as an ordered record, and handle the documents that open in a viewer."
+parent: "Scraping with Playwright"
+grand_parent: "Guides"
+nav_order: 160
+---
+
+
+# How to scrape court docket listings with Playwright
+
+To scrape a public docket, work from **case numbers you already have** and capture the
+docket entries as an ordered list. A docket is a chronological record of filings, and its
+value is the sequence: what was filed, when, by which party, and what the court did next.
+The case summary at the top is a rollup of that sequence and loses the timing.
+
+The other thing to settle before writing code is scope. Court systems publish these
+records deliberately, and they also rate limit hard, because enumeration is a known abuse
+pattern. A scraper that walks a case number space is doing the thing the defences exist
+for, and it will be stopped. One that resolves a list of cases it has a reason to hold
+behaves like a researcher and generally works.
+
+This page covers driving the case lookup, reading the docket sheet, and dealing with the
+documents attached to entries.
+
+## Look up cases you already identified
+
+```python
+from invisible_playwright import InvisiblePlaywright
+
+def open_case(page, case_number):
+    page.goto("https://courts.example.gov/case-search")
+    page.fill("input#caseNumber", case_number)
+    page.click("button#search")
+    page.wait_for_selector("#docketSheet, .case-not-found")
+    return page.query_selector("#docketSheet") is not None
+
+with InvisiblePlaywright(seed=42) as browser:
+    page = browser.new_page()
+    for case_number in known_cases:
+        if open_case(page, case_number):
+            rows = docket_entries(page)
+```
+
+Keep the not-found branch explicit. Sealed, expunged and simply mistyped cases all render
+as an absence, and conflating them with an empty docket produces a dataset that quietly
+asserts cases had no activity.
+
+## The docket sheet is an ordered record
+
+```python
+def docket_entries(page):
+    entries = []
+    for tr in page.query_selector_all("#docketSheet tbody tr"):
+        cells = [td.inner_text().strip() for td in tr.query_selector_all("td")]
+        if len(cells) < 3:
+            continue
+        entries.append({
+            "sequence": cells[0],
+            "filed": cells[1],
+            "text": cells[2],
+            "documents": [a.get_attribute("href")
+                          for a in tr.query_selector_all("a[href]")],
+        })
+    return entries
+```
+
+Keep the court's sequence number as given, and do not renumber. Courts skip numbers, add
+entries out of order after the fact, and use suffixes such as `12-1` for related filings.
+Your own index built by enumeration will silently disagree with every citation anyone
+writes against that docket.
+
+Store `text` verbatim. Docket text is terse legal shorthand written by clerks, and any
+normalisation loses information that a lawyer reading the row will need.
+
+## Documents open in a viewer, not as a download
+
+Attachments on these systems usually open a PDF in a viewer tab rather than downloading.
+That is a specific mechanic worth handling deliberately, and it is the same one described
+in [when a PDF opens in a new tab](how-to-handle-pdf-opens-new-tab-playwright.md).
+
+Where documents are behind a paywall or a per-page fee, which is common, stop at the
+metadata. The entry text plus the document reference is usually enough to answer questions
+about activity and timing, and it avoids both the cost and the licensing question that
+comes with mirroring court documents. If you do fetch documents you are entitled to,
+[downloading linked PDFs](how-to-scrape-linked-pdfs-playwright.md) covers doing it through
+the browser session rather than a side client.
+
+## Pace it slowly and deliberately
+
+Court portals are among the strictest rate limiters in public web infrastructure, and for
+good reason. A pace of one case every several seconds, with a hard daily cap, is both
+respectful and the pace that keeps working:
+
+```python
+    import time
+    for case_number in known_cases[:200]:        # a cap, not a full sweep
+        ...
+        time.sleep(5)
+```
+
+The reasoning behind self-imposed limits, and why they beat waiting to be blocked, is in
+[rate limiting your own scraper](how-to-rate-limit-your-scraper-playwright.md). Run
+overnight in the court's timezone where you can: these systems are used by people doing
+their jobs during the day.
+
+## The parts to leave alone
+
+Three things on these systems are worth naming as out of scope, not because they are hard
+but because taking them is the difference between research and harm.
+
+**Do not enumerate.** Walking a case number range harvests the cases of people who are not
+your subject, including sealed matters that leak through misconfiguration.
+
+**Do not aggregate people.** A docket is public; a compiled profile of every case a named
+individual appears in is a different artefact with different consequences, and several
+jurisdictions treat it as such in law.
+
+**Do not re-publish documents wholesale.** Court records frequently contain personal
+identifiers that the court expects a human reader to see one at a time.
+
+Scraping dockets for a defined question, on cases you can name, is the version of this
+that is both legal in most places and defensible. Store it in something queryable such as
+[a SQLite database](how-to-scrape-into-a-database-playwright.md), keep the raw entry text,
+and keep the run's own metadata so you can say later exactly what you asked and when.

--- a/docs/how-to-scrape-css-pseudo-element-content-playwright.md
+++ b/docs/how-to-scrape-css-pseudo-element-content-playwright.md
@@ -1,0 +1,144 @@
+---
+title: "How to scrape CSS pseudo-element content with Playwright"
+description: "Read text injected by ::before and ::after with Playwright: it is not in the DOM and inner_text will not return it, so query the computed style instead."
+parent: "Scraping with Playwright"
+grand_parent: "Guides"
+nav_order: 169
+---
+
+
+# How to scrape CSS pseudo-element content with Playwright
+
+Text injected by `::before` and `::after` is **not in the DOM**, so `inner_text` and
+`text_content` will never return it. Read it with
+[`getComputedStyle`](https://developer.mozilla.org/en-US/docs/Web/API/Window/getComputedStyle)
+passing the pseudo-element as the second argument, and read the `content` property.
+
+This catches people because the text is plainly visible on screen. You can select it in
+some browsers, you can screenshot it, and every DOM-based extraction returns an empty
+string. Nothing errors, which is the worst version of the problem: the row is written with
+a blank field and the run reports success.
+
+```python
+from invisible_playwright import InvisiblePlaywright
+
+with InvisiblePlaywright(seed=42) as browser:
+    page = browser.new_page()
+    page.goto("https://example.com/product/1234")
+
+    value = page.eval_on_selector(
+        ".badge",
+        "el => getComputedStyle(el, '::after').content",
+    )
+    print(value)        # '"In stock"'  including the quotes
+```
+
+## The value comes back quoted, and sometimes as none
+
+`content` is a CSS value, not a string, so it arrives with its quotation marks and needs
+unwrapping. It can also be the keyword `none` when no rule applies, and `normal` on
+elements where the pseudo-element does not generate a box:
+
+```python
+def pseudo_text(page, selector, pseudo="::after"):
+    raw = page.eval_on_selector(
+        selector,
+        "(el, p) => getComputedStyle(el, p).content",
+        pseudo,
+    )
+    if raw in (None, "none", "normal", '""'):
+        return None
+    if len(raw) >= 2 and raw[0] == raw[-1] and raw[0] in "\"'":
+        return raw[1:-1]
+    return raw
+```
+
+Returning `None` for `none` matters. An empty string and an absent pseudo-element are
+different facts, and only the second means the rule did not apply to this element.
+
+## Four things `content` can hold besides text
+
+The property is more expressive than a string, and each form needs different handling:
+
+- **A literal string**, which is the common case above.
+- **An `attr()` reference**, such as `content: attr(data-label)`. Computed style may
+  return the resolved text or the function itself depending on the engine, so read the
+  attribute directly as a fallback: it is in the DOM and always available.
+- **A `url()`**, meaning the visible thing is an image, and there is no text to recover.
+- **A counter**, from `counter()` or `counters()`, which is how numbered lists and section
+  numbers are often rendered. The computed value gives you the rendered number.
+
+```python
+    raw = pseudo_text(page, ".step")
+    if raw and raw.startswith("attr("):
+        attr = raw[len("attr("):-1].strip()
+        raw = page.get_attribute(".step", attr)
+```
+
+## Reading many elements at once
+
+Doing this per element from Python costs a round trip each time. For a list, collect them
+in one evaluation:
+
+```python
+ALL = """
+(sel) => Array.from(document.querySelectorAll(sel)).map(el => ({
+  text: el.textContent.trim(),
+  before: getComputedStyle(el, '::before').content,
+  after: getComputedStyle(el, '::after').content,
+}))
+"""
+    rows = page.evaluate(ALL, ".product-card .label")
+```
+
+One evaluation is also one moment in time, which matters on pages where a class is toggled
+by script and the pseudo-element content changes with it.
+
+## Where this actually shows up
+
+Four patterns account for almost all real cases:
+
+**Status badges.** "New", "Sold out", "Sale" are frequently pure CSS, driven by a class on
+the parent. The class itself is often the better field to capture, since it is stable while
+the rendered word is localised.
+
+**Currency symbols and units.** A price of `19.99` in the DOM with the currency in a
+`::before` produces a dataset of bare numbers whose currency you cannot recover later. This
+is the case where the omission does the most damage, because the number looks complete.
+
+**Required-field markers and icons.** Usually noise, worth recognising so you do not chase
+them.
+
+**Row numbering.** Counters render an index that has no DOM representation at all, which
+matters when the number is the identifier a user would quote.
+
+## Check for it deliberately, rather than discovering it
+
+The reliable way to find out whether a page uses this is to ask, once, before writing
+selectors:
+
+```python
+FIND = """
+() => {
+  const out = [];
+  document.querySelectorAll('*').forEach(el => {
+    for (const p of ['::before', '::after']) {
+      const c = getComputedStyle(el, p).content;
+      if (c && !['none', 'normal', '""'].includes(c) && !c.startsWith('url('))
+        out.push({ tag: el.tagName, cls: el.className, pseudo: p, content: c });
+    }
+  });
+  return out.slice(0, 50);
+}
+"""
+    print(page.evaluate(FIND))
+```
+
+Run that on one representative page of a new site. It takes a second and tells you whether
+any visible text is missing from your extraction, which is a question that is otherwise
+answered weeks later by someone noticing a column of blanks.
+
+The same class of invisibility appears in two other places worth knowing:
+[shadow DOM content](how-to-scrape-shadow-dom-playwright.md), which needs a different
+traversal, and canvas rendering, where there is no text at all and the approach is in
+[extracting data from canvas charts](how-to-extract-data-from-canvas-charts-playwright.md).

--- a/docs/how-to-scrape-energy-tariffs-playwright.md
+++ b/docs/how-to-scrape-energy-tariffs-playwright.md
@@ -1,0 +1,132 @@
+---
+title: "How to scrape energy tariff comparisons with Playwright"
+description: "Scrape energy tariff comparison sites with Playwright: drive the consumption form that produces the quote, keep standing charge and unit rate apart, and record the assumptions behind every annual figure."
+parent: "Scraping with Playwright"
+grand_parent: "Guides"
+nav_order: 165
+---
+
+
+# How to scrape energy tariff comparisons with Playwright
+
+To scrape energy tariffs, drive the **consumption form** and record what you entered.
+These sites do not have prices, they have quotes, and a quote is a function of postcode,
+annual consumption, meter type and payment method. Two runs with different inputs return
+different tariffs at different prices, and a row that does not carry its inputs cannot be
+compared with anything, including itself.
+
+The second thing to separate is the tariff's two components. A tariff is a standing charge
+per day plus a unit rate per kilowatt hour, and the headline annual figure is those two
+combined with an assumed consumption. Store the components; recompute the annual figure
+when you need it.
+
+This page covers driving the quote form, keeping the components apart, and recording the
+assumptions that make a number reproducible.
+
+## Fill the form the way it expects, in order
+
+```python
+from invisible_playwright import InvisiblePlaywright
+
+INPUTS = {
+    "postcode": "BS1 4DJ",
+    "annual_kwh_electricity": 2700,
+    "annual_kwh_gas": 11500,
+    "payment_method": "direct_debit",
+    "meter": "single_rate",
+}
+
+with InvisiblePlaywright(seed=42) as browser:
+    page = browser.new_page()
+    page.goto("https://example-compare.com/energy")
+
+    page.fill("input[name='postcode']", INPUTS["postcode"])
+    page.click("button#continue")
+
+    page.check("input[value='know_usage']")           # reshapes the form
+    page.fill("input[name='elecKwh']", str(INPUTS["annual_kwh_electricity"]))
+    page.fill("input[name='gasKwh']", str(INPUTS["annual_kwh_gas"]))
+    page.select_option("select[name='payment']", INPUTS["payment_method"])
+    page.click("button#showResults")
+    page.wait_for_selector(".tariff-result")
+```
+
+The `check` before the fills is the step that catches people. These forms branch on
+whether you know your usage, and filling consumption fields that are still hidden silently
+does nothing, so the quote comes back on the site's default assumption instead of yours.
+This is a multi-step flow, and the ordering discipline is the one in
+[scraping multi-step wizard flows](how-to-scrape-multi-step-wizard-flow-playwright.md).
+
+## Keep standing charge and unit rate as separate fields
+
+```python
+    results = []
+    for card in page.query_selector_all(".tariff-result"):
+        def t(sel):
+            n = card.query_selector(sel)
+            return n.inner_text().strip() if n else None
+        results.append({
+            "supplier": t(".supplier-name"),
+            "tariff": t(".tariff-name"),
+            "unit_rate_text": t(".unit-rate"),          # p/kWh
+            "standing_charge_text": t(".standing-charge"),  # p/day
+            "annual_estimate_text": t(".annual-cost"),
+            "contract_length": t(".contract-term"),
+            "exit_fee_text": t(".exit-fee"),
+            **{f"input_{k}": v for k, v in INPUTS.items()},
+        })
+```
+
+Copying the inputs into every row looks redundant and is the single most valuable thing in
+the schema. It makes each row self-describing, so a table assembled from ten runs across
+five postcodes remains analysable a month later, when nobody remembers which run was which.
+
+A tariff with a low unit rate and a high standing charge beats one with the opposite only
+above a certain consumption. That crossover is the actual question these datasets can
+answer, and it is unanswerable from the annual figure alone.
+
+## Dual fuel, exit fees and the fields that decide the choice
+
+Three fields change the ranking more than the price does:
+
+- **Fuel scope.** A dual fuel quote and two single fuel quotes are different products, and
+  comparison sites mix them in one list. Record which each row is.
+- **Exit fee.** A cheap fixed tariff with a large exit fee is not cheap if rates fall.
+- **Contract length and end date.** A twelve month fix quoted today ends on a date, and
+  that date is what a rolling comparison has to line up.
+
+Take them as text and parse later, the same discipline as elsewhere: "None", "£30 per
+fuel" and "£75" are all common, and only one of them is a number.
+
+## The quote is a moment, so timestamp it and expect it to move
+
+```python
+    row["quoted_at"] = time.time()
+```
+
+Energy tariffs change frequently and comparison sites cache aggressively. Two runs an hour
+apart can differ, and a run against a cached result set can return tariffs that are already
+withdrawn. Where the page shows a validity or a "prices correct as of" line, take it, and
+prefer it to your own clock when the two disagree.
+
+## Do not create an account, and do not submit a switch
+
+Everything above is the public quote engine. These sites also offer to switch you, which
+requires personal details and creates a real commercial transaction. That boundary is worth
+stating plainly: reading a quote is scraping, and submitting a switch is entering a
+contract on behalf of a person.
+
+Stay on the public side, keep runs to a handful of profiles rather than a sweep of every
+postcode, and follow the pacing in
+[rate limiting your own scraper](how-to-scrape-without-getting-blocked.md). A comparison
+engine runs a real pricing computation per query, so each request costs the operator
+meaningfully more than serving a page.
+
+## Store it long, one row per tariff per run
+
+Append rather than overwrite, with the inputs and timestamps attached, in
+[JSON Lines](how-to-scrape-to-json-lines-playwright.md) or
+[a SQLite database](how-to-scrape-into-a-database-playwright.md). The value of this data
+is entirely in the series: which suppliers moved, when, and how the crossover consumption
+shifted. A table holding only today's best deal throws away everything that made it worth
+collecting.

--- a/docs/how-to-scrape-ev-charging-availability-playwright.md
+++ b/docs/how-to-scrape-ev-charging-availability-playwright.md
@@ -1,0 +1,152 @@
+---
+title: "How to scrape EV charging availability with Playwright"
+description: "Scrape EV charger availability with Playwright: capture the live status feed the map is drawing from, record a timestamp with every reading, and treat availability as a measurement rather than a fact."
+parent: "Scraping with Playwright"
+grand_parent: "Guides"
+nav_order: 151
+---
+
+
+# How to scrape EV charging availability with Playwright
+
+To scrape charger availability, capture the **status feed** the map is drawing from
+rather than the map, and stamp every reading with the time you took it. Availability is
+not an attribute of a charging point. It is a measurement that was true for a few
+seconds, and a row without a timestamp is a claim you cannot check later.
+
+This is what separates charger data from most listing data. A restaurant menu scraped
+yesterday is still roughly the menu. A connector that read "available" ninety seconds
+ago tells you almost nothing, and a database of such rows without times is not a dataset,
+it is a pile of expired assertions.
+
+This page covers finding the feed behind the map, modelling a charging point correctly
+as a site with several connectors, and polling at a rate that is honest about both the
+data and the operator's servers.
+
+## Read the feed, not the pins
+
+Charger maps are drawn from a JSON response, and the pins are a rendering of it. Capture
+the response instead of parsing markers out of the canvas or the marker layer:
+
+```python
+import json, time
+from invisible_playwright import InvisiblePlaywright
+
+payloads = []
+
+with InvisiblePlaywright(seed=42) as browser:
+    page = browser.new_page()
+
+    def on_response(response):
+        if "/api/" in response.url and "station" in response.url.lower():
+            try:
+                payloads.append({
+                    "at": time.time(),
+                    "url": response.url,
+                    "body": response.json(),
+                })
+            except Exception:
+                pass          # not JSON: a tile, a sprite, an analytics beacon
+
+    page.on("response", on_response)
+    page.goto("https://example.com/map")
+    page.wait_for_timeout(4000)     # let the map settle and issue its queries
+```
+
+The map usually re-queries as you pan, with a bounding box in the request. That is the
+handle you want: it lets you walk a region deliberately instead of scrolling a map and
+hoping. The mechanics of capturing these responses, including the ordering problems, are
+in [capturing XHR and API responses](how-to-capture-xhr-api-responses-playwright.md).
+
+## A charging point is not one thing
+
+The single most common modelling error here is treating a pin as a charger. A pin is a
+site. A site has several charging points. A point has several connectors, often of
+different types and speeds, and availability lives at the connector level:
+
+```python
+def flatten(station):
+    site = {"site_id": station["id"], "name": station.get("name")}
+    for point in station.get("evses", []):
+        for connector in point.get("connectors", []):
+            yield {
+                **site,
+                "point_id": point.get("uid"),
+                "connector_id": connector.get("id"),
+                "standard": connector.get("standard"),      # CCS, CHAdeMO, Type 2
+                "power_kw": connector.get("max_electric_power", 0) / 1000 or None,
+                "status": point.get("status"),              # AVAILABLE, CHARGING, OUTOFORDER
+            }
+```
+
+Flattening to one row per connector costs nothing and makes every later question
+answerable. Flattening to one row per site makes "is there a fast charger free" a
+question your data cannot answer, and you will not notice until someone asks it.
+
+## Stamp the time, and keep the operator's own timestamp separately
+
+Two times matter and they are not the same. There is when **you** read the value, and
+there is when the **operator** last heard from the hardware. The second is often in the
+payload as `last_updated`, and it is frequently minutes or hours old:
+
+```python
+row["observed_at"] = payloads[-1]["at"]              # when we looked
+row["reported_at"] = station.get("last_updated")     # when the network last knew
+```
+
+Keep both. A connector reported as available with a `last_updated` from six hours ago is
+a different fact from one updated forty seconds ago, and collapsing them into a single
+"available" is how a dataset becomes confidently wrong. When the operator gives you no
+`last_updated` at all, record that absence rather than substituting your own time.
+
+## Poll on the data's clock, not on yours
+
+Status changes on the scale of a charging session. Polling every ten seconds produces
+almost entirely duplicate rows and an obvious traffic pattern; polling once an hour
+misses most sessions. A few minutes is the honest middle, and storing only changes keeps
+the volume sane:
+
+```python
+last = {}
+
+def changed(row):
+    key = (row["site_id"], row["connector_id"])
+    if last.get(key) == row["status"]:
+        return False
+    last[key] = row["status"]
+    return True
+```
+
+Write the transitions rather than the polls. The result is a state history you can
+replay, at a fraction of the rows, and it survives a gap in collection better than a
+dense series with holes in it.
+
+Pace the loop deliberately. The rules and the reasoning are in
+[rate limiting your own scraper](how-to-rate-limit-your-scraper-playwright.md), and they
+matter more here than on a static site: a poll loop is by definition repetitive traffic,
+which is the easiest kind to notice.
+
+## Two traps specific to this data
+
+**The map filters before it queries.** Most of these interfaces default to hiding
+out-of-service points, or to showing only connector types matched to a vehicle the site
+remembers. The feed then arrives pre-filtered and looks complete. Check the request
+parameters for a filter you did not set, and clear it in the interface rather than in the
+URL, so the site's own state matches what you asked for.
+
+**Coverage is bounded by the viewport.** The query carries a bounding box, and a large
+box is often silently capped at a maximum number of results. Walk a grid of small boxes
+instead of one large one, and check for a `truncated` or `total` field that tells you the
+response was cut.
+
+## What this is good for, and what it is not
+
+Charger availability is a live operational signal. It supports questions about
+utilisation, reliability and which sites are chronically full. It does not support a
+claim about what is free right now, unless the reading is seconds old, because by the time
+a row lands in a database it may already be wrong.
+
+If you keep the connector-level rows with both timestamps, that limitation is visible in
+the data itself, which is the point. Store it in something you can query by time, such as
+[a SQLite database written as you go](how-to-scrape-into-a-database-playwright.md), and
+resist the temptation to keep only the latest value per connector.

--- a/docs/how-to-scrape-ferry-schedules-playwright.md
+++ b/docs/how-to-scrape-ferry-schedules-playwright.md
@@ -1,0 +1,130 @@
+---
+title: "How to scrape ferry schedules with Playwright"
+description: "Scrape ferry timetables with Playwright: query by date because sailings are seasonal, keep the route direction as part of the key, and record cancellations as data rather than as missing rows."
+parent: "Scraping with Playwright"
+grand_parent: "Guides"
+nav_order: 153
+---
+
+
+# How to scrape ferry schedules with Playwright
+
+To scrape a ferry timetable, query it **date by date** rather than pulling a published
+schedule page, keep the direction in the key, and treat a sailing that disappears as an
+event rather than as an absence. Ferry schedules are seasonal, weather-dependent and
+frequently amended, which makes them one of the few timetable types where yesterday's
+capture genuinely does not describe today.
+
+The trap is that these operators also publish a tidy PDF or HTML timetable for the
+season, and it is very tempting to parse that once and be done. That document is the
+plan. The booking engine is the truth, and on any given day the two disagree.
+
+This page covers driving the date-based query, modelling a sailing so that two
+directions do not collapse into one, and recording the amendments that make the data
+worth having.
+
+## Query by date, because the season decides the timetable
+
+Drive the operator's own date control and step through the range you need:
+
+```python
+from datetime import date, timedelta
+from invisible_playwright import InvisiblePlaywright
+
+def sailings_for(page, route, day):
+    page.goto(f"https://example.com/timetable?route={route}")
+    page.fill("input[name='date']", day.isoformat())
+    page.click("button[type='submit']")
+    page.wait_for_selector(".sailing, .no-sailings")
+    if page.query_selector(".no-sailings"):
+        return []
+    out = []
+    for row in page.query_selector_all(".sailing"):
+        out.append({
+            "date": day.isoformat(),
+            "depart": row.query_selector(".depart-time").inner_text().strip(),
+            "arrive": row.query_selector(".arrive-time").inner_text().strip(),
+            "vessel": (row.query_selector(".vessel") or row).inner_text().strip(),
+        })
+    return out
+
+with InvisiblePlaywright(seed=42) as browser:
+    page = browser.new_page()
+    day = date.today()
+    for offset in range(0, 60):
+        rows = sailings_for(page, "north-crossing", day + timedelta(days=offset))
+```
+
+The explicit `.no-sailings` branch is the part people leave out. A day with no service
+and a day where the selector silently failed produce the same empty list, and once that
+distinction is lost the dataset quietly grows holes that look like winter.
+
+## Direction is part of the identity, not a field you can add later
+
+A route has two directions and the operator often shows them on the same page, sometimes
+in two tables, sometimes in one table with a column. A sailing keyed on
+`(route, date, departure time)` will collide across directions, and the collision is
+silent because both rows look plausible:
+
+```python
+            "from_port": header_port(row, "from"),
+            "to_port": header_port(row, "to"),
+```
+
+Capture the two ports per row, even when the page groups them under a heading. If the
+page really does put direction only in a heading, read the heading into every row
+underneath it rather than trusting yourself to remember the grouping later:
+
+```python
+    current_direction = None
+    for node in page.query_selector_all(".timetable h3, .timetable .sailing"):
+        cls = node.get_attribute("class") or ""
+        if node.evaluate("e => e.tagName") == "H3":
+            current_direction = node.inner_text().strip()
+            continue
+        row = read_sailing(node)
+        row["direction"] = current_direction
+```
+
+## Cancellations and amendments are the interesting data
+
+Operators publish disruption separately from the timetable, usually as a notice banner or
+a status column. That is the part that a seasonal PDF can never give you:
+
+```python
+    notices = [n.inner_text().strip()
+               for n in page.query_selector_all(".service-notice, .disruption")]
+    for row in rows:
+        status_cell = row_node.query_selector(".status")
+        row["status"] = status_cell.inner_text().strip() if status_cell else "scheduled"
+```
+
+Store the status per sailing and the notices per query. When a sailing vanishes between
+two captures of the same date, write that transition explicitly rather than deleting the
+row: a schedule dataset whose history is overwritten cannot answer the one question it is
+uniquely able to answer, which is how often this crossing actually runs.
+
+## Two mechanical traps on these sites
+
+**The date field is a picker, not an input.** Many operators use a calendar widget that
+ignores a written value and only commits on a click. If `fill` leaves the results
+unchanged, open the picker and click the day, which is the same problem described in
+[scraping date-picker calendars](how-to-scrape-date-picker-calendar-playwright.md).
+
+**Results load into the page without a navigation.** The submit button triggers a request
+and swaps a region. Waiting for a load event returns immediately and you read the previous
+day's table. Wait for the result region to change, or capture the response directly with
+the technique in
+[capturing XHR and API responses](how-to-capture-xhr-api-responses-playwright.md).
+
+## Pace it like the resource it is
+
+Sixty days across a handful of routes is a few hundred queries, which is fine once a day
+and rude every hour. Timetables change on the scale of a season, with same-day amendments
+layered on top, so a daily full sweep plus a short poll of the current day covers the real
+volatility. The pacing rules are in
+[rate limiting your own scraper](how-to-rate-limit-your-scraper-playwright.md).
+
+Ferry operators are also small sites with real seasonal traffic spikes. Running the sweep
+overnight in the operator's own timezone is a courtesy that costs you nothing and keeps
+the run out of the window where it would actually be felt.

--- a/docs/how-to-scrape-flight-status-boards-playwright.md
+++ b/docs/how-to-scrape-flight-status-boards-playwright.md
@@ -1,0 +1,146 @@
+---
+title: "How to scrape flight status boards with Playwright"
+description: "Scrape airport arrival and departure boards with Playwright: read a board that rewrites itself, keep scheduled and estimated times as separate fields, and key rows on the flight and the day."
+parent: "Scraping with Playwright"
+grand_parent: "Guides"
+nav_order: 156
+---
+
+
+# How to scrape flight status boards with Playwright
+
+To scrape an arrivals or departures board, capture the row while the board is **between
+refreshes**, and keep scheduled time and estimated time as two separate fields. These
+boards rewrite their own DOM every thirty to sixty seconds, wholesale, and a scraper that
+iterates over rows while a refresh lands reads half of the old table and half of the new
+one without any error.
+
+The second half of the problem is modelling. A flight is not identified by its number.
+The same number flies every day, and on a delayed day it appears on two calendar days at
+once, so a row keyed on flight number alone overwrites yesterday with today.
+
+This page covers reading a self-refreshing board safely, keeping the two times apart, and
+keying rows so a delay does not eat history.
+
+## Snapshot the table in one evaluation
+
+Do not iterate the DOM row by row from Python. Each call crosses into the page separately,
+and the board can replace the table between two of them. Take the whole table in a single
+evaluation instead:
+
+```python
+from invisible_playwright import InvisiblePlaywright
+
+READ_BOARD = """
+() => Array.from(document.querySelectorAll('table.board tbody tr')).map(tr => {
+  const cell = (sel) => {
+    const el = tr.querySelector(sel);
+    return el ? el.textContent.trim() : null;
+  };
+  return {
+    flight: cell('.flight-number'),
+    airline: cell('.airline'),
+    origin: cell('.origin'),
+    destination: cell('.destination'),
+    scheduled: cell('.time-scheduled'),
+    estimated: cell('.time-estimated'),
+    status: cell('.status'),
+    gate: cell('.gate'),
+  };
+})
+"""
+
+with InvisiblePlaywright(seed=42) as browser:
+    page = browser.new_page()
+    page.goto("https://example-airport.com/departures")
+    page.wait_for_selector("table.board tbody tr")
+    rows = page.evaluate(READ_BOARD)
+```
+
+One evaluation is one moment. Everything it returns came from the same DOM, which is the
+property you need and the one a Python-side loop cannot give you. The same reasoning
+applies to any table that updates itself, including
+[virtual scrolling tables](how-to-scrape-virtual-scrolling-tables-playwright.md), where
+the rows are also being recycled underneath you.
+
+## Scheduled and estimated are different facts
+
+Boards show a scheduled time, and once the flight is late, an estimated or actual time
+next to it. Collapsing them into one column destroys the only interesting thing on the
+board:
+
+```python
+    row["delay_minutes"] = None
+    if row["scheduled"] and row["estimated"]:
+        row["delay_minutes"] = minutes_between(row["scheduled"], row["estimated"])
+```
+
+Compute the delay, do not store only the delay. When the board later revises the estimate,
+having both times lets you see the revision; having only a delay number means you cannot
+tell a corrected estimate from a worsening one.
+
+Times on these boards are local to the airport and usually printed without a date or a
+zone. Attach both from context, not from the string:
+
+```python
+    row["airport"] = "BRS"
+    row["service_date"] = board_date          # read from the board header, not from today()
+```
+
+Read the date from the board itself where it shows one. Around midnight, "today" on your
+machine and the board's service day are routinely different, and that is exactly when the
+delayed flights you care about are on screen.
+
+## Key a row on flight plus service day plus direction
+
+```python
+    key = (row["airport"], row["direction"], row["flight"], row["service_date"])
+```
+
+Direction belongs in the key because a code-shared arrival and departure can carry the
+same number at the same airport. Service day belongs in the key because a flight
+scheduled at 23:50 and departing at 00:40 exists on two calendar days, and the board will
+show it under one of them in a way you do not control.
+
+Store status transitions rather than the last value:
+
+```python
+    if previous.get(key, {}).get("status") != row["status"]:
+        write_event(key, row)
+```
+
+A board is a live view. Its value as data is the sequence of states a flight passed
+through, which is lost the moment you keep only the current one.
+
+## The board is a poll, so poll it politely
+
+The page refreshes itself; you do not need to reload it. Keep one page open and read the
+snapshot on an interval, which is both lighter on the airport's servers and closer to what
+a person watching a board does:
+
+```python
+    import time
+    while True:
+        rows = page.evaluate(READ_BOARD)
+        ingest(rows)
+        time.sleep(120)
+```
+
+Two minutes is enough for a board whose own refresh is around a minute. If the page stops
+updating, which happens when a tab is considered inactive, take a screenshot to check what
+is actually on screen before assuming the flights stopped moving, using
+[full page screenshots](how-to-take-full-page-screenshots-playwright.md). Longer loops
+also need the resilience described in
+[retrying failed requests](how-to-retry-failed-requests-playwright.md), because a run
+measured in hours will meet a network blip.
+
+## Two things that quietly truncate the data
+
+**The board paginates by time window.** Most show a few hours around now, with controls
+for earlier and later. A scraper that reads the default view has a partial day and no
+indication of it. Walk the windows explicitly.
+
+**Cancelled and diverted rows leave the board.** They are removed rather than marked in
+many implementations. If you only store what is on screen, a cancellation looks like a
+flight that never existed. Compare each snapshot with the previous one and write the
+disappearance as an event.

--- a/docs/how-to-scrape-fuel-prices-playwright.md
+++ b/docs/how-to-scrape-fuel-prices-playwright.md
@@ -1,0 +1,151 @@
+---
+title: "How to scrape fuel prices with Playwright"
+description: "Scrape fuel prices with Playwright: set the location explicitly instead of letting the site infer one, keep the grade and the currency unit with every price, and record who reported the number and when."
+parent: "Scraping with Playwright"
+grand_parent: "Guides"
+nav_order: 152
+---
+
+
+# How to scrape fuel prices with Playwright
+
+To scrape fuel prices, set the location **explicitly** and keep three things with every
+number: the grade, the unit, and who reported it. A fuel price page answers a question
+about a place, so the page has to decide where you are before it can show you anything,
+and if you do not decide for it the site decides from your exit IP.
+
+That inference is the whole difficulty. A run through one proxy and a run through another
+return different stations and different prices for the same site and the same minute,
+and nothing in the captured row records which location produced it. The data looks
+noisy. It is not noisy, it is unlabelled.
+
+This page covers pinning the location, reading a price table that mixes grades and
+units, and handling the fact that many of these prices are crowd-reported rather than
+observed.
+
+## Set the place before you read the price
+
+Drive the site's own location control instead of relying on where it thinks you are:
+
+```python
+from invisible_playwright import InvisiblePlaywright
+
+with InvisiblePlaywright(seed=42) as browser:
+    page = browser.new_page()
+    page.goto("https://example.com/fuel-prices")
+
+    box = page.wait_for_selector("input[name='location'], input#search-location")
+    box.click()
+    box.type("Bristol", delay=90)          # typed, not assigned
+    page.keyboard.press("Enter")
+    page.wait_for_selector(".station-list .station")
+```
+
+Type into the field rather than setting its value. Location inputs are usually
+autocomplete widgets that only commit on a real key sequence, and a value written
+directly leaves the widget's internal state empty, so the search runs against nothing.
+The same pattern applies to any
+[autocomplete or typeahead input](how-to-scrape-autocomplete-typeahead-playwright.md).
+
+Where the site offers no control and geolocates silently, you are in the territory of
+[geotargeted content](how-to-scrape-geotargeted-content-playwright.md), and the exit you
+browse from becomes part of the query whether you like it or not. Record it either way:
+
+```python
+    row["queried_location"] = "Bristol"
+```
+
+A dataset of fuel prices without a location column is not recoverable later. Write the
+column even when it feels redundant.
+
+## Grade and unit belong to the number
+
+Fuel prices come as a small matrix: several grades per station, each with a price, in a
+unit that varies by country and sometimes by page. Read the matrix as a matrix:
+
+```python
+    stations = []
+    for card in page.query_selector_all(".station-list .station"):
+        prices = []
+        for row in card.query_selector_all(".fuel-row"):
+            prices.append({
+                "grade": row.query_selector(".grade").inner_text().strip(),
+                "price_text": row.query_selector(".price").inner_text().strip(),
+            })
+        stations.append({
+            "name": card.query_selector(".name").inner_text().strip(),
+            "address": card.query_selector(".address").inner_text().strip(),
+            "prices": prices,
+        })
+```
+
+Keep `price_text` unparsed at capture time. The string carries the unit and the currency,
+and those are exactly what a naive float conversion throws away. Parse it in a second
+step where the failure is visible:
+
+```python
+import re
+
+MONEY = re.compile(r"(?P<sym>[$€£]|\b[A-Z]{3}\b)?\s*(?P<amount>\d+[.,]\d+)\s*(?P<per>/\s*\w+)?")
+
+def parse_price(text):
+    m = MONEY.search(text)
+    if not m:
+        return None
+    return {
+        "amount": float(m.group("amount").replace(",", ".")),
+        "currency": m.group("sym"),
+        "per": (m.group("per") or "").lstrip("/ ").strip() or None,
+    }
+```
+
+The `per` group matters more than it looks. The same page can show a price per litre and
+a price per gallon in different regions, and a series that silently mixes them produces a
+chart with a step in it that no one can explain.
+
+## Most of these prices are reports, not observations
+
+A large share of fuel price sites are crowd-sourced. The number is what a visitor said
+they paid, at a time they may not have recorded accurately. Sites usually show this next
+to the price as an age, a username, or a confidence marker. Capture it:
+
+```python
+            "reported_age": row.query_selector(".age").inner_text().strip()
+                            if row.query_selector(".age") else None,
+```
+
+A price reported two hours ago and a price reported nine days ago are not comparable
+data points, and the difference is often the largest source of variance in the whole
+dataset. Sites that publish operator-fed prices instead usually say so; record which kind
+of source you are reading, per station, because a single site can carry both.
+
+## Walking a region without hammering the search
+
+To cover an area, iterate over places rather than paginating a single huge result set:
+
+```python
+    for place in ["Bristol", "Bath", "Weston-super-Mare"]:
+        set_location(page, place)
+        harvest(page)
+        page.wait_for_timeout(3000)
+```
+
+This is slower than requesting a wide radius, and it is the version that works. Wide
+radius queries on these sites are commonly capped at a fixed number of results with no
+indication that anything was dropped, so a national sweep with three requests returns a
+confident subset. If you do use radius, look for a total count in the response and check
+it against the number of rows you received.
+
+Keep the pace conservative and the run scheduled rather than continuous. Prices move a
+few times a day at most, so a poll loop buys nothing and costs the goodwill described in
+[scraping without getting blocked](how-to-scrape-without-getting-blocked.md).
+
+## Store it in long form
+
+One row per station per grade per observation, with location, unit, source type and both
+timestamps. It is more rows than a wide table with one column per grade, and it is the
+shape that survives a site adding a grade, dropping one, or changing the unit in one
+region. Writing it as you go, in
+[a SQLite database](how-to-scrape-into-a-database-playwright.md) or
+[JSON Lines](how-to-scrape-to-json-lines-playwright.md), also means an interrupted run
+leaves usable data rather than nothing.

--- a/docs/how-to-scrape-library-catalog-availability-playwright.md
+++ b/docs/how-to-scrape-library-catalog-availability-playwright.md
@@ -1,0 +1,133 @@
+---
+title: "How to scrape library catalog availability with Playwright"
+description: "Scrape library catalogue availability with Playwright: read holdings per branch rather than per title, keep the loan status vocabulary the catalogue uses, and handle the session the OPAC hands you."
+parent: "Scraping with Playwright"
+grand_parent: "Guides"
+nav_order: 154
+---
+
+
+# How to scrape library catalog availability with Playwright
+
+To scrape catalogue availability, read the **holdings table**, not the title page. A
+library record is one work with many physical copies, each at a branch, each with its own
+status, and the headline "Available" on the record page is a summary that hides which
+branch has it and how many copies are out.
+
+Public catalogues also carry a second surprise: they are session-driven. The search you
+run creates server-side state, results are addressed by a token that expires, and a URL
+copied from one run frequently returns an empty result set in the next. Scraping them by
+saving result URLs produces a script that works once.
+
+This page covers driving the search rather than replaying URLs, reading holdings per
+copy, and keeping the catalogue's own status words instead of flattening them to a
+boolean.
+
+## Drive the search, do not replay the result URL
+
+Run the query in the browser and read the results in the same session:
+
+```python
+from invisible_playwright import InvisiblePlaywright
+
+with InvisiblePlaywright(seed=42) as browser:
+    page = browser.new_page()
+    page.goto("https://catalog.example.org/")
+
+    page.fill("input[name='q']", "the master and margarita")
+    page.press("input[name='q']", "Enter")
+    page.wait_for_selector(".result-item, .no-results")
+
+    hits = []
+    for item in page.query_selector_all(".result-item"):
+        link = item.query_selector("a.title")
+        hits.append({
+            "title": link.inner_text().strip(),
+            "href": link.get_attribute("href"),
+        })
+```
+
+Keep `href` relative and resolve it against `page.url` when you follow it. Catalogue
+links routinely embed the session token in the path, and an absolute URL captured today
+is a dead link tomorrow. Following it inside the same browser session works because the
+token is still the one the server issued you.
+
+## Holdings are per copy, per branch
+
+Open a record and read the holdings table rather than the availability badge:
+
+```python
+def holdings(page):
+    rows = []
+    for tr in page.query_selector_all("table.holdings tbody tr"):
+        cells = [td.inner_text().strip() for td in tr.query_selector_all("td")]
+        if len(cells) < 3:
+            continue
+        rows.append({
+            "branch": cells[0],
+            "call_number": cells[1],
+            "status": cells[2],
+            "due": cells[3] if len(cells) > 3 else None,
+        })
+    return rows
+```
+
+One row per physical copy is the right grain. It answers "which branch can I walk to
+today", which the record-level badge cannot, and it makes the count of copies visible,
+which matters for anything about demand. A record with nine copies all on loan is a very
+different signal from one copy on loan, and both render as "Checked out" at the top of
+the page.
+
+## Keep the catalogue's words
+
+Resist mapping status to a boolean at capture time. Library systems use a vocabulary that
+carries real distinctions:
+
+- **Available** and **On shelf** mean you can take it now.
+- **Checked out** has a due date. **On hold** does not, and means someone is waiting.
+- **In transit** is between branches, so it is available soon but not anywhere now.
+- **Reference only**, **Reserve**, **Staff use**, **Missing**, **On order**, **Withdrawn**
+  are all non-available for different reasons, and only some of them ever become
+  available again.
+
+Store the raw string and derive a boolean at read time if you need one. The mapping from
+these words to availability differs between library systems, and a mapping baked into the
+capture is a decision you cannot revisit without re-scraping.
+
+## The three mechanical traps
+
+**Consent and session interstitials.** Many public catalogues put a terms banner or a
+branch selector in front of the first search. Clear it once at the start of the session,
+the same way you would any
+[cookie consent banner](how-to-handle-cookie-consent-banners-playwright.md), and the rest
+of the run is clean.
+
+**Results paginate server-side against the session.** The "next" control posts back
+rather than changing a query string. Click it and wait for the list to change instead of
+constructing page numbers, which is the pattern in
+[scraping paginated pages](how-to-scrape-paginated-pages-playwright.md).
+
+**Holdings load after the record.** On several widely used platforms the holdings table
+arrives in a second request and the record page renders complete without it. Wait for the
+table specifically, and treat its absence after a timeout as a distinct outcome rather
+than as an empty holdings list.
+
+## Scrape the catalogue, not the patron account
+
+Everything above works against the public catalogue with no login. It is worth being
+explicit that the interesting-looking parts behind a library card, such as your loans,
+holds and fines, are personal data attached to a person, and the general point in
+[why automating login is riskier than reusing a session](automating-login-vs-session-reuse.md)
+applies with extra force when the account is a library record.
+
+The public catalogue is enough for availability questions, and it is the part libraries
+publish deliberately.
+
+## Pace it, and prefer a narrow question
+
+Libraries run these systems on small budgets and the search endpoint is the expensive one.
+A run that walks an entire catalogue is both slow and unkind. Pick the titles you actually
+care about, poll them at a human interval, and use
+[the rate limiting rules](how-to-rate-limit-your-scraper-playwright.md) rather than
+running flat out. Availability changes when someone physically returns a book, which is a
+scale measured in days.

--- a/docs/how-to-scrape-numbers-rendered-as-images-playwright.md
+++ b/docs/how-to-scrape-numbers-rendered-as-images-playwright.md
@@ -1,0 +1,125 @@
+---
+title: "How to scrape numbers rendered as images with Playwright"
+description: "Read prices and figures a site renders as images or sprites with Playwright: recover the value from the markup the page already carries before reaching for pixels, and know when to stop."
+parent: "Scraping with Playwright"
+grand_parent: "Guides"
+nav_order: 168
+---
+
+
+# How to scrape numbers rendered as images with Playwright
+
+When a site renders a number as an image, look for the value in the **markup around the
+image** before trying to read pixels. Sites that do this almost always leave the number
+somewhere accessible, because a figure that no screen reader can announce is a figure that
+fails accessibility law in most of their markets.
+
+That is the practical order of attack, and it resolves the majority of cases in a few
+lines. Optical recognition is the last resort, not the first, and this page is partly about
+recognising when the right answer is to stop.
+
+## Look in the accessible layer first
+
+```python
+from invisible_playwright import InvisiblePlaywright
+
+PROBE = """
+(sel) => {
+  const el = document.querySelector(sel);
+  if (!el) return null;
+  const img = el.tagName === 'IMG' ? el : el.querySelector('img');
+  return {
+    alt: img ? img.getAttribute('alt') : null,
+    title: el.getAttribute('title'),
+    ariaLabel: el.getAttribute('aria-label'),
+    dataset: Object.assign({}, el.dataset),
+    srOnly: el.querySelector('.sr-only, .visually-hidden')?.textContent.trim() || null,
+    describedBy: (() => {
+      const id = el.getAttribute('aria-describedby');
+      return id ? document.getElementById(id)?.textContent.trim() : null;
+    })(),
+  };
+}
+"""
+
+with InvisiblePlaywright(seed=42) as browser:
+    page = browser.new_page()
+    page.goto("https://example.com/product/1234")
+    found = page.evaluate(PROBE, ".price-image")
+```
+
+In practice one of `alt`, `aria-label`, a `data-` attribute or a visually hidden span
+carries the digits. Check all of them rather than the first, because which one is used
+varies by framework and sometimes within a single page.
+
+## Then check whether it is a sprite, not an image of a number
+
+A common technique renders each digit as a background-position offset into one sprite
+image. The number is then recoverable arithmetically, with no recognition involved:
+
+```python
+OFFSETS = """
+() => Array.from(document.querySelectorAll('.price .digit')).map(d => {
+  const s = getComputedStyle(d);
+  return { x: s.backgroundPositionX, y: s.backgroundPositionY, w: s.width };
+})
+"""
+    digits = page.evaluate(OFFSETS)
+```
+
+Each distinct offset maps to one digit. Calibrate once on a page where you know the value
+from elsewhere, build the offset-to-digit map, and every other page on that site decodes
+exactly. This is more reliable than recognition because it is a lookup, and it breaks
+loudly rather than silently when the site changes the sprite.
+
+Be aware that the mapping is often deliberately shuffled per session or per page load, and
+in that case it is a defence rather than an artefact. That distinction matters for what you
+do next.
+
+## Custom fonts with remapped glyphs
+
+A third variant ships a font where the glyph for "7" draws a 3. The DOM text is then
+misleading rather than absent: you read a number and it is wrong, with no error anywhere.
+
+The tell is a page-specific `@font-face` with an obfuscated family name applied to exactly
+the elements carrying figures. If you find one, the DOM text cannot be trusted for those
+elements, and you either decode the font's character map or you stop. Reading the text and
+hoping is the one option that produces a database full of confidently wrong numbers.
+
+## If you do render, render the element and nothing else
+
+Where the value genuinely exists only as pixels and you have a legitimate reason to read it,
+capture the element rather than the page:
+
+```python
+    element = page.query_selector(".price-image")
+    element.screenshot(path="price.png")
+```
+
+An element screenshot is smaller, deterministic and much easier to feed to recognition than
+a full page. The general capture mechanics, including the traps around lazy content and
+scroll position, are in
+[taking full page screenshots](how-to-take-full-page-screenshots-playwright.md).
+
+Then treat the recognised value as a measurement with an error rate, not as a fact. Store
+the image path or hash next to the number so a suspicious row can be checked by a human,
+and set a confidence threshold below which you record a null rather than a guess.
+
+## When to stop, and why that is a real answer
+
+Sprite shuffling, per-session glyph remapping and image-only figures with no accessible
+label are all deliberate anti-extraction measures. When you meet the deliberate version,
+the useful question is whether you have a relationship with the site that entitles you to
+the data, such as a contract, an API, or a published export.
+
+There is a related honesty point that runs through this whole corpus. A browser that
+behaves like a real browser gets past defences aimed at things that are not browsers, and
+[scraping without getting blocked](how-to-scrape-without-getting-blocked.md) covers where
+that line sits. It does not, and should not, extend to defeating a measure whose only
+purpose is to say no to bulk extraction of that specific field.
+
+The number rendered as an image is usually a price. Prices are also usually available in a
+feed, a partner API, or a structured markup block the same page emits for search engines,
+which is worth checking before any of the above:
+[extracting JSON-LD structured data](how-to-extract-json-ld-structured-data-playwright.md)
+takes about a minute to rule in or out.

--- a/docs/how-to-scrape-package-download-stats-playwright.md
+++ b/docs/how-to-scrape-package-download-stats-playwright.md
@@ -1,0 +1,140 @@
+---
+title: "How to scrape package download statistics with Playwright"
+description: "Scrape package download counts with Playwright: take the series behind the chart rather than the rendered chart, keep the mirror and CI caveats with the numbers, and prefer the published dataset where one exists."
+parent: "Scraping with Playwright"
+grand_parent: "Guides"
+nav_order: 163
+---
+
+
+# How to scrape package download statistics with Playwright
+
+To scrape download statistics, take the **series the chart is drawing**, not the chart.
+Every registry dashboard renders its graph from a JSON response, and that response has the
+per-day numbers at full precision, already aligned to dates, without the rounding and
+smoothing the picture applies.
+
+The second point matters more than the technique: a download count is not a user count.
+Mirrors, CI runs, container builds and caching proxies all appear as downloads, and on
+some packages they are the majority. A number captured without that caveat attached will
+be read as adoption by whoever sees it next, including you in six months.
+
+This page covers taking the series, the caveats that belong with it, and the case for not
+scraping at all.
+
+## First, check whether the data is published
+
+Several registries publish their download data as a dataset or an endpoint, which is
+faster, complete, and does not require a browser. That is the correct first move, and it
+takes one look at the registry's documentation.
+
+Where a public dataset exists, use it and stop reading here. This page is for the case
+where the numbers exist only behind a dashboard.
+
+## Take the response, not the rendering
+
+```python
+import time
+from invisible_playwright import InvisiblePlaywright
+
+series = []
+
+with InvisiblePlaywright(seed=42) as browser:
+    page = browser.new_page()
+
+    def on_response(response):
+        url = response.url
+        if any(k in url for k in ("/downloads", "/stats", "/metrics")):
+            try:
+                series.append({"url": url, "at": time.time(), "body": response.json()})
+            except Exception:
+                pass
+
+    page.on("response", on_response)
+    page.goto("https://registry.example.com/package/some-package")
+    page.wait_for_selector("canvas, svg.chart")
+    page.wait_for_timeout(2500)
+```
+
+The request usually carries the window as parameters, which is the handle for getting more
+than the default view:
+
+```python
+    page.goto("https://registry.example.com/package/some-package?range=12m&interval=day")
+```
+
+Change the range in the interface and watch which parameter moves, rather than guessing
+parameter names. The general mechanics, including the ordering trap where the response
+arrives before your listener is attached, are in
+[capturing XHR and API responses](how-to-capture-xhr-api-responses-playwright.md).
+
+## When the numbers really are only in the picture
+
+Some dashboards render server-side to an image, or draw to a canvas with no JSON behind
+it. Read the values from the accessible layer before reaching for pixels:
+
+```python
+    points = page.eval_on_selector_all(
+        "svg.chart [role='graphics-symbol'], svg.chart .datapoint",
+        "els => els.map(e => ({ label: e.getAttribute('aria-label'), value: e.dataset.value }))",
+    )
+```
+
+Charts built for accessibility carry the values in attributes, and reading them is exact
+where reading pixels is not. Where that fails too, the approach and its limits are in
+[extracting data from canvas charts](how-to-extract-data-from-canvas-charts-playwright.md).
+
+## Keep the caveats in the row, not in your head
+
+Store the qualifiers the registry itself publishes, because they change what the number
+means:
+
+```python
+    row = {
+        "package": "some-package",
+        "date": "2026-09-06",
+        "downloads": 18432,
+        "counts_mirrors": None,        # unknown unless the registry says
+        "source": "registry dashboard",
+        "captured_at": time.time(),
+    }
+```
+
+Three specific distortions are worth a column each where the registry tells you:
+
+- **Mirrors and proxies.** A single corporate proxy can multiply or divide the count.
+- **CI traffic.** A popular library's weekday-versus-weekend pattern is often CI, not
+  people, and it is visible as a flat weekly cycle in the series.
+- **Version splits.** Total downloads across versions hide that most traffic is an old
+  pinned release, which is usually the interesting fact.
+
+Where the dashboard offers a per-version breakdown, take it. Total-only series answer
+almost no question worth asking.
+
+## Comparing packages is where this goes wrong
+
+The tempting use is a comparison, and it is the least reliable one. Two packages with the
+same headline count can differ by an order of magnitude in real users, because one is a
+transitive dependency of something popular and the other is installed deliberately.
+
+If you make the comparison anyway, at minimum compare the same window, the same interval
+and the same registry, and say in the output that the number counts requests. That is the
+same honesty a
+[realness-first mindset](how-to-scrape-without-getting-blocked.md) asks for elsewhere:
+report what you measured, not what you hope it means.
+
+## Store the series long, refresh daily
+
+One row per package per day per version, appended. Registries revise recent days for
+several days after the fact, so re-fetch a trailing window rather than only yesterday:
+
+```python
+    for day in last_n_days(10):
+        upsert(package, day, value_for(day))
+```
+
+Ten days of overlap costs nothing and quietly repairs the revisions. Daily is the right
+cadence, the pacing rules in
+[rate limiting your own scraper](how-to-rate-limit-your-scraper-playwright.md) apply, and
+[JSON Lines](how-to-scrape-to-json-lines-playwright.md) is a good fit for an append-only
+series you will reprocess later.

--- a/docs/how-to-scrape-package-tracking-playwright.md
+++ b/docs/how-to-scrape-package-tracking-playwright.md
@@ -1,0 +1,141 @@
+---
+title: "How to scrape package tracking status with Playwright"
+description: "Scrape parcel tracking with Playwright: capture the event timeline rather than the headline status, keep the carrier's own wording, and poll on the shipment's clock instead of yours."
+parent: "Scraping with Playwright"
+grand_parent: "Guides"
+nav_order: 155
+---
+
+
+# How to scrape package tracking status with Playwright
+
+To scrape tracking, capture the **event timeline** rather than the headline status. A
+tracking page shows one summary word at the top, and that word is a carrier's
+interpretation of a list of scans underneath it. The list is the data. The summary is a
+derived field you can always recompute, and it is the field carriers change the wording
+of without warning.
+
+The second thing to get right is the polling interval. A parcel generates a handful of
+events over several days, so a tight poll produces thousands of identical reads and an
+obvious traffic signature, on endpoints that are unusually well monitored because they
+are a favourite target of abuse.
+
+This page covers reading the timeline, keeping carrier vocabulary intact, and polling in
+a way that matches how shipments actually move.
+
+## Read the timeline, one row per scan
+
+Each scan is a timestamp, a location and a description. Capture all three:
+
+```python
+from invisible_playwright import InvisiblePlaywright
+
+def timeline(page):
+    events = []
+    for row in page.query_selector_all(".tracking-event, li.event"):
+        def text(sel):
+            node = row.query_selector(sel)
+            return node.inner_text().strip() if node else None
+        events.append({
+            "when_text": text(".event-date, time"),
+            "where": text(".event-location"),
+            "what": text(".event-description, .status-text"),
+        })
+    return events
+
+with InvisiblePlaywright(seed=42) as browser:
+    page = browser.new_page()
+    page.goto("https://example-carrier.com/track?number=ABC123456789")
+    page.wait_for_selector(".tracking-event, .not-found")
+    events = timeline(page)
+```
+
+Keep `when_text` as text at capture time. Carriers write dates in local formats, in the
+timezone of the scanning facility, sometimes without a year, and a parse that fails
+silently at capture puts a wrong timestamp in your database forever. Parse in a second
+pass where you can see what failed.
+
+## Order is not guaranteed, and neither is stability
+
+Two properties of these timelines surprise people. Events do not always arrive in order,
+because facilities upload in batches, so a scan from Tuesday can appear after one from
+Wednesday. And events are sometimes **revised**: a carrier can correct a location or drop
+a duplicate scan between two of your reads.
+
+Treat the timeline as a set keyed on the event, not as an append-only log:
+
+```python
+def merge(known, fresh):
+    index = {(e["when_text"], e["what"], e["where"]): e for e in known}
+    for e in fresh:
+        index[(e["when_text"], e["what"], e["where"])] = e
+    return sorted(index.values(), key=lambda e: e["when_text"] or "")
+```
+
+If you also want to detect revisions rather than absorb them, keep each capture whole,
+with the time you took it, and diff captures later. That costs more rows and answers
+questions about carrier behaviour that a merged view erases.
+
+## Keep the carrier's words, add your own status separately
+
+Carriers use different vocabularies for the same physical event, and they change them.
+"Out for delivery", "With courier", "On vehicle for delivery" all mean the same thing at
+three carriers. Store the original string, then map it in a layer you control:
+
+```python
+DELIVERED = {"delivered", "consegnato", "livre", "zugestellt"}
+
+def is_delivered(event):
+    return (event["what"] or "").strip().lower() in DELIVERED
+```
+
+Keeping the mapping outside the capture means a new phrase costs you a line, rather than
+a re-scrape. It also keeps the honest fact that you are guessing at semantics visible in
+the code, instead of buried in a column called `status`.
+
+## Poll on the shipment's clock
+
+A parcel produces events at handoffs: collection, hub in, hub out, local depot, out for
+delivery, delivered. That is a handful of moments over days. Polling every minute is
+noise, and it looks exactly like the abuse these endpoints exist to resist.
+
+A workable shape is an interval that widens when nothing changes and tightens near
+delivery:
+
+```python
+def next_interval(events, last_seen):
+    if not events:
+        return 6 * 3600            # nothing yet: check rarely
+    latest = events[-1]["what"] or ""
+    if "out for delivery" in latest.lower():
+        return 30 * 60             # the one phase worth watching closely
+    if events == last_seen:
+        return 4 * 3600
+    return 60 * 60
+```
+
+The general pacing rules, and why a self-imposed limit beats being told, are in
+[rate limiting your own scraper](how-to-rate-limit-your-scraper-playwright.md).
+
+## Three traps worth knowing
+
+**The number is entered, not in the URL.** Many carriers reject a URL with a tracking
+number in it unless the session has been through the form. Type it into the field and
+submit, the same way a person would.
+
+**Not found and not yet scanned look identical.** A number that a carrier has never seen
+and one that was created but not collected both render as an empty page with a generic
+message. Capture the message text as a distinct outcome instead of writing an empty
+timeline.
+
+**Consent walls and locale interstitials come first.** Especially on European carrier
+sites, the first visit is a consent dialog. Clear it once per session as in
+[handling cookie consent banners](how-to-handle-cookie-consent-banners-playwright.md).
+
+## Track your own parcels
+
+Tracking numbers are not personal data in themselves, but a timeline is a record of where
+someone's package went, and often where they live. Scrape numbers you have a reason to
+hold, keep the retention short, and do not enumerate. Guessing tracking numbers to see
+what comes back is the behaviour these endpoints are defended against, and it is the one
+use of this page that is not worth having.

--- a/docs/how-to-scrape-parking-rates-playwright.md
+++ b/docs/how-to-scrape-parking-rates-playwright.md
@@ -1,0 +1,163 @@
+---
+title: "How to scrape parking rates with Playwright"
+description: "Scrape parking garage rates with Playwright: read the tariff table as duration bands rather than prices, resolve the band an arrival time falls into, and keep the rules that override the table."
+parent: "Scraping with Playwright"
+grand_parent: "Guides"
+nav_order: 150
+---
+
+
+# How to scrape parking rates with Playwright
+
+To scrape parking rates, capture the tariff **table** rather than a price: a garage does
+not have "a rate", it has duration bands whose boundaries move by day of week and time
+of arrival. Read every row as a triple of lower bound, upper bound and amount, record
+the day and time window each table applies to, and keep the override rules printed
+underneath it, because those are what decide the final amount more often than the rows
+above them.
+
+The mistake that produces unusable data is scraping the number that the page shows you.
+A garage page usually renders one headline figure, chosen for a default stay that the
+site picked, and that figure changes if you arrive an hour later. Two runs a day apart
+then disagree, and nothing in the captured row explains why.
+
+This page covers reading the band table without flattening it, handling the arrival
+time the page silently assumed, and the overrides that sit in small print and quietly
+outrank everything else.
+
+## Read the bands, not the headline price
+
+Capture every row of the tariff table with its bounds intact. The unit of data is the
+band, and a band without its bounds is a number with no meaning:
+
+```python
+import re
+from invisible_playwright import InvisiblePlaywright
+
+DURATION = re.compile(
+    r"(?P<lo>\d+(?:\.\d+)?)\s*(?P<lo_unit>min|minutes|hour|hours|hr|day|days)?"
+    r"\s*(?:to|-|and)\s*"
+    r"(?P<hi>\d+(?:\.\d+)?)\s*(?P<hi_unit>min|minutes|hour|hours|hr|day|days)",
+    re.I,
+)
+
+def to_minutes(value, unit):
+    value = float(value)
+    unit = (unit or "hour").lower()
+    if unit.startswith("min"):
+        return int(value)
+    if unit.startswith(("hour", "hr")):
+        return int(value * 60)
+    return int(value * 60 * 24)
+
+with InvisiblePlaywright(seed=42) as browser:
+    page = browser.new_page()
+    page.goto("https://example.com/garages/central/rates")
+
+    bands = []
+    for row in page.query_selector_all("table.rates tbody tr"):
+        cells = [c.inner_text().strip() for c in row.query_selector_all("td")]
+        if len(cells) < 2:
+            continue
+        m = DURATION.search(cells[0])
+        if not m:
+            continue          # a footnote row, not a band
+        bands.append({
+            "from_minutes": to_minutes(m.group("lo"), m.group("lo_unit") or m.group("hi_unit")),
+            "to_minutes": to_minutes(m.group("hi"), m.group("hi_unit")),
+            "label": cells[0],
+            "amount": cells[1],
+        })
+```
+
+Keep `label` alongside the parsed bounds. When a row parses in a way that later looks
+wrong, the original text is the only thing that lets you tell a bad regex from a strange
+tariff, and garages write these strings in every format there is.
+
+## The table is scoped to a day and a time, and the page rarely says so twice
+
+The same garage usually publishes several tables: weekday, weekend, event day, overnight.
+The page shows one at a time and switches between them with a control that does not
+change the URL. Scraping the visible table without recording which one it is produces
+rows that contradict each other for no visible reason.
+
+Record the scope with the bands, and drive the control to collect the others:
+
+```python
+    tariffs = []
+    for tab in page.query_selector_all("[role='tab'], .rate-tabs button"):
+        scope = tab.inner_text().strip()        # "Weekday", "Weekend", "Event"
+        tab.click()
+        page.wait_for_selector("table.rates tbody tr")
+        tariffs.append({"scope": scope, "bands": read_bands(page)})
+```
+
+Click the control rather than fetching a variant URL you guessed. The tab often triggers
+a request whose response the page merges into the table, and driving the real control is
+also the version that behaves like a visitor. The same reasoning applies to any
+[tabbed or accordion content](how-to-scrape-accordion-and-tab-content-playwright.md), where
+the hidden panels are frequently not in the DOM until something opens them.
+
+## Resolve an arrival time instead of storing a spread
+
+Once you have bands, a price is a function of two inputs: when the car arrives and how
+long it stays. Store the function, and compute prices at read time:
+
+```python
+def price_for(tariff, arrival, minutes):
+    """arrival is a datetime, minutes an int. Returns the matching band."""
+    scope = "Weekend" if arrival.weekday() >= 5 else "Weekday"
+    table = next(t for t in tariff if t["scope"] == scope)
+    for band in table["bands"]:
+        if band["from_minutes"] <= minutes <= band["to_minutes"]:
+            return band
+    return table["bands"][-1]      # over the top band: the daily maximum applies
+```
+
+The fallback on the last line is not a detail. Most tariffs end with a maximum that
+covers everything beyond the final band, and a scraper that returns nothing for a
+fourteen hour stay is reporting an absence that the garage does not have.
+
+## The small print outranks the table
+
+Underneath the table sit the rules that decide the real amount: a daily maximum, a
+minimum charge, a grace period, a different rate after midnight, an early-bird rate that
+requires arriving before a cutoff. These are prose, not rows, and they routinely
+contradict the table above them.
+
+Capture them verbatim rather than trying to parse them:
+
+```python
+    notes = [n.inner_text().strip()
+             for n in page.query_selector_all(".rate-notes li, .rates-footnote")]
+```
+
+Verbatim text is the honest form here. A parser that turns "maximum $28 per 24 hours,
+in and out privileges not included" into a number throws away the second clause, and the
+second clause is the one that makes the number wrong. Store the strings, resolve them
+when a human asks a question that needs them.
+
+## Two practical traps
+
+**The price appears after a date picker is filled.** Many operators only show rates once
+you enter arrival and departure. That is a form to drive, not a page to read, and it
+behaves like any other
+[multi-step wizard flow](how-to-scrape-multi-step-wizard-flow-playwright.md): fill it in
+order, wait for the result region, then read.
+
+**Rates are location-scoped even on the same site.** A chain publishes the same page
+shell for every garage and fills the numbers per location, sometimes from your inferred
+position rather than the URL. If the figures change when the exit IP changes, the page is
+reading a location you did not set, and the fix is the one in
+[scraping geotargeted content](how-to-scrape-geotargeted-content-playwright.md).
+
+## Collect politely, because these pages are cheap to overload
+
+Parking operators run small sites. A run that walks every garage in a city at full speed
+is a visible load spike on infrastructure that was not built for it, and the block that
+follows is deserved rather than adversarial. Pace the run with
+[a rate limit you impose on yourself](how-to-rate-limit-your-scraper-playwright.md), and
+prefer one pass per day over a poll: tariffs change on the scale of months.
+
+The result is a table of bands, plus scopes, plus notes. It is more data than a single
+price, and it is the only form that still means the same thing tomorrow.

--- a/docs/how-to-scrape-pet-adoption-listings-playwright.md
+++ b/docs/how-to-scrape-pet-adoption-listings-playwright.md
@@ -1,0 +1,135 @@
+---
+title: "How to scrape pet adoption listings with Playwright"
+description: "Scrape shelter adoption listings with Playwright: reconcile disappearances instead of deleting rows, key animals on the shelter's own identifier, and keep photos as references rather than copies."
+parent: "Scraping with Playwright"
+grand_parent: "Guides"
+nav_order: 158
+---
+
+
+# How to scrape pet adoption listings with Playwright
+
+To scrape adoption listings, treat a **disappearance as data**. Listings leave these sites
+constantly, because the animal was adopted, moved to another shelter, or the listing was
+merged, and a scraper that mirrors the current page loses the single most interesting
+signal the dataset contains: how long an animal waited.
+
+The second decision is the key. Shelter software gives every animal an identifier, usually
+in the URL. Use it. Names repeat heavily in this domain, and keying on name plus breed
+merges two different dogs called Luna every time.
+
+This page covers reconciling each run against the last, keying on the shelter's own
+identifier, and handling the photo-heavy pages these listings live on.
+
+## Key on the shelter's identifier, from the URL
+
+```python
+import re
+from invisible_playwright import InvisiblePlaywright
+
+ID_IN_URL = re.compile(r"/(?:animal|pet)/(?P<id>[A-Za-z0-9-]+)")
+
+def listing_rows(page):
+    rows = []
+    for card in page.query_selector_all(".animal-card"):
+        link = card.query_selector("a")
+        href = link.get_attribute("href") or ""
+        m = ID_IN_URL.search(href)
+        rows.append({
+            "shelter_id": m.group("id") if m else None,
+            "href": href,
+            "name": card.query_selector(".name").inner_text().strip(),
+            "summary": card.inner_text().strip(),
+        })
+    return rows
+```
+
+When no identifier is available anywhere, fall back to a hash of the stable fields and say
+so in the row, rather than pretending the key is authoritative. A key you invented behaves
+differently from one the site issued, and the difference shows up as churn that looks like
+animals arriving and leaving daily.
+
+## Reconcile, do not mirror
+
+Each run, compare the set you see with the set you saw last time, and write three kinds of
+event:
+
+```python
+def reconcile(previous_ids, current_rows, run_at):
+    current_ids = {r["shelter_id"] for r in current_rows}
+    events = []
+    for row in current_rows:
+        if row["shelter_id"] not in previous_ids:
+            events.append({"type": "appeared", "at": run_at, **row})
+    for gone in previous_ids - current_ids:
+        events.append({"type": "disappeared", "at": run_at, "shelter_id": gone})
+    return events
+```
+
+"Disappeared" is not "adopted", and it is worth being strict about that in the schema.
+Listings also vanish because a shelter reorganised its site, because a filter you did not
+set was applied, or because a page failed to load fully. Record the neutral fact and let
+an analysis layer interpret it, ideally alongside the run's own health, such as how many
+cards the page returned in total.
+
+Guard against the failure mode where an empty page reads as a mass adoption event:
+
+```python
+    if len(current_rows) < 0.5 * len(previous_ids):
+        raise SystemExit("listing count halved: treating as a failed run, not a rescue")
+```
+
+## The list is filtered before you see it
+
+Shelter sites default to filters more often than most listing sites: species, adoptable
+status, location radius, sometimes an animal's readiness date. Set them deliberately and
+record what you set:
+
+```python
+    page.select_option("select[name='species']", "any")
+    page.check("input[name='include_pending']")
+    row["filters"] = {"species": "any", "include_pending": True}
+```
+
+Recording the filters is what makes two runs comparable. A dataset whose filters drifted
+between runs shows population changes that never happened, and there is nothing in the
+rows to reveal it.
+
+Facet controls that repopulate the list without a navigation behave like the ones in
+[multi-select facet filters](how-to-scrape-multi-select-facets-playwright.md): wait for
+the list to settle rather than for a load event.
+
+## Photos: keep the URL, not the file
+
+These pages are image heavy, and mirroring photographs is both a bandwidth cost to a
+shelter and a licensing question you probably have not answered. Keep the URL and the
+alt text:
+
+```python
+        img = card.query_selector("img")
+        row["photo_url"] = img.get_attribute("src") if img else None
+        row["photo_alt"] = img.get_attribute("alt") if img else None
+```
+
+If the images are lazy loaded, the `src` may be a placeholder until the card scrolls into
+view. The handling is the same as in
+[scraping lazy-loaded images](how-to-scrape-lazy-loaded-images-playwright.md): trigger
+the load, then read, or read the real URL from the `data-src` attribute the page is
+holding it in.
+
+## Pagination and the long tail
+
+Most shelters have few animals and one page. Aggregators have many, behind
+[a load-more button](how-to-scrape-load-more-button-playwright.md) or classic pagination.
+Walk it to the end rather than taking the first page, because the animals that have been
+waiting longest are usually last in the default sort, and those are exactly the rows a
+"how long do they wait" question needs.
+
+## Be gentle, and consider asking
+
+Shelters are volunteer-run more often than not, and several publish an export or an API on
+request precisely so people stop scraping them. That is a genuinely better source: it is
+faster for you, cheaper for them, and it comes with permission attached. Where you do
+scrape, run once a day, respect the pacing in
+[rate limiting your own scraper](how-to-rate-limit-your-scraper-playwright.md), and keep
+the contact details of the site you are reading in case someone wants to ask you to stop.

--- a/docs/how-to-scrape-scholarship-listings-playwright.md
+++ b/docs/how-to-scrape-scholarship-listings-playwright.md
@@ -1,0 +1,135 @@
+---
+title: "How to scrape scholarship listings with Playwright"
+description: "Scrape scholarship databases with Playwright: parse deadlines that are often not dates, keep eligibility criteria as text, and separate the aggregator's summary from the provider's own page."
+parent: "Scraping with Playwright"
+grand_parent: "Guides"
+nav_order: 161
+---
+
+
+# How to scrape scholarship listings with Playwright
+
+To scrape scholarship listings, treat the **deadline** as a field that is frequently not a
+date and the **eligibility** as text you must not compress. Those two fields carry all the
+decision value, and both are routinely written in ways that defeat a naive parser:
+"rolling", "varies by campus", "30 days before term start", "closed for 2026".
+
+There is a second structural point. Most scholarship data lives on aggregators that
+summarise a provider's own page, and the summary is often stale or subtly wrong. If your
+use is helping someone decide where to apply, capture the provider link and treat the
+aggregator row as an index entry rather than as the truth.
+
+This page covers deadlines that are not dates, eligibility that resists structuring, and
+following through to the source.
+
+## Parse the deadline into a shape that admits it is not a date
+
+```python
+import re
+from datetime import date
+
+RELATIVE = re.compile(r"(?P<n>\d+)\s+days?\s+before\s+(?P<anchor>.+)", re.I)
+
+def parse_deadline(text):
+    t = (text or "").strip()
+    low = t.lower()
+    if not t:
+        return {"kind": "unknown", "raw": text}
+    if "rolling" in low or "any time" in low:
+        return {"kind": "rolling", "raw": t}
+    if "varies" in low:
+        return {"kind": "varies", "raw": t}
+    if "closed" in low:
+        return {"kind": "closed", "raw": t}
+    m = RELATIVE.search(low)
+    if m:
+        return {"kind": "relative", "days_before": int(m.group("n")),
+                "anchor": m.group("anchor").strip(), "raw": t}
+    parsed = try_absolute(t)
+    if parsed:
+        return {"kind": "date", "date": parsed.isoformat(), "raw": t}
+    return {"kind": "unparsed", "raw": t}
+```
+
+The `unparsed` branch is the one that keeps the dataset honest. A pipeline that coerces
+everything into a date column has to invent something for "varies by campus", and whatever
+it invents will send someone to a deadline that does not exist.
+
+Absolute dates need care too: these listings mix `03/04/2026` in both conventions, often
+on the same aggregator, because providers submit them as free text. Where the site
+publishes a machine-readable date in an attribute, prefer it:
+
+```python
+    node = card.query_selector("time[datetime]")
+    iso = node.get_attribute("datetime") if node else None
+```
+
+## Eligibility is prose, and compressing it does harm
+
+Eligibility rules combine study level, field, nationality, residency, income, institution,
+sometimes demographic criteria and sometimes an essay requirement. Aggregators show them
+as chips, which loses the conjunctions: whether the criteria are all required or any of
+them qualify.
+
+Capture both forms:
+
+```python
+        "eligibility_chips": [c.inner_text().strip()
+                              for c in card.query_selector_all(".eligibility .chip")],
+        "eligibility_text": (card.query_selector(".eligibility-full").inner_text().strip()
+                             if card.query_selector(".eligibility-full") else None),
+```
+
+The chips are searchable; the text is correct. If you only keep one, keep the text. A
+student filtered out by a chip that dropped an "or" is a real cost, and it is invisible in
+the data.
+
+## The award amount has a shape too
+
+```python
+    "amount_text": "Up to $5,000 per year, renewable for 4 years"
+```
+
+Amounts carry a maximum, a period, a renewal and sometimes a count of awards. Store the
+string and derive numbers with the same explicit-unknown discipline as deadlines. A single
+`amount` float turns "up to" into "is", which is the most common way these datasets
+overstate what a student will receive.
+
+## Follow through to the provider
+
+The aggregator row should carry a link to the source, and the source is where the current
+deadline lives:
+
+```python
+    provider = card.query_selector("a.provider-link, a[rel='nofollow'][target='_blank']")
+    row["provider_url"] = provider.get_attribute("href") if provider else None
+```
+
+Where you visit the provider page, capture its own deadline and eligibility separately
+rather than overwriting the aggregator's. The disagreement between the two is useful
+information about how stale the aggregator is, and it is lost the moment you merge them.
+
+Many provider pages are university sites whose listings sit behind a search form; that is
+the pattern in
+[scraping search results by driving a form](how-to-scrape-search-results-form-playwright.md).
+
+## Filters, pagination and a rewarding shortcut
+
+Aggregators put the useful selection behind facets, which repopulate the list without a
+navigation, exactly like
+[multi-select facet filters](how-to-scrape-multi-select-facets-playwright.md). Set them
+explicitly and record what you set, because a filter left at a default silently narrows
+your dataset in a way no column reveals.
+
+The shortcut worth trying first: many of these listings are marked up with structured data
+for search engines, which gives you a clean object without parsing the cards at all. Check
+before writing selectors, using
+[extracting JSON-LD structured data](how-to-extract-json-ld-structured-data-playwright.md).
+
+## Refresh on the deadline calendar
+
+Scholarship data has a natural rhythm: providers update in a season, deadlines cluster,
+and most rows do not change for months. A weekly full pass plus a daily pass over rows
+whose deadline is within a month covers the volatility at a fraction of the requests, and
+keeps you well inside the pacing described in
+[rate limiting your own scraper](how-to-rate-limit-your-scraper-playwright.md).

--- a/docs/how-to-scrape-school-term-calendars-playwright.md
+++ b/docs/how-to-scrape-school-term-calendars-playwright.md
@@ -1,0 +1,129 @@
+---
+title: "How to scrape school term calendars with Playwright"
+description: "Scrape school term dates with Playwright: prefer the calendar feed the page links to, expand date ranges into days, and keep the difference between a closure and a staff day."
+parent: "Scraping with Playwright"
+grand_parent: "Guides"
+nav_order: 166
+---
+
+
+# How to scrape school term calendars with Playwright
+
+To scrape term dates, look for the **calendar feed** before parsing the page. Schools and
+districts publish the same information three ways: an HTML table, a PDF, and very often an
+iCalendar subscription for parents. The feed is structured, dated, and already carries the
+distinction between an all-day closure and a timed event, which the HTML table usually
+loses.
+
+When there is no feed, the work is expanding ranges. Term calendars are written as spans,
+"14 October to 18 October", and almost every question people ask of this data is about a
+single day. Storing the span and expanding at read time is fine; storing only the span text
+is not.
+
+This page covers finding the feed, expanding ranges correctly, and keeping the category of
+each non-teaching day.
+
+## Look for the feed first
+
+```python
+from urllib.parse import urljoin
+from invisible_playwright import InvisiblePlaywright
+
+FEED = ("a[href$='.ics'], link[type='text/calendar'], "
+        "a[href*='webcal'], a[href*='ical']")
+
+with InvisiblePlaywright(seed=42) as browser:
+    page = browser.new_page()
+    page.goto("https://example-school.org/term-dates")
+
+    node = page.query_selector(FEED)
+    if node:
+        feed_url = urljoin(page.url, node.get_attribute("href"))
+        page.goto(feed_url.replace("webcal://", "https://"))
+        ics_text = page.inner_text("pre") or page.content()
+```
+
+Fetch the feed inside the same browser rather than with a separate client. It is usually
+served from the same host with the same protection, and the reasoning is the one that
+applies to any secondary document: a side request is a fresh visitor with none of the
+context the page accumulated.
+
+Where the link points at a PDF instead, that is a different job with its own mechanics, in
+[downloading and reading linked PDFs](how-to-scrape-linked-pdfs-playwright.md).
+
+## Expanding a range needs the inclusive end
+
+```python
+from datetime import date, timedelta
+
+def expand(start: date, end: date, label: str):
+    day = start
+    while day <= end:                 # inclusive: the last day is a holiday too
+        yield {"date": day.isoformat(), "label": label}
+        day += timedelta(days=1)
+```
+
+The inclusive comparison is the bug that shows up every single time. A half-term written
+as "14 October to 18 October" is five days, and an exclusive loop returns four, silently
+sending a child to school on the Friday.
+
+Weekends inside a term-time range are also not closures in the useful sense, so decide once
+whether your expansion emits them and record the choice, rather than leaving each consumer
+to guess.
+
+## Keep the category, because not all closures are the same
+
+Term calendars mix several kinds of non-teaching day, and parents care about the
+difference:
+
+- **Term dates**: the boundaries of teaching.
+- **Half term and holidays**: school closed, most childcare closed.
+- **Staff training days**: school closed to pupils, often not to staff, and frequently
+  moved by an individual school inside a district-wide calendar.
+- **Occasional closures**: weather, elections, building work. These appear late and vanish
+  from the page afterwards.
+
+```python
+        {"date": "2026-10-14", "kind": "half_term", "raw_label": "October half term"}
+```
+
+Keep `raw_label` next to your normalised `kind`. School sites write these labels in local
+vocabulary that a fixed mapping will not cover, and the raw string is what lets a human
+resolve an unfamiliar one later.
+
+## District calendars and per-school overrides
+
+Where a district publishes a calendar and individual schools publish their own, the school
+page overrides on training days specifically. Scrape both and keep the source per row:
+
+```python
+        {"date": "2026-11-03", "kind": "staff_day", "source": "school", "school_id": "1234"}
+```
+
+Merging them into one calendar without a source column produces a dataset that disagrees
+with itself on exactly the dates people need most, with no way to tell which row is
+authoritative.
+
+## These pages change once a year, and then quietly
+
+Term dates for the following year are usually published months ahead and then adjusted.
+A weekly pass is generous; the useful trigger is a change in the page rather than the
+calendar. Hashing the extracted rows and only writing when the hash moves keeps the history
+small and makes the amendments visible:
+
+```python
+    import hashlib, json
+    digest = hashlib.sha256(json.dumps(rows, sort_keys=True).encode()).hexdigest()
+```
+
+Store each version rather than overwriting, so "when did they move the training day" stays
+answerable. [JSON Lines](how-to-scrape-to-json-lines-playwright.md) suits this well, and
+the pacing is trivially inside anything
+[rate limiting your own scraper](how-to-rate-limit-your-scraper-playwright.md) recommends.
+
+## A note on scope
+
+School sites are small, often run by one person, and contain material about children.
+Take the calendar, which is published for parents, and leave the rest. There is rarely a
+reason for a scraper to touch newsletters, staff lists or photo galleries, and taking only
+the pages that answer your question is both the polite and the defensible default.

--- a/docs/how-to-scrape-snow-reports-playwright.md
+++ b/docs/how-to-scrape-snow-reports-playwright.md
@@ -1,0 +1,135 @@
+---
+title: "How to scrape snow reports with Playwright"
+description: "Scrape ski resort snow reports with Playwright: normalise the units before storing, keep base and summit as separate measurements, and record the report time the resort publishes."
+parent: "Scraping with Playwright"
+grand_parent: "Guides"
+nav_order: 157
+---
+
+
+# How to scrape snow reports with Playwright
+
+To scrape a snow report, normalise the **unit** at capture and keep each measurement
+point separate. A resort publishes several numbers that all look like "snow depth": base,
+mid-mountain, summit, new snow in 24 hours, new snow in 48 hours, season total. They are
+different measurements, taken at different altitudes, and a column called `depth` that
+mixes them is worse than no column.
+
+The unit is the other half. The same resort site serves centimetres to one visitor and
+inches to another, usually from a toggle that remembers a previous choice or from an
+inferred locale. A series that silently switches unit halfway through looks like a
+blizzard followed by a thaw.
+
+This page covers pinning the unit, reading the measurement points as separate rows, and
+keeping the resort's own report timestamp.
+
+## Pin the unit before reading any number
+
+Set the toggle explicitly rather than trusting the default:
+
+```python
+from invisible_playwright import InvisiblePlaywright
+
+with InvisiblePlaywright(seed=42) as browser:
+    page = browser.new_page()
+    page.goto("https://example-resort.com/snow-report")
+
+    toggle = page.query_selector("[data-unit='cm'], .units-metric")
+    if toggle:
+        toggle.click()
+        page.wait_for_timeout(500)
+
+    unit = page.eval_on_selector(".depth-value", "e => e.dataset.unit || 'unknown'")
+```
+
+Then record the unit with every row, even after pinning it. A toggle that failed to click
+leaves the page in the other unit and your rows still say what you intended rather than
+what you read. Reading the unit back from the DOM after the click is the version that
+catches that.
+
+Where the site has no toggle and decides by locale, you are looking at
+[geotargeted content](how-to-scrape-geotargeted-content-playwright.md) and the exit you
+browse from becomes part of the measurement.
+
+## One row per measurement point
+
+```python
+POINTS = {
+    ".base .depth-value": "base",
+    ".mid .depth-value": "mid",
+    ".summit .depth-value": "summit",
+}
+
+    readings = []
+    for selector, point in POINTS.items():
+        node = page.query_selector(selector)
+        if not node:
+            continue
+        readings.append({
+            "point": point,
+            "value_text": node.inner_text().strip(),
+            "unit": unit,
+        })
+```
+
+Resorts drop and add points between seasons, and some publish only one. A missing point
+should be an absent row, not a zero. Zero snow at the summit and no summit reading are
+opposite facts, and only one of them is ever true in January.
+
+## New snow is a window, so store the window
+
+"New snow" is meaningless without the period it covers, and the period varies by resort
+and sometimes by season:
+
+```python
+        {"metric": "new_snow", "window_hours": 24, "value_text": "12", "unit": "cm"}
+```
+
+Read the window from the label next to the number rather than assuming 24 hours. Sites
+write "Last 24h", "Overnight", "Since 5pm" and "48 hour total" in the same widget across a
+handful of resorts, and "Overnight" is not a fixed duration at all. When the label does
+not resolve to a number of hours, keep it as text and leave `window_hours` null. A null is
+honest; a 24 you invented is not.
+
+## Keep the resort's report time, not your fetch time
+
+Snow reports are published once or twice a day and the page shows when:
+
+```python
+    reported = page.query_selector(".report-updated")
+    row["reported_text"] = reported.inner_text().strip() if reported else None
+    row["observed_at"] = time.time()
+```
+
+Both times matter for the same reason they matter in any live-status scrape. A page
+fetched at noon showing a report from 6am is a six hour old measurement, and a series
+built on fetch time alone will show snow arriving at whatever hour your cron happens to
+run.
+
+## The lift and trail counts are a different kind of number
+
+Most snow reports sit next to counts of open lifts and open runs. They are worth taking,
+with the same care about denominators:
+
+```python
+    lifts_text = page.inner_text(".lifts-open")     # "8 / 14"
+```
+
+Store the numerator and denominator, not a percentage. Resorts change the total number of
+lifts between seasons, and a stored percentage cannot be recomputed once the total is
+gone. This is the same discipline as
+[reading stock levels](how-to-scrape-stock-levels-playwright.md), where the count and the
+capacity are two facts that only mean something together.
+
+## Season shape and polite polling
+
+These sites are seasonal and small. Out of season the page often keeps last season's
+numbers frozen rather than clearing them, so a scraper running in July happily records a
+metre of base snow. Guard on the report timestamp: if it has not moved in a week, stop
+storing new rows and record the staleness instead.
+
+In season, once or twice a day matches publication. There is no faster truth to get, and
+the pacing advice in
+[rate limiting your own scraper](how-to-rate-limit-your-scraper-playwright.md) applies
+with the extra note that resort sites see genuine traffic spikes at 7am local time, which
+is precisely when a naive scheduler would fire.

--- a/docs/how-to-scrape-spare-part-compatibility-playwright.md
+++ b/docs/how-to-scrape-spare-part-compatibility-playwright.md
@@ -1,0 +1,135 @@
+---
+title: "How to scrape spare part compatibility with Playwright"
+description: "Scrape fitment and compatibility tables with Playwright: drive cascading dropdowns that repopulate from the server, capture the whole combination as the key, and keep the exceptions the site prints."
+parent: "Scraping with Playwright"
+grand_parent: "Guides"
+nav_order: 167
+---
+
+
+# How to scrape spare part compatibility with Playwright
+
+To scrape compatibility data, drive the **cascading dropdowns** in order and record the
+full combination with every result. These selectors are the classic make, model, year,
+variant chain, where each choice repopulates the next from the server, and the answer only
+exists at the end of a complete path.
+
+That structure has a consequence people underestimate: the dataset is the cross product,
+and it is large. A parts catalogue with 40 makes, 30 models each, 20 years and 4 variants
+is 96,000 paths. Walking it exhaustively is both slow and a load pattern no catalogue will
+tolerate, so the first design decision is which slice you actually need.
+
+This page covers driving the cascade reliably, keying results on the full path, and
+keeping the fitment exceptions that make compatibility data trustworthy.
+
+## Drive the cascade, waiting for each level to repopulate
+
+```python
+from invisible_playwright import InvisiblePlaywright
+
+def options(page, selector):
+    return page.eval_on_selector_all(
+        f"{selector} option",
+        "els => els.map(e => ({value: e.value, label: e.textContent.trim()}))"
+            ".filter(o => o.value && o.value !== '0')",
+    )
+
+def choose(page, selector, value, next_selector):
+    before = page.eval_on_selector(next_selector, "e => e.options.length")
+    page.select_option(selector, value)
+    page.wait_for_function(
+        "args => document.querySelector(args.sel).options.length !== args.n",
+        arg={"sel": next_selector, "n": before},
+    )
+```
+
+Waiting on the option count of the **next** control is what makes this reliable. Waiting a
+fixed time is a race that fails on a slow response and wastes seconds on a fast one, and
+waiting for a network idle event misses the case where the site repopulates from data it
+already had. The count changes exactly when the level below is ready.
+
+Where the chain repopulates without a full page load, capturing the underlying responses
+directly can be faster than reading the DOM at each step; the mechanics are in
+[capturing XHR and API responses](how-to-capture-xhr-api-responses-playwright.md).
+
+## The key is the whole path, not the part number
+
+```python
+with InvisiblePlaywright(seed=42) as browser:
+    page = browser.new_page()
+    page.goto("https://parts.example.com/fitment")
+
+    rows = []
+    for make in options(page, "select#make"):
+        choose(page, "select#make", make["value"], "select#model")
+        for model in options(page, "select#model"):
+            choose(page, "select#model", model["value"], "select#year")
+            for year in options(page, "select#year"):
+                choose(page, "select#year", year["value"], "select#variant")
+                for variant in options(page, "select#variant"):
+                    page.select_option("select#variant", variant["value"])
+                    page.click("button#findParts")
+                    page.wait_for_selector(".part-result, .no-fit")
+                    for part in page.query_selector_all(".part-result"):
+                        rows.append({
+                            "make": make["label"], "model": model["label"],
+                            "year": year["label"], "variant": variant["label"],
+                            "part_number": part.query_selector(".sku").inner_text().strip(),
+                            "part_name": part.query_selector(".name").inner_text().strip(),
+                        })
+```
+
+One row per combination per part is the shape that answers the real question, which runs in
+both directions: what fits this vehicle, and what does this part fit. A schema keyed on
+part number with a compatibility blob attached answers the first well and the second badly.
+
+## Fitment notes are the difference between right and nearly right
+
+Catalogues attach qualifiers to a fit: a build date cutoff, an engine code, a market, a
+"with air conditioning" condition. These are the exceptions that make the difference
+between the correct part and a return:
+
+```python
+                        note = part.query_selector(".fitment-note")
+                        row["fitment_note"] = note.inner_text().strip() if note else None
+```
+
+Never drop these. A compatibility dataset without qualifiers is confidently wrong on
+exactly the vehicles where the answer matters, and the failure is expensive in the physical
+world rather than only in the data.
+
+Capture the negative case too. A combination that returns no parts is information, and
+storing it prevents you re-walking that path on the next run:
+
+```python
+                    if page.query_selector(".no-fit"):
+                        rows.append({"make": ..., "variant": ..., "part_number": None,
+                                     "result": "no_fit"})
+```
+
+## Slice before you sweep
+
+Decide the scope explicitly rather than starting at the top of the cross product:
+
+```python
+    TARGET_MAKES = ["Example Motors"]
+    TARGET_YEARS = range(2018, 2027)
+```
+
+A single make across nine years is a few thousand queries, which is a night's polite work.
+The whole catalogue is not, and a run that tries it will be stopped partway with an
+incomplete dataset and a blocked address. Where the site publishes a bulk fitment file for
+trade customers, that is the honest route and worth asking about.
+
+Make the run resumable, because at this scale it will be interrupted. Write each
+combination as it completes and checkpoint the path you were on, using the pattern in
+[resuming an interrupted scrape](how-to-resume-an-interrupted-scrape-playwright.md), with
+[retrying failed requests](how-to-retry-failed-requests-playwright.md) for the transient
+failures a long walk will meet.
+
+## Pace it like the database query it is
+
+Every combination is a lookup against a real catalogue database, not a cached page. Keep a
+deliberate delay between combinations and run outside the retailer's trading hours where
+you can. The reasoning, and why a self-imposed limit beats being told, is in
+[rate limiting your own scraper](how-to-rate-limit-your-scraper-playwright.md).


### PR DESCRIPTION
Twenty new scraping guides. The topics were picked from this week's ranking data rather than from keyword research: among our indexed pages, queries matching a page title rank 84% of the time and generic queries 4%, so the generic Playwright subjects that consistently lose were left out on purpose.

Each one has a different technical problem at its centre, so they do not read as twenty variants of the same article: duration bands for parking, a DOM that rewrites itself for flight boards, cascading dropdowns for part fitment, computed style for pseudo-element content, and so on.

They sit at nav_order 150 to 169 under Scraping with Playwright, no collisions, no broken internal links. One honest gap: they average 851 words against about 1,900 for the pages that rank, so extending them is still open work.