### PR TITLE
Extend the twenty new guides to the length the corpus publishes at

### DIFF
--- a/docs/how-to-scrape-bank-interest-rates-playwright.md
+++ b/docs/how-to-scrape-bank-interest-rates-playwright.md
@@ -141,3 +141,101 @@ in [rate limiting your own scraper](how-to-rate-limit-your-scraper-playwright.md
 and storing the history in
 [a SQLite database](how-to-scrape-into-a-database-playwright.md) gives you the one thing
 the bank's own page never shows: what the rate used to be.
+
+## A complete pass over several products
+
+```python
+import json, time
+from invisible_playwright import InvisiblePlaywright
+
+PRODUCTS = [("CA", "TFSA"), ("CA", "GIC"), ("CA", "SAVINGS")]
+
+def read_rates(page, region, product):
+    page.goto("https://example-bank.com/savings/rates", wait_until="domcontentloaded")
+    page.select_option("select#region", region)
+    page.select_option("select#product", product)
+    page.wait_for_function(
+        "() => document.querySelectorAll('table.rates tbody tr').length > 0")
+
+    node = page.query_selector(".rates-effective, .as-of-date")
+    effective = node.inner_text().strip() if node else None
+    kinds = page.eval_on_selector_all(
+        "table.rates thead th", "els => els.map(e => e.textContent.trim())")
+
+    rows = []
+    for parsed in page.evaluate(RESOLVE):
+        cells, notes = parsed["cells"], parsed["footnotes"]
+        if len(cells) < 2:
+            continue
+        rows.append({
+            "region": region, "product": product,
+            **parse_tier(cells[0]),
+            "rate_text": cells[1],
+            "rate_kind": kinds[1] if len(kinds) > 1 else None,
+            "footnotes": notes,
+            "effective_text": effective,
+            "observed_at": time.time(),
+        })
+    return rows
+
+with InvisiblePlaywright(seed=42) as browser, open("rates.jsonl", "a", encoding="utf-8") as out:
+    page = browser.new_page()
+    for region, product in PRODUCTS:
+        for row in read_rates(page, region, product):
+            out.write(json.dumps(row, ensure_ascii=False) + "\n")
+        out.flush()
+        page.wait_for_timeout(4000)
+```
+
+Reading the column headers into `rate_kind` rather than hardcoding "APY" is what keeps the
+dataset correct when the bank reorders its table or serves a different label by region.
+It costs one line and removes a whole class of silent mismatch.
+
+## Banks cache hard, and that is the failure to design for
+
+Retail banking sites are rarely hostile to a reader, and they are aggressively cached and
+heavily regionalised. Three consequences.
+
+**A stale page is the normal failure.** The request succeeds, the table renders, and the
+effective date is from last week. That is why `effective_text` is captured on every row
+rather than derived once: without it, a series shows a rate holding steady when the page
+simply was not refreshed.
+
+**The region control sometimes loses.** Where the site also infers a region from the
+visitor, selecting one in the dropdown can be overridden on the next navigation. Read the
+region back from the page after the table loads, and record what the page says rather than
+what you asked for:
+
+```python
+    shown = page.eval_on_selector("select#region", "e => e.value")
+    if shown != region:
+        row["region_requested"], row["region"] = region, shown
+```
+
+**Product pages sit behind an interstitial.** Regulatory splash screens and region pickers
+appear on first visit in several markets, and a run that does not clear them reads the
+splash instead of the rates. Handle it once per session the same way as any
+[cookie consent banner](how-to-handle-cookie-consent-banners-playwright.md).
+
+If a rate table does come back empty rather than stale, the page itself is the fastest
+diagnosis, in the order set out in
+[scraping without getting blocked](how-to-scrape-without-getting-blocked.md).
+
+## The schema, and the join that makes it useful
+
+One row per bank, region, product, tier and observation, with footnotes as an array:
+
+| field | why it earns its place |
+|---|---|
+| `min_balance` / `max_balance` | the tier, with null meaning open ended |
+| `rate_text` and parsed `rate` | the string survives a format change |
+| `rate_kind` | APY and APR are different quantities |
+| `footnotes` | resolved text, not markers |
+| `effective_text` | the bank's clock |
+| `observed_at` | yours, so staleness is measurable |
+
+The analysis this shape enables, and that the banks' own pages cannot, is the one comparing
+a headline rate against its conditions over time. Introductory rates that quietly shorten
+their bonus period, tiers whose thresholds drift upward, and footnotes that gain a
+requirement between two captures are all visible as a diff, and all invisible in a table
+that keeps only the current best rate per product.

--- a/docs/how-to-scrape-conference-agendas-playwright.md
+++ b/docs/how-to-scrape-conference-agendas-playwright.md
@@ -135,3 +135,93 @@ Either way this is a small site with a spiky audience, so keep to the pacing in
 [rate limiting your own scraper](how-to-rate-limit-your-scraper-playwright.md) and prefer
 running outside the conference hours themselves, when the site is serving the people
 actually at the event.
+
+## A complete capture, days and sessions
+
+```python
+import json, time
+from invisible_playwright import InvisiblePlaywright
+
+def capture_agenda(page, url):
+    page.goto(url, wait_until="domcontentloaded")
+    page.wait_for_selector(".schedule-grid .session", timeout=20000)
+
+    tz_node = page.query_selector("meta[name='event-timezone'], .event-timezone")
+    tz = page.evaluate("e => e.content || e.textContent.trim()", tz_node) if tz_node else None
+
+    days, sessions = page.query_selector_all(".day-tabs [role='tab']"), []
+    if not days:
+        for s in page.evaluate(GRID):
+            sessions.append({**s, "day": None})
+    else:
+        for tab in days:
+            label = tab.inner_text().strip()
+            tab.click()
+            page.wait_for_function(
+                "() => document.querySelectorAll('.schedule-grid .session').length > 0")
+            page.wait_for_timeout(400)          # let the grid settle after the swap
+            for s in page.evaluate(GRID):
+                sessions.append({**s, "day": label})
+
+    return {"url": url, "event_timezone": tz,
+            "captured_at": time.time(), "sessions": sessions}
+
+with InvisiblePlaywright(seed=42) as browser, open("agenda.jsonl", "a", encoding="utf-8") as out:
+    page = browser.new_page()
+    agenda = capture_agenda(page, "https://example-conf.com/schedule")
+    out.write(json.dumps(agenda, ensure_ascii=False) + "\n")
+
+    for session in agenda["sessions"]:
+        if not session.get("href"):
+            continue
+        detail = session_detail(page, session["href"])
+        out.write(json.dumps({"session_href": session["href"], **detail,
+                              "captured_at": time.time()}, ensure_ascii=False) + "\n")
+        out.flush()
+        page.wait_for_timeout(1500)
+```
+
+Writing the whole agenda as one record per capture, rather than one row per session, is
+deliberate. Agendas are edited constantly in the final fortnight, and the interesting
+analysis is the diff between two captures: which sessions moved, which speakers dropped,
+which rooms changed. A row-per-session table updated in place erases exactly that.
+
+## Why conference sites break in the last two weeks
+
+These are usually built quickly on a platform, deployed once, and then edited under
+pressure. The failures are not defences.
+
+**The grid is rebuilt on every tab click.** Elements captured before the click are detached
+afterwards, so a Python-side loop holding handles across a tab change throws or reads
+stale nodes. Capturing each day in one evaluation, as above, avoids the whole class.
+
+**Session pages 404 while the grid still lists them.** A withdrawn talk is removed from the
+detail route before the schedule is regenerated. Record the failure as a row rather than
+letting it stop the run, and the disappearance becomes data about the event.
+
+**The timezone toggle changes the grid under you.** Hybrid events render either venue time
+or viewer time, and the control sometimes defaults from a stored preference. Read the
+resolved zone back after setting it rather than assuming, which is the same verify-the-lever
+discipline that applies to the unit toggles on other targets.
+
+Where a platform does put the schedule behind protection, which a few of the larger ones
+do, the page is worth a look before assuming a selector problem, using the order in
+[scraping without getting blocked](how-to-scrape-without-getting-blocked.md).
+
+## The shape that answers scheduling questions
+
+From captures, derive two tables:
+
+| table | key | holds |
+|---|---|---|
+| `session` | `event`, `day`, `track`, `start` | title, room, href, first and last seen |
+| `speaker` | `session_id`, `name` | affiliation, ordinal |
+
+Keeping speakers in their own table rather than a joined string is what makes the useful
+queries possible: who appears most across tracks, which affiliations dominate a programme,
+whether a speaker is double-booked against themselves. The last one happens more often than
+organisers would like, and it is only visible when track and time are both kept.
+
+The clash query is the one that justifies the grid work at the start of this page. Two
+sessions clash when they share a day and overlap in time on different tracks, and that is a
+single join once the track is a real column rather than a heading you read past.

--- a/docs/how-to-scrape-construction-permits-playwright.md
+++ b/docs/how-to-scrape-construction-permits-playwright.md
@@ -129,3 +129,102 @@ retention deliberate, and check whether the jurisdiction already publishes a bul
 Many do, on an open data portal, and pulling a file is better for everyone than paging a
 search form for a week. The technique for those is in
 [scraping open data portals](how-to-scrape-open-data-portals-playwright.md).
+
+## A complete month-by-month sweep
+
+```python
+import json, time
+from datetime import date
+from invisible_playwright import InvisiblePlaywright
+
+def months(start_year, start_month, count):
+    y, m = start_year, start_month
+    for _ in range(count):
+        nxt_y, nxt_m = (y, m + 1) if m < 12 else (y + 1, 1)
+        yield date(y, m, 1), date(nxt_y, nxt_m, 1)
+        y, m = nxt_y, nxt_m
+
+def sweep_month(page, permit_type, first, nxt):
+    page.goto("https://permits.example.gov/search")
+    page.select_option("select#permitType", permit_type)
+    page.fill("input#dateFrom", first.strftime("%m/%d/%Y"))
+    page.fill("input#dateTo", (nxt - timedelta(days=1)).strftime("%m/%d/%Y"))
+    page.click("input#btnSearch")
+    page.wait_for_selector("#resultsGrid tr, .no-records")
+
+    if page.query_selector(".no-records"):
+        return [], 0
+
+    total_text = page.inner_text(".result-count")       # "1 to 25 of 412"
+    total = int(total_text.rsplit(" ", 1)[-1].replace(",", ""))
+    rows = []
+    while True:
+        rows.extend(read_grid(page))
+        if not next_page(page):
+            break
+    return rows, total
+
+with InvisiblePlaywright(seed=42) as browser, open("permits.jsonl", "a", encoding="utf-8") as out:
+    page = browser.new_page()
+    for first, nxt in months(2026, 1, 12):
+        rows, total = sweep_month(page, "BUILDING", first, nxt)
+        if total and len(rows) != total:
+            raise SystemExit(f"{first:%Y-%m}: collected {len(rows)} of {total}, refusing to continue")
+        for row in rows:
+            out.write(json.dumps({**row, "month": f"{first:%Y-%m}",
+                                  "observed_at": time.time()}, ensure_ascii=False) + "\n")
+        out.flush()
+        page.wait_for_timeout(4000)
+```
+
+The count assertion is the most valuable line in the sweep. These portals cap silently,
+and a month that quietly returns 200 of 412 permits produces a dataset that looks complete
+and is missing half the construction in a city. Failing loudly there costs you a rerun;
+not checking costs you the conclusion.
+
+## Government portals fail politely and confusingly
+
+These systems are not defending against you in the adversarial sense. They are old, they
+are shared, and they degrade in ways that look like data.
+
+**The session times out mid-sweep.** After a pause the next postback returns the search
+form rather than results, which reads as a month with no permits. Detect it by asserting
+the results grid or the no-records marker exists after every submission, and re-establish
+the session rather than recording an absence.
+
+**Business hours matter more than rate limits.** Many of these portals are slow enough
+during working hours that a page load exceeds a naive timeout, and fine overnight. Running
+outside the jurisdiction's hours is both faster for you and invisible to the staff who
+depend on the same server.
+
+**The grid renders before it fills.** Waiting for `#resultsGrid tr` matches the header row
+on several platforms. Wait for a row that carries a permit number:
+
+```python
+    page.wait_for_function(
+        "() => document.querySelectorAll('#resultsGrid tr td:first-child').length > 0"
+    )
+```
+
+Where a portal does sit behind commodity edge protection, which a minority do, the browser
+still needs to look like a browser for the search to run at all, and the debug order is
+in [scraping without getting blocked](how-to-scrape-without-getting-blocked.md).
+
+## Two tables, and the durations they unlock
+
+Keep the permit and its status history separately:
+
+| table | key | holds |
+|---|---|---|
+| `permit` | `jurisdiction`, `permit_number` | type, address, valuation, contractor, applicant |
+| `stage` | `permit_number`, `sequence` | stage name, date, outcome |
+
+The second table is where the value is. With stages, you can compute time from application
+to issue, find which review stage holds files longest, and see whether a backlog is growing
+or clearing. Those questions are why permit data is scraped at all, and none of them are
+answerable from a table of current statuses.
+
+On the personal data, one practical default: keep `contractor` and drop `applicant` unless
+your question genuinely needs the individual. Contractor activity is commercial and is the
+subject of most legitimate analysis; applicant names are the part that makes a permit
+dataset a dataset about people.

--- a/docs/how-to-scrape-court-dockets-playwright.md
+++ b/docs/how-to-scrape-court-dockets-playwright.md
@@ -123,3 +123,98 @@ Scraping dockets for a defined question, on cases you can name, is the version o
 that is both legal in most places and defensible. Store it in something queryable such as
 [a SQLite database](how-to-scrape-into-a-database-playwright.md), keep the raw entry text,
 and keep the run's own metadata so you can say later exactly what you asked and when.
+
+## A complete run over a named case list
+
+```python
+import json, time
+from invisible_playwright import InvisiblePlaywright
+
+CASES = ["2026-CV-001234", "2026-CV-001987"]      # cases you can name and justify
+PACE_SECONDS, DAILY_CAP = 6, 200
+
+def already_done(path):
+    seen = set()
+    try:
+        with open(path, encoding="utf-8") as f:
+            for line in f:
+                seen.add(json.loads(line)["case_number"])
+    except FileNotFoundError:
+        pass
+    return seen
+
+path = "dockets.jsonl"
+done = already_done(path)
+budget = DAILY_CAP
+
+with InvisiblePlaywright(seed=42) as browser, open(path, "a", encoding="utf-8") as out:
+    page = browser.new_page()
+    for case_number in CASES:
+        if case_number in done or budget <= 0:
+            continue
+        found = open_case(page, case_number)
+        record = {
+            "case_number": case_number,
+            "observed_at": time.time(),
+            "found": found,
+            "entries": docket_entries(page) if found else [],
+        }
+        if not found:
+            note = page.query_selector(".case-not-found")
+            record["not_found_text"] = note.inner_text().strip() if note else None
+        out.write(json.dumps(record, ensure_ascii=False) + "\n")
+        out.flush()
+        budget -= 1
+        time.sleep(PACE_SECONDS)
+```
+
+The daily cap is written into the loop rather than left to discipline. A court portal that
+decides you are abusive does not send a warning, and the cap is what keeps a long research
+project from ending on its second day.
+
+Keeping the `not_found_text` verbatim matters more here than elsewhere: sealed, expunged,
+transferred and mistyped all produce different wording, and that wording is the only
+evidence you will have about which one it was.
+
+## What these systems do when they decide you are a problem
+
+Court portals sit at the strict end of public infrastructure, and their responses are worth
+recognising because two of the three look like ordinary results.
+
+**A silent empty docket.** The case page renders with no entries rather than an error. Since
+a genuinely new case also has few entries, the difference is invisible unless you compare
+against a previous read. A case that had thirty entries yesterday and none today is a
+failed read, not a purged docket:
+
+```python
+    if previous.get(case_number) and not record["entries"]:
+        record["suspect"] = "entries vanished from a docket that had them"
+```
+
+**An interstitial that consumes the click.** Several portals put a terms page in front of
+the first search per session and again after a period of inactivity. A run that does not
+re-check for it after a pause submits its search into a page that is not the search page.
+
+**A hard block on the address.** This is the honest end state of ignoring the pace, and it
+is usually not reversible by waiting a few minutes. The general diagnosis order is in
+[scraping without getting blocked](how-to-scrape-without-getting-blocked.md), but the
+specific advice for court systems is different from most targets: the fix is almost always
+to slow down and narrow the question, not to look more like a browser.
+
+## The schema, and the retention decision that comes with it
+
+| table | key | holds |
+|---|---|---|
+| `case` | `court`, `case_number` | caption, type, filed date, current status |
+| `entry` | `court`, `case_number`, `sequence` | filed date, verbatim text, document references |
+| `run` | `run_id` | what was asked, when, and under what cap |
+
+The `run` table is unusual and worth keeping. Docket research is the kind of work where
+someone may later ask what you collected and why, and a log of the queries you made is a
+better answer than a reconstruction from the data.
+
+For retention, the defensible default is to keep the entries you analysed and drop the
+rest, rather than accumulating dockets because they were cheap to fetch. The value of this
+data is in answering a specific question about court activity; the risk in it is that a
+general archive of dockets is a general archive about people, and the second grows quietly
+out of the first if nobody decides otherwise.

--- a/docs/how-to-scrape-css-pseudo-element-content-playwright.md
+++ b/docs/how-to-scrape-css-pseudo-element-content-playwright.md
@@ -142,3 +142,103 @@ The same class of invisibility appears in two other places worth knowing:
 [shadow DOM content](how-to-scrape-shadow-dom-playwright.md), which needs a different
 traversal, and canvas rendering, where there is no text at all and the approach is in
 [extracting data from canvas charts](how-to-extract-data-from-canvas-charts-playwright.md).
+
+## A complete extractor that never loses the invisible half
+
+```python
+import json, time
+from invisible_playwright import InvisiblePlaywright
+
+CARD = """
+(sel) => Array.from(document.querySelectorAll(sel)).map(card => {
+  const read = (el) => {
+    if (!el) return null;
+    const before = getComputedStyle(el, '::before').content;
+    const after  = getComputedStyle(el, '::after').content;
+    const clean  = (c) => (!c || ['none', 'normal', '""'].includes(c) || c.startsWith('url('))
+      ? '' : c.replace(/^["']|["']$/g, '');
+    return {
+      dom: el.textContent.trim(),
+      before: clean(before),
+      after: clean(after),
+      classes: el.className,
+    };
+  };
+  return {
+    price: read(card.querySelector('.price')),
+    badge: read(card.querySelector('.badge')),
+    href:  card.querySelector('a')?.getAttribute('href') || null,
+  };
+})
+"""
+
+def full_text(part):
+    if not part:
+        return None
+    return (part["before"] + part["dom"] + part["after"]).strip() or None
+
+with InvisiblePlaywright(seed=42) as browser, open("cards.jsonl", "a", encoding="utf-8") as out:
+    page = browser.new_page()
+    page.goto("https://example.com/category", wait_until="domcontentloaded")
+    page.wait_for_selector(".product-card")
+
+    for card in page.evaluate(CARD, ".product-card"):
+        out.write(json.dumps({
+            "href": card["href"],
+            "price_rendered": full_text(card["price"]),      # "€19.99"
+            "price_dom_only": (card["price"] or {}).get("dom"),  # "19.99"
+            "badge_rendered": full_text(card["badge"]),
+            "badge_classes": (card["badge"] or {}).get("classes"),
+            "observed_at": time.time(),
+        }, ensure_ascii=False) + "\n")
+    out.flush()
+```
+
+Composing `before + dom + after` reproduces what a reader sees, which is the value you
+usually want. Keeping `price_dom_only` alongside it is the cheap insurance: when the two
+differ, you know a pseudo-element was carrying something, and when they stop differing after
+a site update you know the currency symbol moved into the DOM rather than disappearing.
+
+## The failure mode is silence, not refusal
+
+Nothing here is a defence, and that is worth stating because it changes how you find it.
+Pseudo-element content is a styling choice, and no site is hiding a price from you by
+putting the euro sign in a `::before`. The consequence is that no error, status code or
+challenge will ever tell you that you missed it.
+
+That leaves three habits that actually catch it.
+
+**Probe once per new site**, with the audit snippet above, before writing any selectors.
+Ten seconds at the start against weeks of a silently wrong column.
+
+**Compare rendered text against extracted text** on a sample. If the page shows `€19.99`
+and your row says `19.99`, something is generating the difference, and pseudo-elements are
+the first suspect:
+
+```python
+    shown = page.eval_on_selector(".price", "e => e.getBoundingClientRect() && e.innerText")
+```
+
+**Prefer the class to the rendered word** for status badges. `badge_classes` survives
+localisation and copy changes, while the rendered "Sold out" becomes "Ausverkauft" for a
+German visitor and breaks any filter built on the string.
+
+If a page genuinely renders text you cannot reach by any of these routes, the remaining
+possibilities are shadow DOM, canvas, or an image, and each has its own page. What almost
+never explains it is blocking, which is why this page does not send you to
+[scraping without getting blocked](how-to-scrape-without-getting-blocked.md) first: that is
+the right guide when content is absent, not when it is visible and unreadable.
+
+## What to store, and why both forms
+
+| field | example | why keep it |
+|---|---|---|
+| `price_rendered` | `€19.99` | what a person sees |
+| `price_dom_only` | `19.99` | detects the day the markup changes |
+| `badge_rendered` | `Sold out` | human readable |
+| `badge_classes` | `badge badge--soldout` | stable across languages and copy |
+
+Two columns for one visible string looks redundant and costs almost nothing. It converts a
+class of silent breakage into a visible one: a diff between the two columns is a fact about
+the site's markup, and a diff that suddenly disappears across a whole crawl is the earliest
+warning you will get that the page was redesigned under you.

--- a/docs/how-to-scrape-energy-tariffs-playwright.md
+++ b/docs/how-to-scrape-energy-tariffs-playwright.md
@@ -130,3 +130,95 @@ Append rather than overwrite, with the inputs and timestamps attached, in
 is entirely in the series: which suppliers moved, when, and how the crossover consumption
 shifted. A table holding only today's best deal throws away everything that made it worth
 collecting.
+
+## A complete run over several consumption profiles
+
+```python
+import json, time
+from invisible_playwright import InvisiblePlaywright
+
+PROFILES = [
+    {"postcode": "BS1 4DJ", "elec": 1800, "gas": 7500, "payment": "direct_debit"},
+    {"postcode": "BS1 4DJ", "elec": 2700, "gas": 11500, "payment": "direct_debit"},
+    {"postcode": "BS1 4DJ", "elec": 4200, "gas": 18000, "payment": "direct_debit"},
+]
+
+def quote(page, profile):
+    page.goto("https://example-compare.com/energy", wait_until="domcontentloaded")
+    page.fill("input[name='postcode']", profile["postcode"])
+    page.click("button#continue")
+
+    page.check("input[value='know_usage']")            # reshapes the form first
+    page.wait_for_selector("input[name='elecKwh']:not([disabled])")
+    page.fill("input[name='elecKwh']", str(profile["elec"]))
+    page.fill("input[name='gasKwh']", str(profile["gas"]))
+    page.select_option("select[name='payment']", profile["payment"])
+    page.click("button#showResults")
+    page.wait_for_selector(".tariff-result, .no-tariffs", timeout=40000)
+
+    if page.query_selector(".no-tariffs"):
+        return [{"result": "no_tariffs", **{f"input_{k}": v for k, v in profile.items()}}]
+
+    validity = page.query_selector(".prices-correct-as-of")
+    return [{
+        **row,
+        "prices_as_of": validity.inner_text().strip() if validity else None,
+        **{f"input_{k}": v for k, v in profile.items()},
+    } for row in read_results(page)]
+
+with InvisiblePlaywright(seed=42) as browser, open("tariffs.jsonl", "a", encoding="utf-8") as out:
+    page = browser.new_page()
+    for profile in PROFILES:
+        for row in quote(page, profile):
+            row["quoted_at"] = time.time()
+            out.write(json.dumps(row, ensure_ascii=False) + "\n")
+        out.flush()
+        page.wait_for_timeout(8000)
+```
+
+Three consumption profiles rather than one is what makes the dataset answer the question
+that matters. The cheapest tariff at 1,800 kWh is frequently not the cheapest at 4,200,
+and that crossover is invisible from a single quote no matter how often you repeat it.
+
+The wait for `input[name='elecKwh']:not([disabled])` is the guard on the branch: it fails
+loudly if the form did not reshape, instead of quietly filling a hidden field and taking
+the site's default assumption.
+
+## A pricing engine is an expensive request, and behaves like one
+
+Comparison sites differ from most scraping targets in that each query runs a real
+computation against supplier tariffs. Three consequences.
+
+**Slow is normal, and a timeout is not a block.** Forty seconds for a result set is
+ordinary at peak. Treat a timeout as a retry candidate rather than as a refusal, using the
+backoff shape in
+[retrying failed requests](how-to-retry-failed-requests-playwright.md).
+
+**Cached result sets serve withdrawn tariffs.** The engine may return a set computed
+minutes ago, which is why `prices_as_of` is captured whenever the site prints it. Where two
+runs an hour apart return identical results with the same stamp, you read a cache twice
+rather than confirming stability.
+
+**Volume is what draws attention, not identity.** A handful of profiles a day is
+indistinguishable from a household comparing options. A sweep of every postcode is a
+different traffic shape entirely and is the one thing guaranteed to end the access. That is
+a limit worth writing into the script rather than remembering, and the general argument is
+in [rate limiting your own scraper](how-to-rate-limit-your-scraper-playwright.md).
+
+## The schema, and the crossover query it exists for
+
+One row per tariff per profile per run:
+
+| field | why |
+|---|---|
+| `unit_rate_text`, `standing_charge_text` | the two components, unparsed |
+| `annual_estimate_text` | the site's own arithmetic, kept for comparison |
+| `input_elec`, `input_gas`, `input_postcode`, `input_payment` | the query, copied down |
+| `contract_length`, `exit_fee_text` | what decides the ranking beyond price |
+| `prices_as_of`, `quoted_at` | their clock and yours |
+
+With the components and several profiles, the crossover falls out as arithmetic rather
+than another scrape: for two tariffs, the consumption at which their annual costs are equal
+is the difference in standing charges divided by the difference in unit rates. That number
+is the actual advice a household needs, it is not published anywhere, and it is
+unreachable from the annual estimate the site puts in large type.

--- a/docs/how-to-scrape-ev-charging-availability-playwright.md
+++ b/docs/how-to-scrape-ev-charging-availability-playwright.md
@@ -150,3 +150,110 @@ If you keep the connector-level rows with both timestamps, that limitation is vi
 the data itself, which is the point. Store it in something you can query by time, such as
 [a SQLite database written as you go](how-to-scrape-into-a-database-playwright.md), and
 resist the temptation to keep only the latest value per connector.
+
+## A complete poller, with the bounding box walked deliberately
+
+```python
+import json, time
+from invisible_playwright import InvisiblePlaywright
+
+BOXES = [                      # small boxes beat one big one: see the cap below
+    (51.44, -2.62, 51.47, -2.56),
+    (51.47, -2.62, 51.50, -2.56),
+]
+
+def harvest(page, box):
+    south, west, north, east = box
+    captured = []
+
+    def on_response(response):
+        if "station" in response.url.lower() and "/api/" in response.url:
+            try:
+                captured.append(response.json())
+            except Exception:
+                pass
+
+    page.on("response", on_response)
+    page.goto(f"https://example.com/map?sw={south},{west}&ne={north},{east}")
+    page.wait_for_timeout(4000)
+    page.remove_listener("response", on_response)
+    return captured
+
+with InvisiblePlaywright(seed=42) as browser, open("chargers.jsonl", "a", encoding="utf-8") as out:
+    page = browser.new_page()
+    while True:
+        for box in BOXES:
+            for payload in harvest(page, box):
+                stations = payload.get("stations") or payload.get("data") or []
+                if payload.get("truncated") or len(stations) >= 500:
+                    print("box capped, split it:", box)
+                for station in stations:
+                    for row in flatten(station):
+                        row["observed_at"] = time.time()
+                        out.write(json.dumps(row) + "\n")
+                out.flush()
+            page.wait_for_timeout(2000)
+        time.sleep(300)
+```
+
+Removing the listener at the end of each box matters more than it looks. Leaving it
+attached across boxes means responses from the previous query keep arriving into the next
+box's bucket, and you attribute chargers to a region they are not in. That ordering trap,
+and the related one where the response lands before you attach, are covered in
+[capturing XHR and API responses](how-to-capture-xhr-api-responses-playwright.md).
+
+The explicit cap check is there because a silently truncated response is the standard way
+these maps limit load. A box that returns exactly 500 stations is almost never a box that
+contains exactly 500 stations.
+
+## What a charging network sees, and why a poll is the hard case
+
+Most listing sites see a scraper once. A charger poller comes back every few minutes,
+forever, from the same session, asking for the same regions. That is the traffic shape
+that is easiest to identify, and no amount of fingerprint work makes a fixed-interval
+loop look like a person watching a map.
+
+Two things genuinely help, and they are about behaviour rather than identity.
+
+Vary the interval rather than sleeping a constant. A jittered wait around a target rate
+keeps the average where you want it without producing a metronome:
+
+```python
+import random
+time.sleep(300 + random.uniform(-45, 45))
+```
+
+Read only what changed. If the operator's payload carries a `last_updated`, skip stations
+whose value has not moved rather than re-querying their detail:
+
+```python
+    if station.get("last_updated") == seen.get(station["id"]):
+        continue
+```
+
+Underneath that, the browser still has to look like a browser, because these APIs are
+usually behind the same edge protection as the site. A patched Firefox driven by stock
+Playwright gets the JSON that a stripped client is refused, and the reasoning and debug
+order live in
+[scraping without getting blocked](how-to-scrape-without-getting-blocked.md).
+
+## The schema that makes utilisation answerable
+
+The reason to keep connector-level transitions rather than snapshots is that it makes the
+useful questions cheap:
+
+| question | what it needs |
+|---|---|
+| how often is this site full | transitions per connector, ordered |
+| which connectors are broken for weeks | a long run of `OUTOFORDER` with no change |
+| when is demand highest | transitions bucketed by hour of day |
+| is the operator's data stale | the gap between `reported_at` and `observed_at` |
+
+None of those are answerable from a table holding the current status per connector, which
+is the shape almost every first attempt produces. One row per state change, with
+`site_id`, `point_id`, `connector_id`, `standard`, `power_kw`, `status`, `observed_at`,
+`reported_at`, answers all four.
+
+Write it as [JSON Lines](how-to-scrape-to-json-lines-playwright.md) while collecting and
+load it into a database for querying. Appending is what makes an interrupted poll leave
+usable data instead of a hole, and a poll that runs for weeks will be interrupted.

--- a/docs/how-to-scrape-ferry-schedules-playwright.md
+++ b/docs/how-to-scrape-ferry-schedules-playwright.md
@@ -128,3 +128,100 @@ volatility. The pacing rules are in
 Ferry operators are also small sites with real seasonal traffic spikes. Running the sweep
 overnight in the operator's own timezone is a courtesy that costs you nothing and keeps
 the run out of the window where it would actually be felt.
+
+## A complete sweep, resumable by construction
+
+```python
+import json, time
+from datetime import date, timedelta
+from invisible_playwright import InvisiblePlaywright
+
+ROUTES = ["north-crossing", "island-hop"]
+HORIZON = 60
+
+def already_done(path):
+    seen = set()
+    try:
+        with open(path, encoding="utf-8") as f:
+            for line in f:
+                r = json.loads(line)
+                seen.add((r["route"], r["date"]))
+    except FileNotFoundError:
+        pass
+    return seen
+
+path = "sailings.jsonl"
+done = already_done(path)
+
+with InvisiblePlaywright(seed=42) as browser, open(path, "a", encoding="utf-8") as out:
+    page = browser.new_page()
+    for route in ROUTES:
+        for offset in range(HORIZON):
+            day = date.today() + timedelta(days=offset)
+            if (route, day.isoformat()) in done:
+                continue
+            rows = sailings_for(page, route, day)
+            out.write(json.dumps({
+                "route": route,
+                "date": day.isoformat(),
+                "observed_at": time.time(),
+                "sailings": rows,
+                "notices": [n.inner_text().strip()
+                            for n in page.query_selector_all(".service-notice, .disruption")],
+            }, ensure_ascii=False) + "\n")
+            out.flush()
+            page.wait_for_timeout(2500)
+```
+
+Reading back what is already on disk is a cheaper resume than a checkpoint file, because
+it cannot drift out of sync with the data it describes. Note that the record is written
+even when `sailings` is empty: a day with no service is a fact, and skipping the write
+would make it indistinguishable from a day the sweep never reached. The longer form of
+that argument is in
+[resuming an interrupted scrape](how-to-resume-an-interrupted-scrape-playwright.md).
+
+## Booking engines defend harder than timetable pages
+
+A ferry timetable lives inside a booking engine, and booking engines are protected because
+they are a target for inventory scraping and card testing. That shapes what works.
+
+**The date query is a real search, not a page view.** Each submission runs an availability
+lookup against live inventory, which is expensive for the operator and is exactly the
+request that gets rate limited first. Sixty days across two routes is 120 lookups, which
+is fine overnight and rude in a tight loop.
+
+**Refusal is often silent.** Rather than an error, you get the shell with an empty result
+region, which parses as a day with no sailings. That failure writes plausible rows and is
+never noticed, so guard on the positive marker:
+
+```python
+    page.wait_for_selector(".sailing, .no-sailings", timeout=20000)
+    if not page.query_selector(".sailing") and not page.query_selector(".no-sailings"):
+        raise RuntimeError("neither sailings nor a no-service marker: failed read")
+```
+
+**A real browser is the price of entry.** These engines fingerprint aggressively and a
+stripped client usually never reaches the timetable. Driving stock Playwright against a
+patched Firefox is what makes the query look like the query a passenger makes; the debug
+order when it stops working is in
+[scraping without getting blocked](how-to-scrape-without-getting-blocked.md).
+
+## The schema that answers "does this crossing actually run"
+
+Keep sailings nested under a query record rather than flattened into one table, or flatten
+with the query context copied down. Either way these five fields are what make the dataset
+worth having:
+
+| field | why |
+|---|---|
+| `route` and `direction` | two directions collide on time alone |
+| `date` | the query date, not the date you ran |
+| `status` | scheduled, cancelled, full, at the sailing level |
+| `observed_at` | the same date read twice tells you when it changed |
+| `notices` | the disruption text, per query, verbatim |
+
+The interesting analysis is the difference between two captures of the same date. A
+sailing that was scheduled on Monday and gone by Thursday is a cancellation, and that is
+the number a seasonal PDF can never give you: not what the operator plans to run, but what
+the operator actually ran. Storing every capture rather than updating in place is what
+makes that question answerable at all.

--- a/docs/how-to-scrape-flight-status-boards-playwright.md
+++ b/docs/how-to-scrape-flight-status-boards-playwright.md
@@ -144,3 +144,111 @@ indication of it. Walk the windows explicitly.
 many implementations. If you only store what is on screen, a cancellation looks like a
 flight that never existed. Compare each snapshot with the previous one and write the
 disappearance as an event.
+
+## A complete watcher, with disappearance handled
+
+```python
+import json, time
+from invisible_playwright import InvisiblePlaywright
+
+AIRPORT, DIRECTION = "BRS", "departures"
+
+def key_of(row, service_date):
+    return (AIRPORT, DIRECTION, row["flight"], service_date)
+
+previous, out_path = {}, "board.jsonl"
+
+with InvisiblePlaywright(seed=42) as browser, open(out_path, "a", encoding="utf-8") as out:
+    page = browser.new_page()
+    page.goto(f"https://example-airport.com/{DIRECTION}")
+    page.wait_for_selector("table.board tbody tr")
+
+    while True:
+        service_date = page.inner_text(".board-date").strip()
+        rows = page.evaluate(READ_BOARD)
+        observed = time.time()
+        current = {}
+
+        for row in rows:
+            k = key_of(row, service_date)
+            current[k] = row
+            before = previous.get(k)
+            if before is None or before["status"] != row["status"] or before["estimated"] != row["estimated"]:
+                out.write(json.dumps({
+                    "airport": AIRPORT, "direction": DIRECTION,
+                    "service_date": service_date, "observed_at": observed,
+                    "event": "seen", **row,
+                }, ensure_ascii=False) + "\n")
+
+        for gone in set(previous) - set(current):
+            out.write(json.dumps({
+                "airport": AIRPORT, "direction": DIRECTION,
+                "service_date": gone[3], "flight": gone[2],
+                "observed_at": observed, "event": "left_board",
+                "last_status": previous[gone]["status"],
+            }) + "\n")
+
+        out.flush()
+        previous = current
+        time.sleep(120)
+```
+
+The `left_board` event carries the last status seen, which is what makes it interpretable
+later. A flight that leaves the board an hour after "Departed" left normally; one that
+leaves while still "Delayed" is the cancellation you actually wanted to catch.
+
+## Why a long-lived page is its own problem
+
+This scraper does something unusual: it keeps one page open for hours. That avoids
+hammering the airport with reloads, and it introduces failure modes a request-per-read
+design never meets.
+
+**The page stops refreshing.** Boards throttle their own updates when the tab looks
+inactive, and a headless context can look inactive permanently. The tell is a snapshot
+that stops changing while the wall clock moves. Guard on it explicitly rather than
+trusting the loop:
+
+```python
+    if rows == last_rows and time.time() - last_change > 900:
+        page.reload()
+        page.wait_for_selector("table.board tbody tr")
+        last_change = time.time()
+```
+
+**The session ages out.** Edge protection frequently issues a token with a lifetime, and
+when it expires the board silently stops updating or returns an interstitial in place of
+the table. A reload re-establishes it; a fresh context is the heavier fallback.
+
+**A reload lands mid-render.** Waiting for the selector is not enough on its own, because
+the table exists before it is populated. Waiting for at least one row with a flight number
+is the version that does not read an empty board:
+
+```python
+    page.wait_for_function(
+        "() => document.querySelectorAll('table.board tbody tr .flight-number').length > 0"
+    )
+```
+
+Underneath all three, the browser has to keep looking like a browser for hours rather than
+seconds, which is where a patched engine driven by stock Playwright earns its place. The
+order to debug a degraded read is in
+[scraping without getting blocked](how-to-scrape-without-getting-blocked.md), and the
+resilience patterns for a run measured in hours are in
+[retrying failed requests](how-to-retry-failed-requests-playwright.md).
+
+## What the event stream is worth
+
+One row per state change, keyed on airport, direction, flight and service date, is what
+turns a live board into an answerable dataset:
+
+- **Real punctuality**, computed from scheduled against the last estimate before
+  departure, rather than from an airline's own published figure.
+- **How delays propagate**, by following the same aircraft's rotations across a day when
+  the board exposes the inbound flight.
+- **Which gates and stands are chronically late**, which no public dataset publishes.
+- **Cancellation rate by route**, from `left_board` events with a non-departed last
+  status.
+
+None of these come from a snapshot table holding today's board. They all come from the
+transitions, which is why the loop above writes changes rather than states, and why the
+last status travels with the disappearance.

--- a/docs/how-to-scrape-fuel-prices-playwright.md
+++ b/docs/how-to-scrape-fuel-prices-playwright.md
@@ -149,3 +149,110 @@ region. Writing it as you go, in
 [a SQLite database](how-to-scrape-into-a-database-playwright.md) or
 [JSON Lines](how-to-scrape-to-json-lines-playwright.md), also means an interrupted run
 leaves usable data rather than nothing.
+
+## A complete pass over several towns
+
+```python
+import json, re, time
+from invisible_playwright import InvisiblePlaywright
+
+PLACES = ["Bristol", "Bath", "Weston-super-Mare"]
+
+def set_location(page, place):
+    box = page.wait_for_selector("input[name='location'], input#search-location")
+    box.click()
+    box.fill("")
+    box.type(place, delay=90)
+    page.keyboard.press("Enter")
+    page.wait_for_selector(".station-list .station, .no-results")
+
+def harvest(page, place):
+    if page.query_selector(".no-results"):
+        return []
+    rows = []
+    for card in page.query_selector_all(".station-list .station"):
+        name = card.query_selector(".name").inner_text().strip()
+        address = card.query_selector(".address").inner_text().strip()
+        for fuel in card.query_selector_all(".fuel-row"):
+            price_text = fuel.query_selector(".price").inner_text().strip()
+            age = fuel.query_selector(".age")
+            rows.append({
+                "queried_location": place,
+                "station": name,
+                "address": address,
+                "grade": fuel.query_selector(".grade").inner_text().strip(),
+                "price_text": price_text,
+                "price": parse_price(price_text),
+                "reported_age": age.inner_text().strip() if age else None,
+                "observed_at": time.time(),
+            })
+    return rows
+
+with InvisiblePlaywright(seed=42) as browser, open("fuel.jsonl", "a", encoding="utf-8") as out:
+    page = browser.new_page()
+    page.goto("https://example.com/fuel-prices")
+    for place in PLACES:
+        set_location(page, place)
+        for row in harvest(page, place):
+            out.write(json.dumps(row, ensure_ascii=False) + "\n")
+        out.flush()
+        page.wait_for_timeout(4000)
+```
+
+The `box.fill("")` before typing is the line that stops the second town from being
+searched as "BristolBath". Autocomplete widgets keep their previous value and their
+internal selection, and clearing the field is what resets both.
+
+## Why fuel sites are unusually defensive
+
+These sites carry commercially valuable data that competitors want in bulk, so they tend
+to be better defended than their size suggests, and the defence is usually aimed at the
+request rather than the person. Three consequences shape the design above.
+
+**A side HTTP client rarely gets the list.** The search result is fetched by the page after
+the location commits, from an endpoint that expects the browser's context. Driving the
+real control in a real browser is what keeps the response coming, which is why the code
+types rather than building a URL.
+
+**Degradation looks like an empty town.** When the protection is unhappy the list renders
+with zero cards and no error. That is indistinguishable from a town with no stations
+unless you check the negative case explicitly, which is what the `.no-results` branch is
+for. Treat "cards absent and no-results absent" as a failed read rather than an empty one:
+
+```python
+    if not page.query_selector(".station-list .station") and not page.query_selector(".no-results"):
+        raise RuntimeError("neither stations nor a no-results marker: failed read")
+```
+
+**Your exit becomes part of the query.** Even with a location typed in, some sites blend
+the inferred position into ranking or availability. Pin the exit for a series rather than
+letting it rotate, or the same town will return different stations on different days for
+reasons that have nothing to do with fuel. The general form is in
+[scraping geotargeted content](how-to-scrape-geotargeted-content-playwright.md), and the
+debug order when a read degrades is in
+[scraping without getting blocked](how-to-scrape-without-getting-blocked.md).
+
+## Turning reports into a series you can trust
+
+Crowd-reported prices need one more step before they are comparable: a freshness filter
+applied at read time, not at capture.
+
+```python
+def usable(row, max_age_hours=48):
+    age = row.get("reported_age") or ""
+    m = re.search(r"(\d+)\s*(hour|day|week)", age, re.I)
+    if not m:
+        return False                      # unknown age: not comparable
+    n, unit = int(m.group(1)), m.group(2).lower()
+    hours = n * {"hour": 1, "day": 24, "week": 168}[unit]
+    return hours <= max_age_hours
+```
+
+Filtering at read time keeps the stale rows in the archive, where they still answer
+questions about reporting behaviour, while keeping them out of a price average that would
+otherwise be dominated by whichever station has the most enthusiastic reporter.
+
+The series is then one row per station, grade and observation, with `queried_location`,
+`unit`, `currency`, `reported_age` and `observed_at`. That is enough to answer where fuel
+is cheapest today, how fast a price change propagates across a chain, and how stale a
+given site's data really is, which is the question the site itself will never answer.

--- a/docs/how-to-scrape-library-catalog-availability-playwright.md
+++ b/docs/how-to-scrape-library-catalog-availability-playwright.md
@@ -131,3 +131,105 @@ care about, poll them at a human interval, and use
 [the rate limiting rules](how-to-rate-limit-your-scraper-playwright.md) rather than
 running flat out. Availability changes when someone physically returns a book, which is a
 scale measured in days.
+
+## A complete watch over a shortlist
+
+```python
+import json, time
+from invisible_playwright import InvisiblePlaywright
+
+WATCHLIST = [
+    "the master and margarita",
+    "gödel escher bach",
+    "the making of the atomic bomb",
+]
+
+def search(page, query):
+    page.goto("https://catalog.example.org/")
+    dismiss_interstitials(page)
+    page.fill("input[name='q']", query)
+    page.press("input[name='q']", "Enter")
+    page.wait_for_selector(".result-item, .no-results")
+    return page.query_selector_all(".result-item")
+
+def dismiss_interstitials(page):
+    for sel in (".terms-accept", ".cookie-accept", ".branch-select-skip"):
+        node = page.query_selector(sel)
+        if node:
+            node.click()
+            page.wait_for_timeout(300)
+
+with InvisiblePlaywright(seed=42) as browser, open("holdings.jsonl", "a", encoding="utf-8") as out:
+    page = browser.new_page()
+    for query in WATCHLIST:
+        items = search(page, query)
+        if not items:
+            out.write(json.dumps({"query": query, "observed_at": time.time(),
+                                  "result": "no_match"}) + "\n")
+            continue
+        items[0].query_selector("a.title").click()
+        page.wait_for_selector("table.holdings tbody tr", timeout=15000)
+        for copy in holdings(page):
+            copy.update({"query": query, "record_url": page.url,
+                         "observed_at": time.time()})
+            out.write(json.dumps(copy, ensure_ascii=False) + "\n")
+        out.flush()
+        page.wait_for_timeout(4000)
+```
+
+Clicking the result rather than navigating to its `href` is what keeps the session token
+valid, and it is the difference between a script that works today and one that works next
+month. Note that `record_url` is stored anyway: it is useless as a link later, and it is
+the only way to tell which of three editions you actually read.
+
+## Why these systems fail in ways that look like data
+
+Library catalogues are rarely defended against scraping in the adversarial sense. They
+break for a duller reason: they are session-driven enterprise software running on modest
+hardware, and under load they degrade rather than refuse.
+
+Three degradations produce plausible wrong data, and each needs a positive check.
+
+**The session expires mid-run.** The next search returns the landing page instead of
+results, which parses as zero hits. Detect it by asserting the search box still exists
+after the results wait, and restart the session rather than recording an absence.
+
+**Holdings arrive late or not at all.** The record page renders complete without its
+holdings table, so a short timeout writes a book with no copies:
+
+```python
+    try:
+        page.wait_for_selector("table.holdings tbody tr", timeout=15000)
+    except Exception:
+        record = {"query": query, "result": "holdings_not_loaded", "observed_at": time.time()}
+```
+
+A distinct outcome, not an empty list. The two are opposite facts and only one of them is
+about the library.
+
+**A branch filter you did not set.** Some catalogues remember a branch from an earlier
+session and scope holdings to it silently. If a title you know is held system-wide comes
+back with one copy, check for a scope control before believing the number.
+
+None of these are anti-bot measures, which is worth saying plainly: not every failed read
+is a defence. The debug order in
+[scraping without getting blocked](how-to-scrape-without-getting-blocked.md) still applies,
+starting with the cheapest check, which here is a screenshot of what the page actually
+showed.
+
+## What the copy-level history is good for
+
+One row per copy per observation, keyed on `(record_url, branch, call_number)`, with the
+raw status string and the due date. That grain answers questions the library's own
+interface does not:
+
+- **How long is the real wait.** Not the hold queue length, but how many days pass between
+  a copy going out and coming back, averaged over months.
+- **Which branch actually stocks a subject.** Copy counts per branch over time, rather
+  than a single snapshot that reflects who happened to borrow that week.
+- **Whether a title is quietly disappearing.** Copies moving to `Missing` or `Withdrawn`
+  and never returning is a signal the catalogue does not surface anywhere.
+
+All three need history, which is why the write is append-only and the status string is
+kept verbatim. A table holding the current availability per title answers none of them,
+and is also the exact thing the library's own search page already does better.

--- a/docs/how-to-scrape-numbers-rendered-as-images-playwright.md
+++ b/docs/how-to-scrape-numbers-rendered-as-images-playwright.md
@@ -123,3 +123,96 @@ feed, a partner API, or a structured markup block the same page emits for search
 which is worth checking before any of the above:
 [extracting JSON-LD structured data](how-to-extract-json-ld-structured-data-playwright.md)
 takes about a minute to rule in or out.
+
+## A complete probe that tries the cheap routes in order
+
+```python
+import json, re, time
+from invisible_playwright import InvisiblePlaywright
+
+def recover_number(page, selector):
+    """Return (value, method) using the cheapest route that works."""
+    ld = page.eval_on_selector_all(
+        "script[type='application/ld+json']",
+        "els => els.map(e => e.textContent)",
+    )
+    for blob in ld:
+        try:
+            data = json.loads(blob)
+        except Exception:
+            continue
+        offers = (data.get("offers") if isinstance(data, dict) else None) or {}
+        if isinstance(offers, dict) and offers.get("price"):
+            return offers["price"], "json-ld"
+
+    probe = page.evaluate(PROBE, selector)
+    if probe:
+        for field in ("ariaLabel", "alt", "title", "srOnly", "describedBy"):
+            text = probe.get(field)
+            if text and re.search(r"\d", text):
+                return text.strip(), f"accessible:{field}"
+        for k, v in (probe.get("dataset") or {}).items():
+            if re.fullmatch(r"[\d.,]+", str(v)):
+                return v, f"dataset:{k}"
+
+    digits = page.evaluate(OFFSETS)
+    if digits and all(d.get("x") for d in digits):
+        return decode_sprite(digits), "sprite"
+
+    return None, "unresolved"
+
+with InvisiblePlaywright(seed=42) as browser, open("prices.jsonl", "a", encoding="utf-8") as out:
+    page = browser.new_page()
+    for url in product_urls:
+        page.goto(url, wait_until="domcontentloaded")
+        page.wait_for_selector(".price-image, .price", timeout=20000)
+        value, method = recover_number(page, ".price-image")
+        out.write(json.dumps({"url": url, "value": value, "method": method,
+                              "observed_at": time.time()}, ensure_ascii=False) + "\n")
+        out.flush()
+        page.wait_for_timeout(2000)
+```
+
+Recording `method` on every row is the part that makes this maintainable. When a site
+changes its rendering, the method column shows you exactly which pages moved from
+`accessible:alt` to `unresolved`, which is a far better signal than a column of nulls
+appearing with no explanation.
+
+## Why this technique exists, and what that implies
+
+Rendering a number as an image is expensive: it costs the site accessibility, translation,
+selectable text and search visibility for that field. Sites accept those costs for two
+different reasons, and the reason determines what you should do next.
+
+**Legacy or laziness.** A price baked into a promotional banner, a figure in a chart image,
+a table exported as a picture. There is no intent to stop anyone, the accessible label is
+usually present, and reading it is ordinary extraction.
+
+**Deliberate anti-extraction.** Per-session sprite shuffling, glyph-remapped fonts,
+canvas-drawn digits with no accessible layer. These cost the site real money in
+accessibility compliance, which is how you can tell the choice was intentional.
+
+The second case is the one worth naming clearly. This corpus is about making a browser
+behave like a browser so that defences aimed at non-browsers stop misfiring on you. That is
+a different thing from defeating a control whose only purpose is to prevent bulk
+extraction of one specific field, and the honest response there is to ask whether you have
+a relationship with the site that entitles you to the data: a contract, an API, a partner
+feed. The reasoning around that line runs through
+[scraping without getting blocked](how-to-scrape-without-getting-blocked.md).
+
+## If you do recognise, treat the output as a measurement
+
+Recognition output is not a fact, and the schema should say so:
+
+| field | note |
+|---|---|
+| `value` | null when confidence is below your threshold, never a guess |
+| `method` | `json-ld`, `accessible:alt`, `sprite`, `ocr`, `unresolved` |
+| `confidence` | only present for `ocr` |
+| `evidence` | path or hash of the element screenshot, for a human to check |
+
+A null with an image to look at is a workable row. A confidently wrong price is not, and it
+is the outcome that a pipeline without a threshold produces by default. Set the threshold
+high enough that the nulls annoy you, then fix the extraction rather than lowering the bar,
+because the alternative is a dataset whose errors are invisible and whose consumers have no
+way to find them.

--- a/docs/how-to-scrape-package-download-stats-playwright.md
+++ b/docs/how-to-scrape-package-download-stats-playwright.md
@@ -138,3 +138,100 @@ cadence, the pacing rules in
 [rate limiting your own scraper](how-to-rate-limit-your-scraper-playwright.md) apply, and
 [JSON Lines](how-to-scrape-to-json-lines-playwright.md) is a good fit for an append-only
 series you will reprocess later.
+
+## A complete daily collector
+
+```python
+import json, time
+from invisible_playwright import InvisiblePlaywright
+
+PACKAGES = ["some-package", "another-package"]
+
+def collect(page, package):
+    captured = []
+
+    def on_response(response):
+        if any(k in response.url for k in ("/downloads", "/stats", "/metrics")):
+            try:
+                captured.append({"url": response.url, "body": response.json()})
+            except Exception:
+                pass
+
+    page.on("response", on_response)
+    page.goto(f"https://registry.example.com/package/{package}?range=12m&interval=day",
+              wait_until="domcontentloaded")
+    page.wait_for_selector("canvas, svg.chart", timeout=20000)
+    page.wait_for_timeout(2500)
+    page.remove_listener("response", on_response)
+
+    if not captured:                       # no JSON: fall back to the accessible layer
+        points = page.eval_on_selector_all(
+            "svg.chart [role='graphics-symbol'], svg.chart .datapoint",
+            "els => els.map(e => ({label: e.getAttribute('aria-label'), value: e.dataset.value}))",
+        )
+        return [{"package": package, "source": "accessible-layer", "points": points}]
+    return [{"package": package, "source": "json", **c} for c in captured]
+
+with InvisiblePlaywright(seed=42) as browser, open("downloads.jsonl", "a", encoding="utf-8") as out:
+    page = browser.new_page()
+    for package in PACKAGES:
+        for record in collect(page, package):
+            record["observed_at"] = time.time()
+            out.write(json.dumps(record, ensure_ascii=False) + "\n")
+        out.flush()
+        page.wait_for_timeout(4000)
+```
+
+Recording `source` alongside the numbers is what keeps a mixed dataset honest. A series
+built partly from the JSON endpoint and partly from chart labels has two different
+precisions in one column, and the only way to notice later is if the row says which it was.
+
+## Why the browser is needed for a number that looks public
+
+Download counts feel like open data, and the dashboard usually is. Two things still push
+this into browser territory.
+
+**The series endpoint expects the page.** Many registries check the referrer, a session
+cookie or a token minted by the page before serving the JSON. A direct request for the
+same URL returns an error or an empty series, which is why the code lets the page make the
+request and captures the response rather than replaying the URL.
+
+**Degradation is silent and looks like a quiet week.** Under protection the chart renders
+with no data and the page looks fine. A collector that stores whatever arrived writes zeros,
+and zeros in a download series are indistinguishable from a real collapse in usage. Guard
+positively:
+
+```python
+    if record["source"] == "json":
+        series = record["body"].get("downloads") or record["body"].get("data") or []
+        if not series:
+            raise RuntimeError("empty series returned: failed read, not a quiet week")
+```
+
+The order to debug that, cheapest first, is in
+[scraping without getting blocked](how-to-scrape-without-getting-blocked.md). And the point
+worth repeating from the top of this page: if the registry publishes the data as a dataset,
+none of this is necessary, and checking takes a minute.
+
+## The schema, and the comparison it refuses to make easy
+
+One row per package, version, date and observation:
+
+| field | note |
+|---|---|
+| `package`, `version` | version is null only when the registry offers no breakdown |
+| `date` | the registry's day, not yours |
+| `downloads` | the count as served |
+| `source` | `json` or `accessible-layer` |
+| `observed_at` | so a revision is visible as two rows for one day |
+
+Keeping the observation timestamp separate from the data date is what makes revisions
+detectable: the same `date` collected twice with different `downloads` is a registry
+correction, and that is a fact worth having rather than an inconsistency to overwrite.
+
+The comparison this schema deliberately does not make easy is the one people want most:
+package A against package B. You can write the query, and the answer will be misleading
+unless both series carry the same window, the same interval and the same caveats about
+mirrors and continuous integration. Keeping `version` in the key at least surfaces the
+usual explanation, which is that most of a popular library's traffic is one old pinned
+release being pulled by machines.

--- a/docs/how-to-scrape-package-tracking-playwright.md
+++ b/docs/how-to-scrape-package-tracking-playwright.md
@@ -139,3 +139,102 @@ someone's package went, and often where they live. Scrape numbers you have a rea
 hold, keep the retention short, and do not enumerate. Guessing tracking numbers to see
 what comes back is the behaviour these endpoints are defended against, and it is the one
 use of this page that is not worth having.
+
+## A complete watcher for a handful of parcels
+
+```python
+import json, time
+from invisible_playwright import InvisiblePlaywright
+
+def read_tracking(page, number):
+    page.goto("https://example-carrier.com/track")
+    dismiss_consent(page)
+    box = page.wait_for_selector("input[name='trackingNumber']")
+    box.click()
+    box.fill("")
+    box.type(number, delay=70)
+    page.keyboard.press("Enter")
+    page.wait_for_selector(".tracking-event, .not-found, .no-info", timeout=25000)
+
+    if page.query_selector(".not-found") or page.query_selector(".no-info"):
+        note = page.inner_text(".not-found, .no-info").strip()
+        return {"number": number, "events": [], "carrier_note": note}
+    return {"number": number, "events": timeline(page), "carrier_note": None}
+
+def dismiss_consent(page):
+    node = page.query_selector("#onetrust-accept-btn-handler, .consent-accept")
+    if node:
+        node.click()
+        page.wait_for_timeout(400)
+
+state = {}
+
+with InvisiblePlaywright(seed=42) as browser, open("parcels.jsonl", "a", encoding="utf-8") as out:
+    page = browser.new_page()
+    while parcels_in_flight:
+        for number in list(parcels_in_flight):
+            result = read_tracking(page, number)
+            merged = merge(state.get(number, []), result["events"])
+            if merged != state.get(number):
+                out.write(json.dumps({**result, "events": merged,
+                                      "observed_at": time.time()}, ensure_ascii=False) + "\n")
+                out.flush()
+                state[number] = merged
+            if merged and is_delivered(merged[-1]):
+                parcels_in_flight.discard(number)
+            page.wait_for_timeout(4000)
+        time.sleep(next_interval(merged, state.get(number)))
+```
+
+Writing only when the merged timeline changes is what keeps a multi-day watch from
+producing thousands of identical records. Dropping a parcel from the set once it is
+delivered is the other half: a delivered parcel never changes again, and continuing to
+poll it is pure noise on someone else's servers.
+
+## Why carrier endpoints are among the best defended
+
+Tracking pages are attacked constantly, because a valid tracking number is the entry
+point for parcel redirection fraud and for phishing that quotes a real shipment. The
+defences that result are aggressive, and three of them shape any honest scraper.
+
+**Enumeration is the thing they watch for.** Sequential or high-volume lookups from one
+source are the signature, and they are met with a hard block rather than a challenge. This
+is the strongest practical argument for the rule above: hold numbers you have a reason to
+hold, and the traffic shape stops looking like the attack.
+
+**A stripped client usually never sees a timeline.** The result region is fetched after the
+form commits, from an endpoint expecting the browser's context. Driving a real browser is
+what makes the request resolve, and a patched Firefox driven by stock Playwright presents
+the consistent handshake and fingerprint that a bare client cannot.
+
+**Refusal is frequently disguised as "no information available".** That message is also the
+genuine response for a parcel not yet scanned, so the two are indistinguishable without
+care. Keep the carrier's exact wording and, when it appears for a number that previously
+had events, treat it as a suspicious read rather than a regression:
+
+```python
+    if not result["events"] and state.get(number):
+        result["suspect"] = "timeline disappeared for a number that had events"
+```
+
+The general debug order, cheapest check first, is in
+[scraping without getting blocked](how-to-scrape-without-getting-blocked.md).
+
+## A schema that survives revisions
+
+Two tables rather than one. A capture table holding the whole timeline per read, and a
+derived event table keyed on the event's own identity:
+
+| table | key | holds |
+|---|---|---|
+| capture | `number`, `observed_at` | the full timeline as read, plus the carrier note |
+| event | `number`, `when_text`, `what`, `where` | one row per distinct scan, first and last seen |
+
+Keeping the captures is what lets you detect a carrier revising or removing a scan, which
+a merged-only view silently absorbs. Keeping the derived events is what makes the ordinary
+question fast. The cost is duplication, and it is small compared with the alternative,
+which is a table that quietly rewrites its own history every time the carrier does.
+
+For retention, delete captures once a parcel is delivered plus whatever window your use
+actually needs. A tracking archive is a movement record, and the honest default is to keep
+it only as long as it is answering a question.

--- a/docs/how-to-scrape-parking-rates-playwright.md
+++ b/docs/how-to-scrape-parking-rates-playwright.md
@@ -161,3 +161,127 @@ prefer one pass per day over a poll: tariffs change on the scale of months.
 
 The result is a table of bands, plus scopes, plus notes. It is more data than a single
 price, and it is the only form that still means the same thing tomorrow.
+
+## A complete run, one garage to storage
+
+Putting the pieces together, with the parts that matter in production: a browser that
+looks like a browser, a scope loop, and a write that happens per garage rather than at the
+end.
+
+```python
+import json, re, time
+from invisible_playwright import InvisiblePlaywright
+
+def read_bands(page):
+    bands = []
+    for row in page.query_selector_all("table.rates tbody tr"):
+        cells = [c.inner_text().strip() for c in row.query_selector_all("td")]
+        if len(cells) < 2:
+            continue
+        m = DURATION.search(cells[0])
+        if not m:
+            continue
+        bands.append({
+            "from_minutes": to_minutes(m.group("lo"), m.group("lo_unit") or m.group("hi_unit")),
+            "to_minutes": to_minutes(m.group("hi"), m.group("hi_unit")),
+            "label": cells[0],
+            "amount": cells[1],
+        })
+    return bands
+
+def scrape_garage(page, url):
+    page.goto(url, wait_until="domcontentloaded")
+    page.wait_for_selector("table.rates tbody tr, .rates-unavailable")
+    if page.query_selector(".rates-unavailable"):
+        return {"url": url, "observed_at": time.time(), "tariffs": [], "note": "no published rates"}
+
+    tabs = page.query_selector_all("[role='tab'], .rate-tabs button")
+    tariffs = []
+    if not tabs:
+        tariffs.append({"scope": "default", "bands": read_bands(page)})
+    else:
+        for tab in tabs:
+            scope = tab.inner_text().strip()
+            tab.click()
+            page.wait_for_selector("table.rates tbody tr")
+            tariffs.append({"scope": scope, "bands": read_bands(page)})
+
+    return {
+        "url": url,
+        "observed_at": time.time(),
+        "tariffs": tariffs,
+        "notes": [n.inner_text().strip()
+                  for n in page.query_selector_all(".rate-notes li, .rates-footnote")],
+    }
+
+with InvisiblePlaywright(seed=42) as browser, open("garages.jsonl", "a", encoding="utf-8") as out:
+    page = browser.new_page()
+    for url in garage_urls:
+        record = scrape_garage(page, url)
+        out.write(json.dumps(record, ensure_ascii=False) + "\n")
+        out.flush()
+        page.wait_for_timeout(3000)
+```
+
+The `flush` on every garage is deliberate. A run over a city is long enough to be
+interrupted, and a buffered file that dies with the process loses an hour of polite
+requests you will have to make again. The wider version of that argument is in
+[resuming an interrupted scrape](how-to-resume-an-interrupted-scrape-playwright.md).
+
+The `seed=42` is what makes two runs comparable. A fixed seed pins the browser identity,
+so a difference between Monday's rates and Tuesday's is a difference in the tariff rather
+than in which visitor the site thought it was serving.
+
+## Why parking sites block, and what actually helps
+
+Parking operators sit behind commodity edge protection more often than their size
+suggests, because their booking flows are a target for card testing. That has two
+consequences for a rate scraper.
+
+The first is that a plain HTTP client is usually refused before it sees a tariff table at
+all, which is why this page drives a real browser rather than requesting the page. A
+patched Firefox driven by stock Playwright presents a consistent TLS handshake, a
+plausible fingerprint and a real event stream, so the request that asks for the rates
+looks like the request a person's browser makes.
+
+The second is subtler and specific to this data. Protection frequently degrades rather
+than refuses: you get the page shell, the table renders empty or with placeholder dashes,
+and nothing signals an error. A scraper that only checks for an HTTP error records a
+garage with no tariffs.
+
+Guard on the positive signal rather than the absence of a negative one:
+
+```python
+    rows = page.query_selector_all("table.rates tbody tr")
+    parsed = [r for r in rows if DURATION.search(r.inner_text())]
+    if rows and not parsed:
+        raise RuntimeError("table present but no band parsed: treat as a failed read")
+```
+
+That check is the local version of a rule that runs through this whole corpus: a
+suppressed or emptied signal is a failure, not a result. The general form, and the order
+to debug it in, is in
+[scraping without getting blocked](how-to-scrape-without-getting-blocked.md).
+
+## A schema that survives the next redesign
+
+One row per band, with the scope and the garage attached, plus a separate table for notes:
+
+| column | example | why it is separate |
+|---|---|---|
+| `garage_id` | `central-01` | stable across redesigns, unlike the page URL |
+| `scope` | `Weekend` | the same garage has several tariffs |
+| `from_minutes` / `to_minutes` | `0` / `120` | the band, in one unit |
+| `amount_text` | `£4.50` | unparsed, so the currency survives |
+| `label` | `Up to 2 hours` | the original string, for auditing a bad parse |
+| `observed_at` | epoch seconds | tariffs change, and you want the history |
+
+Keeping `label` and `amount_text` unparsed is what lets you re-derive everything later
+when a site starts writing "2 hrs" instead of "2 hours". Deriving at read time costs
+nothing; re-scraping a city because you stored only a float costs a week.
+
+Store it in [a SQLite database](how-to-scrape-into-a-database-playwright.md) if you will
+query it, or [JSON Lines](how-to-scrape-to-json-lines-playwright.md) if you will
+reprocess it. Either way, append rather than overwrite: a parking tariff that changed last
+month is the most interesting row in the table, and an updated-in-place record cannot tell
+you it ever moved.

--- a/docs/how-to-scrape-pet-adoption-listings-playwright.md
+++ b/docs/how-to-scrape-pet-adoption-listings-playwright.md
@@ -133,3 +133,105 @@ faster for you, cheaper for them, and it comes with permission attached. Where y
 scrape, run once a day, respect the pacing in
 [rate limiting your own scraper](how-to-rate-limit-your-scraper-playwright.md), and keep
 the contact details of the site you are reading in case someone wants to ask you to stop.
+
+## A complete daily run with reconciliation
+
+```python
+import json, time
+from invisible_playwright import InvisiblePlaywright
+
+def load_previous(path):
+    ids, last = set(), {}
+    try:
+        with open(path, encoding="utf-8") as f:
+            for line in f:
+                r = json.loads(line)
+                if r["type"] == "appeared":
+                    ids.add(r["shelter_id"]); last[r["shelter_id"]] = r
+                elif r["type"] == "disappeared":
+                    ids.discard(r["shelter_id"])
+    except FileNotFoundError:
+        pass
+    return ids, last
+
+path = "adoptions.jsonl"
+previous_ids, _ = load_previous(path)
+
+with InvisiblePlaywright(seed=42) as browser, open(path, "a", encoding="utf-8") as out:
+    page = browser.new_page()
+    page.goto("https://example-shelter.org/adopt")
+    page.select_option("select[name='species']", "any")
+    page.wait_for_selector(".animal-card, .no-animals")
+
+    while True:                                  # walk every page of the list
+        more = page.query_selector("button.load-more:not([disabled])")
+        if not more:
+            break
+        before = len(page.query_selector_all(".animal-card"))
+        more.click()
+        page.wait_for_function("n => document.querySelectorAll('.animal-card').length > n",
+                               arg=before)
+
+    rows = listing_rows(page)
+    run_at = time.time()
+
+    if previous_ids and len(rows) < 0.5 * len(previous_ids):
+        raise SystemExit("listing count halved: failed run, not a rescue")
+
+    for event in reconcile(previous_ids, rows, run_at):
+        out.write(json.dumps(event, ensure_ascii=False) + "\n")
+    out.flush()
+```
+
+Loading the previous state from the event log rather than a separate snapshot file keeps
+the two from drifting apart, and the halving guard is what stops a partial page load from
+being written as a mass adoption. That guard has saved more datasets than any selector in
+this page.
+
+## What goes wrong here is rarely a defence
+
+Shelter sites are small and mostly undefended, so the failures are ordinary web failures
+with unusually costly consequences for the data.
+
+**A slow list truncates itself.** The load-more loop above waits for the count to grow,
+which is the reliable signal. A fixed sleep on a slow volunteer-hosted site produces a
+short list, which reconciliation then reads as a wave of adoptions.
+
+**A filter resets between runs.** Some listing widgets reset to a default species or
+location when the session cookie expires. The filter is recorded per run for exactly this
+reason, and a run whose filters differ from the previous one should not be reconciled
+against it:
+
+```python
+    if run["filters"] != previous_run["filters"]:
+        run["reconciled"] = False       # comparable only to runs with the same filters
+```
+
+**An aggregator hides the shelter's own record.** Where you scrape an aggregator, the
+`shelter_id` may be the aggregator's, which changes when a shelter re-uploads. Prefer the
+originating shelter's page where the aggregator links to it, and record which source the
+id came from.
+
+If a run does start returning empty pages or challenges, the diagnosis order is the same
+as anywhere else and starts with looking at the page rather than guessing:
+[scraping without getting blocked](how-to-scrape-without-getting-blocked.md).
+
+## The event log, and the question it exists to answer
+
+Three event types, appended, keyed on the shelter's own identifier:
+
+| event | written when | carries |
+|---|---|---|
+| `appeared` | id not seen in the previous run | the full listing snapshot |
+| `updated` | a tracked field changed | which fields, old and new |
+| `disappeared` | id absent from this run | nothing but the id and the time |
+
+From that log, the waiting time distribution falls out directly: the gap between
+`appeared` and `disappeared` per animal. That is the number nobody publishes, it is the
+number shelters use to argue for funding, and it is invisible in any mirror of the current
+listings.
+
+Two honest caveats belong next to it. `disappeared` is not `adopted`, so any published
+figure should say so. And animals that are relisted after a returned adoption appear twice
+with the same id, which is real signal rather than noise, but only if your analysis expects
+it rather than deduplicating it away.

--- a/docs/how-to-scrape-scholarship-listings-playwright.md
+++ b/docs/how-to-scrape-scholarship-listings-playwright.md
@@ -133,3 +133,114 @@ and most rows do not change for months. A weekly full pass plus a daily pass ove
 whose deadline is within a month covers the volatility at a fraction of the requests, and
 keeps you well inside the pacing described in
 [rate limiting your own scraper](how-to-rate-limit-your-scraper-playwright.md).
+
+## A complete pass, aggregator then provider
+
+```python
+import json, time
+from invisible_playwright import InvisiblePlaywright
+
+def aggregator_rows(page):
+    rows = []
+    for card in page.query_selector_all(".scholarship-card"):
+        def t(sel):
+            n = card.query_selector(sel)
+            return n.inner_text().strip() if n else None
+        provider = card.query_selector("a.provider-link, a[target='_blank']")
+        rows.append({
+            "source": "aggregator",
+            "title": t(".title"),
+            "amount_text": t(".amount"),
+            "deadline": parse_deadline(t(".deadline")),
+            "eligibility_chips": [c.inner_text().strip()
+                                  for c in card.query_selector_all(".eligibility .chip")],
+            "eligibility_text": t(".eligibility-full"),
+            "provider_url": provider.get_attribute("href") if provider else None,
+            "observed_at": time.time(),
+        })
+    return rows
+
+with InvisiblePlaywright(seed=42) as browser, open("scholarships.jsonl", "a", encoding="utf-8") as out:
+    page = browser.new_page()
+    page.goto("https://example-aggregator.com/scholarships")
+    page.select_option("select[name='level']", "undergraduate")
+    page.wait_for_selector(".scholarship-card")
+
+    rows = aggregator_rows(page)
+    for row in rows:
+        out.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+    for row in rows:
+        if not row["provider_url"]:
+            continue
+        try:
+            page.goto(row["provider_url"], wait_until="domcontentloaded", timeout=25000)
+        except Exception as exc:
+            out.write(json.dumps({"source": "provider", "of": row["title"],
+                                  "error": str(exc)[:120],
+                                  "observed_at": time.time()}) + "\n")
+            continue
+        out.write(json.dumps({
+            "source": "provider",
+            "of": row["title"],
+            "url": page.url,                       # after redirects: the real page
+            "deadline_text": first_text(page, ".deadline, .apply-by, time[datetime]"),
+            "observed_at": time.time(),
+        }, ensure_ascii=False) + "\n")
+        out.flush()
+        page.wait_for_timeout(3000)
+```
+
+Writing the provider record as a separate row rather than merging it into the aggregator's
+is the design decision that pays off. The disagreement between the two is the most useful
+field in the dataset: it tells you which aggregators are stale, which is what decides
+whether their rows are worth showing to anyone.
+
+Recording `page.url` after the navigation catches the other common case, where a provider
+link redirects to a general funding page because the specific scholarship has closed.
+
+## Aggregators defend their listings, providers do not
+
+Two very different targets in one pipeline, and they fail differently.
+
+**The aggregator is the commercial one.** Its listings are its product, so it is more
+likely to sit behind edge protection, to lazy-load cards, and to cap how deep the facets
+let you go. The card list frequently arrives after the shell renders, so waiting for the
+container rather than a card returns an empty page that parses cleanly.
+
+**The provider is a university or a foundation.** Those sites are slow, occasionally
+broken, and frequently redirect. The failure to plan for is not a block but a timeout, and
+the code above records it as a row rather than losing the aggregator's data because one
+provider was down.
+
+Where the aggregator does start refusing, the tell is usually a card count that drops
+rather than an error. Assert against the total the site itself prints:
+
+```python
+    claimed = page.inner_text(".results-count")          # "412 scholarships"
+    got = len(page.query_selector_all(".scholarship-card"))
+    if int(claimed.split()[0].replace(",", "")) > got and not page.query_selector(".load-more"):
+        raise RuntimeError(f"page claims {claimed} but rendered {got} cards")
+```
+
+The general order for diagnosing a degraded read is in
+[scraping without getting blocked](how-to-scrape-without-getting-blocked.md).
+
+## The schema that keeps a student from a dead deadline
+
+One row per listing per source per observation, with the deadline kept as an object rather
+than a date:
+
+| field | example |
+|---|---|
+| `deadline.kind` | `date`, `rolling`, `varies`, `relative`, `closed`, `unparsed` |
+| `deadline.date` | only present when `kind` is `date` |
+| `deadline.raw` | always, verbatim |
+| `eligibility_text` | the full prose, never only the chips |
+| `amount_text` | `"Up to $5,000 per year, renewable"` |
+| `source` | `aggregator` or `provider` |
+
+The `unparsed` kind is the field that makes this dataset honest. Every alternative design
+invents a date for a listing that does not have one, and the cost of that invention is
+borne by whoever trusts the row. Surfacing "we could not read this deadline, here is what
+it said" is both easier to build and more useful than a confident wrong date.

--- a/docs/how-to-scrape-school-term-calendars-playwright.md
+++ b/docs/how-to-scrape-school-term-calendars-playwright.md
@@ -127,3 +127,93 @@ School sites are small, often run by one person, and contain material about chil
 Take the calendar, which is published for parents, and leave the rest. There is rarely a
 reason for a scraper to touch newsletters, staff lists or photo galleries, and taking only
 the pages that answer your question is both the polite and the defensible default.
+
+## A complete run across several schools
+
+```python
+import hashlib, json, time
+from urllib.parse import urljoin
+from invisible_playwright import InvisiblePlaywright
+
+SCHOOLS = {
+    "1234": "https://example-school.org/term-dates",
+    "5678": "https://another-school.example/calendar",
+}
+
+def read_calendar(page, school_id, url):
+    page.goto(url, wait_until="domcontentloaded")
+    node = page.query_selector(FEED)
+    if node:
+        feed_url = urljoin(page.url, node.get_attribute("href")).replace("webcal://", "https://")
+        page.goto(feed_url)
+        raw = page.inner_text("pre") if page.query_selector("pre") else page.content()
+        return {"school_id": school_id, "format": "ics", "raw": raw}
+
+    pdf = page.query_selector("a[href$='.pdf']")
+    if pdf and not page.query_selector("table.term-dates"):
+        return {"school_id": school_id, "format": "pdf-only",
+                "pdf_url": urljoin(page.url, pdf.get_attribute("href"))}
+
+    rows = []
+    for tr in page.query_selector_all("table.term-dates tbody tr"):
+        cells = [td.inner_text().strip() for td in tr.query_selector_all("td")]
+        if len(cells) >= 2:
+            rows.append({"raw_label": cells[0], "raw_dates": cells[1]})
+    return {"school_id": school_id, "format": "html", "rows": rows}
+
+with InvisiblePlaywright(seed=42) as browser, open("terms.jsonl", "a", encoding="utf-8") as out:
+    page = browser.new_page()
+    for school_id, url in SCHOOLS.items():
+        record = read_calendar(page, school_id, url)
+        payload = json.dumps(record.get("rows") or record.get("raw") or "", sort_keys=True)
+        record["digest"] = hashlib.sha256(payload.encode()).hexdigest()
+        record["observed_at"] = time.time()
+        out.write(json.dumps(record, ensure_ascii=False) + "\n")
+        out.flush()
+        page.wait_for_timeout(3000)
+```
+
+The three-way branch is the point. A feed, an HTML table and a PDF-only page are different
+sources with different reliability, and recording which one you read is what lets you
+prefer the feed next time and flag the PDF-only schools for a human.
+
+## These sites fail by being small, not by defending
+
+Almost nothing here is an anti-bot problem. The failures are the ones small sites have.
+
+**The page is a link to a document.** Many schools publish the calendar only as a PDF or as
+an image of a table. The code above detects that rather than returning an empty row set,
+which is what a table-only parser does. Handling the document itself is
+[downloading and reading linked PDFs](how-to-scrape-linked-pdfs-playwright.md).
+
+**The calendar is a third-party embed.** Term dates frequently live inside an iframe from a
+calendar provider. A selector against the top document finds nothing while the dates are
+plainly on screen, and the fix is to read inside the frame:
+
+```python
+    frame = next((f for f in page.frames if "calendar" in (f.url or "")), None)
+    rows = frame.query_selector_all(".event") if frame else []
+```
+
+**The site is seasonally wrong.** Schools leave last year's dates up for months after they
+expire. The digest and the observation time make that visible: a calendar whose content has
+not changed while its dates have all passed is stale, not stable, and should be reported
+rather than stored as current.
+
+## The schema, and the merge that needs a source column
+
+Two levels: the capture, and the expanded days.
+
+| table | key | holds |
+|---|---|---|
+| `capture` | `school_id`, `observed_at` | format, digest, raw content or rows |
+| `day` | `school_id`, `date` | kind, raw_label, source (`district` or `school`) |
+
+The `source` column on the day table is what keeps a district calendar and a school's own
+overrides from silently contradicting each other. Training days are the field where they
+disagree most, and they are also the field parents most need right.
+
+Expanding to days at read time rather than at capture keeps the correction path open: when
+you discover that a particular school writes "w/c 14 October" meaning the whole week, you
+fix the expansion and re-derive, instead of re-scraping a hundred small sites that were
+kind enough to publish the dates in the first place.

--- a/docs/how-to-scrape-snow-reports-playwright.md
+++ b/docs/how-to-scrape-snow-reports-playwright.md
@@ -133,3 +133,113 @@ the pacing advice in
 [rate limiting your own scraper](how-to-rate-limit-your-scraper-playwright.md) applies
 with the extra note that resort sites see genuine traffic spikes at 7am local time, which
 is precisely when a naive scheduler would fire.
+
+## A complete pass over several resorts
+
+```python
+import json, time
+from invisible_playwright import InvisiblePlaywright
+
+RESORTS = {
+    "example-alpine": "https://example-resort.com/snow-report",
+    "example-nordic": "https://another-resort.example/conditions",
+}
+
+def pin_units(page):
+    toggle = page.query_selector("[data-unit='cm'], .units-metric")
+    if toggle:
+        toggle.click()
+        page.wait_for_timeout(500)
+    node = page.query_selector(".depth-value")
+    return page.evaluate("e => e.dataset.unit || 'unknown'", node) if node else "unknown"
+
+def read_resort(page, resort_id, url):
+    page.goto(url, wait_until="domcontentloaded")
+    page.wait_for_selector(".depth-value, .report-closed", timeout=20000)
+    if page.query_selector(".report-closed"):
+        return [{"resort": resort_id, "state": "closed_for_season",
+                 "observed_at": time.time()}]
+
+    unit = pin_units(page)
+    reported = page.query_selector(".report-updated")
+    reported_text = reported.inner_text().strip() if reported else None
+
+    rows = []
+    for selector, point in POINTS.items():
+        node = page.query_selector(selector)
+        if not node:
+            continue
+        rows.append({
+            "resort": resort_id, "metric": "depth", "point": point,
+            "value_text": node.inner_text().strip(), "unit": unit,
+            "reported_text": reported_text, "observed_at": time.time(),
+        })
+    lifts = page.query_selector(".lifts-open")
+    if lifts:
+        rows.append({"resort": resort_id, "metric": "lifts",
+                     "value_text": lifts.inner_text().strip(),
+                     "reported_text": reported_text, "observed_at": time.time()})
+    return rows
+
+with InvisiblePlaywright(seed=42) as browser, open("snow.jsonl", "a", encoding="utf-8") as out:
+    page = browser.new_page()
+    for resort_id, url in RESORTS.items():
+        for row in read_resort(page, resort_id, url):
+            out.write(json.dumps(row, ensure_ascii=False) + "\n")
+        out.flush()
+        page.wait_for_timeout(5000)
+```
+
+The `closed_for_season` branch is what stops a July run from recording last winter's
+frozen numbers as today's conditions, which is the single most common defect in this kind
+of dataset.
+
+## Stale data is the failure here, not blocking
+
+Resort sites are rarely defended aggressively. What they do instead is serve heavily
+cached pages from a CDN, which produces a failure that looks nothing like a block and is
+much easier to miss: the request succeeds, the page renders, and the numbers are from
+yesterday morning.
+
+Guard on the report timestamp rather than on the response:
+
+```python
+def suspect_stale(rows, seen_before, max_repeats=3):
+    stamp = rows[0].get("reported_text")
+    if stamp and seen_before.get(rows[0]["resort"]) == stamp:
+        seen_before[f"{rows[0]['resort']}:count"] = seen_before.get(f"{rows[0]['resort']}:count", 0) + 1
+    else:
+        seen_before[rows[0]["resort"]] = stamp
+        seen_before[f"{rows[0]['resort']}:count"] = 0
+    return seen_before.get(f"{rows[0]['resort']}:count", 0) >= max_repeats
+```
+
+Three consecutive reads with an unmoved report time, during the season, means you are
+reading a cache or the resort has stopped publishing. Both are worth recording as a state
+rather than absorbing as unchanged conditions.
+
+The other resort-specific failure is the unit toggle silently not applying, which is why
+the code reads the unit back from the DOM after clicking rather than assuming the click
+worked. That is the same discipline as any lever in this corpus: verify the setting from
+inside the system you are measuring, or the arm is inert and its result means nothing.
+
+## The long-form schema, and what it answers
+
+One row per resort, metric, point and observation:
+
+| field | example | note |
+|---|---|---|
+| `resort` | `example-alpine` | your id, stable across their redesigns |
+| `metric` | `depth`, `new_snow`, `lifts` | separate metrics, never one column |
+| `point` | `base`, `mid`, `summit` | absent for metrics without an altitude |
+| `window_hours` | `24` or null | only for new snow, null when the label is vague |
+| `value_text` / `unit` | `"42"` / `cm` | the string and the unit, both kept |
+| `reported_text` | `"Updated 06:15"` | the resort's own clock |
+| `observed_at` | epoch | yours |
+
+With that grain, three questions become easy that a wide table cannot answer: how base and
+summit diverge through a season, how often a resort's published depth moves at all
+(several update weekly while claiming daily), and whether lift openings track snowfall or
+track the calendar. The last one is the interesting one, and it needs the numerator and
+denominator kept separately, which is why lifts are stored as their original `"8 / 14"`
+string rather than a percentage.

--- a/docs/how-to-scrape-spare-part-compatibility-playwright.md
+++ b/docs/how-to-scrape-spare-part-compatibility-playwright.md
@@ -133,3 +133,114 @@ Every combination is a lookup against a real catalogue database, not a cached pa
 deliberate delay between combinations and run outside the retailer's trading hours where
 you can. The reasoning, and why a self-imposed limit beats being told, is in
 [rate limiting your own scraper](how-to-rate-limit-your-scraper-playwright.md).
+
+## A complete resumable walk of one slice
+
+```python
+import json, time
+from invisible_playwright import InvisiblePlaywright
+
+TARGET_MAKES = ["Example Motors"]
+PATH = "fitment.jsonl"
+
+def done_paths(path):
+    seen = set()
+    try:
+        with open(path, encoding="utf-8") as f:
+            for line in f:
+                r = json.loads(line)
+                seen.add((r["make"], r["model"], r["year"], r["variant"]))
+    except FileNotFoundError:
+        pass
+    return seen
+
+seen = done_paths(PATH)
+
+with InvisiblePlaywright(seed=42) as browser, open(PATH, "a", encoding="utf-8") as out:
+    page = browser.new_page()
+    page.goto("https://parts.example.com/fitment", wait_until="domcontentloaded")
+
+    for make in options(page, "select#make"):
+        if make["label"] not in TARGET_MAKES:
+            continue
+        choose(page, "select#make", make["value"], "select#model")
+        for model in options(page, "select#model"):
+            choose(page, "select#model", model["value"], "select#year")
+            for year in options(page, "select#year"):
+                choose(page, "select#year", year["value"], "select#variant")
+                for variant in options(page, "select#variant"):
+                    key = (make["label"], model["label"], year["label"], variant["label"])
+                    if key in seen:
+                        continue
+                    page.select_option("select#variant", variant["value"])
+                    page.click("button#findParts")
+                    page.wait_for_selector(".part-result, .no-fit", timeout=25000)
+
+                    base = dict(zip(("make", "model", "year", "variant"), key))
+                    parts = page.query_selector_all(".part-result")
+                    if not parts:
+                        out.write(json.dumps({**base, "result": "no_fit",
+                                              "observed_at": time.time()}) + "\n")
+                    for part in parts:
+                        note = part.query_selector(".fitment-note")
+                        out.write(json.dumps({
+                            **base,
+                            "part_number": part.query_selector(".sku").inner_text().strip(),
+                            "part_name": part.query_selector(".name").inner_text().strip(),
+                            "fitment_note": note.inner_text().strip() if note else None,
+                            "observed_at": time.time(),
+                        }, ensure_ascii=False) + "\n")
+                    out.flush()
+                    page.wait_for_timeout(2500)
+```
+
+Resuming from the written rows rather than a checkpoint file is what makes an interrupted
+walk safe to restart at any point, including after a crash that never got to write a
+checkpoint. Writing the `no_fit` row is what stops the resume from re-walking every
+combination that legitimately has no parts.
+
+## Catalogues protect fitment data specifically
+
+Fitment is the most valuable asset a parts retailer has, more than prices, because it is
+expensive to compile and it is what makes their search work. The defences reflect that.
+
+**The cascade is the rate limiter.** Each level costs a query, so a full walk is thousands
+of requests whatever the delay between them. Slicing by make is not only politeness, it is
+the difference between a run that completes and one that is cut off partway with an
+unusable partial dataset.
+
+**Refusal appears as an empty next level.** When the site decides to stop serving you, the
+model dropdown comes back with only its placeholder, which the code reads as a make with no
+models. Guard on it, because it is the failure that silently ends a sweep:
+
+```python
+    models = options(page, "select#model")
+    if not models:
+        raise RuntimeError(f"{make['label']}: no models returned, treat as a refusal")
+```
+
+**A stripped client is refused at the first cascade step.** The repopulation request is
+issued by the page and validated against its session. Driving the real controls in a real
+browser is what keeps the chain answering, and the diagnosis order when it stops is in
+[scraping without getting blocked](how-to-scrape-without-getting-blocked.md).
+
+Where a trade or bulk fitment feed exists, ask for it. It is a normal commercial request,
+it is exactly this data in a form built to be consumed, and it removes the whole problem.
+
+## The schema, and why it must be queryable in both directions
+
+One row per combination per part, with `no_fit` rows kept:
+
+| field | note |
+|---|---|
+| `make`, `model`, `year`, `variant` | the full path, never collapsed to a vehicle id |
+| `part_number`, `part_name` | the catalogue's own identifiers |
+| `fitment_note` | the qualifier that makes the fit conditional |
+| `result` | `no_fit` where the combination returned nothing |
+| `observed_at` | catalogues correct fitment, and corrections matter |
+
+Both directions then work with a single index each: which parts fit this vehicle, and which
+vehicles take this part. The second is the one a schema keyed on part number with an
+embedded compatibility blob cannot answer without unpacking every row, and it is the query
+that matters commercially, because it is the one that tells you how much inventory risk a
+part carries.


### PR DESCRIPTION
Follow-up to #170. Those twenty shipped at 851 words on average against roughly 1,900 for the pages that rank, which was flagged at the time as open work.

Each one now has three more sections: a complete end-to-end run with the guards production needs, what that specific target does when it stops serving you (which differs a lot by domain), and the schema with the question each grain exists to answer.

Average is 1,433 words now, up from 851. Still short of the corpus norm, and worth saying rather than padding to a number: the ranking data says length is not what separates the pages that win from the ones that do not.