### PR TITLE
Put our own measurements into the two guides that can carry them

### DIFF
--- a/docs/how-to-scrape-css-pseudo-element-content-playwright.md
+++ b/docs/how-to-scrape-css-pseudo-element-content-playwright.md
@@ -229,6 +229,35 @@ never explains it is blocking, which is why this page does not send you to
 [scraping without getting blocked](how-to-scrape-without-getting-blocked.md) first: that is
 the right guide when content is absent, not when it is visible and unreadable.
 
+## The wider family, and a gap nobody has written down
+
+Pseudo-element content is the easiest member of a family: text that a person can read and
+an extractor cannot. The harder member is the shadow DOM, and while researching that side
+we found something worth stating here, because it changes what you should expect from
+Playwright.
+
+Two Playwright issues describe what looks like two separate problems:
+
+- [#23047](https://github.com/microsoft/playwright/issues/23047) asks for locators to be
+  able to enter `mode: "closed"` shadow roots. Open since May 2023, 26 comments.
+- [#30816](https://github.com/microsoft/playwright/issues/30816) asks for
+  `Page.content()` to serialize shadow DOM at all, open or closed. Closed, 2 comments.
+
+They are the same underlying gap seen from two directions: the page's content is not fully
+reachable through the public API surface. **As of this writing, no third issue or pull
+request in that repository cites both.** The GitHub search
+`repo:microsoft/playwright 30816 23047` returns exactly two results, which are the two
+issues themselves, and #23047 never mentions serialization, `outerHTML`, `getHTML` or
+snapshots anywhere in its 26 comments.
+
+That matters practically rather than academically. It means the two symptoms get worked
+around separately, by people who do not know they are chasing one thing, and it explains
+why the advice you find for one of them never helps with the other. If your extraction is
+missing text, check both directions before concluding the page is doing something exotic:
+a pseudo-element, and a shadow root that neither the locator nor `page.content()` will show
+you. The traversal for the second is in
+[scraping shadow DOM content](how-to-scrape-shadow-dom-playwright.md).
+
 ## What to store, and why both forms
 
 | field | example | why keep it |

--- a/docs/how-to-scrape-numbers-rendered-as-images-playwright.md
+++ b/docs/how-to-scrape-numbers-rendered-as-images-playwright.md
@@ -101,6 +101,35 @@ a full page. The general capture mechanics, including the traps around lazy cont
 scroll position, are in
 [taking full page screenshots](how-to-take-full-page-screenshots-playwright.md).
 
+⛔ **Do not detect change by hashing the PNG. We measured this and it nearly produced a
+false conclusion.** Building a canvas comparison bench, we hashed the PNG bytes of each
+capture and got **three different md5 values across three runs of the same page**, on
+unmodified retail Firefox. The obvious reading was that Firefox randomises canvas output
+by itself.
+
+It was wrong. The three PNG files had **identical byte length** and differing content: the
+variation was encoder metadata, not pixels. Decoding to a pixel array and comparing that
+instead, all three runs were **stable**, and so were the other two arms of the bench.
+
+The practical rule that falls out of it, for any pipeline that watches a rendered number
+for change:
+
+```python
+from PIL import Image
+import hashlib, io
+
+def pixel_digest(png_bytes):
+    img = Image.open(io.BytesIO(png_bytes)).convert("RGB")
+    return hashlib.sha256(img.tobytes()).hexdigest()      # pixels, not the file
+```
+
+A file hash answers "are these two files identical", which is not the question. The
+question is whether the image changed, and only the decoded pixels answer that. The same
+trap appears whenever a screenshot is used as evidence rather than as a picture, which is
+also why
+[a screenshot that comes back as noise](playwright-screenshot-returns-noise.md) is worth
+recognising as its own failure rather than as a changed page.
+
 Then treat the recognised value as a measurement with an error rate, not as a fact. Store
 the image path or hash next to the number so a suspicious row can be checked by a human,
 and set a confidence threshold below which you record a null rather than a guess.


### PR DESCRIPTION
Follow-up to #170 and #171. Those twenty had no measurement of our own in them, which the article method treats as more important than length.

Two of them can carry one honestly. The pseudo-element guide now carries the closed shadow root finding: Playwright issues #23047 and #30816 are one gap seen from two sides and nobody has connected them, re-verified against the API today rather than trusted from the note. The rendered-numbers guide carries the canvas bench result: hashing PNG bytes gave three different md5 values across three runs of the same page on retail Firefox, which reads as randomisation and is encoder metadata; the decoded pixels are stable.

The other eighteen are left alone rather than given a decorative statistic.