### PR TITLE
Give the twenty September guides the blocks the house format requires

### DIFF
--- a/docs/how-to-scrape-bank-interest-rates-playwright.md
+++ b/docs/how-to-scrape-bank-interest-rates-playwright.md
@@ -239,3 +239,37 @@ a headline rate against its conditions over time. Introductory rates that quietl
 their bonus period, tiers whose thresholds drift upward, and footnotes that gain a
 requirement between two captures are all visible as a diff, and all invisible in a table
 that keeps only the current best rate per product.
+
+## Short answers to the questions that lead here
+
+**What do the little superscript markers next to a rate mean?** They point at a
+footnote further down the page, and the footnote frequently carries the condition that
+makes the rate real: a minimum balance, a term, a new-money-only clause. Resolve the
+marker to its text at capture time, while the pointer is still in front of you.
+
+**Is APR the same as APY?** No, and mixing them is the most common error in this data.
+Deposit products publish a yield that includes compounding; lending products publish a
+rate that does not. Read the column header into the row instead of hardcoding either.
+
+**The rate table has bands. What is the row?** The tier. Tier bounds are part of the
+rate, and a null upper bound means the open-ended top band. Keep the tier text as
+written too, because banks describe the same band in words that do not always match
+the numbers.
+
+**How fresh is a published rate?** Banks print an effective date, and it is the
+closest thing to a timestamp this data has. These pages are also cached hard, so the
+effective date and your fetch time can differ by days.
+
+**See also:** [How to scrape geotargeted content with
+Playwright](how-to-scrape-geotargeted-content-playwright.md), [How to handle cookie
+consent banners in Playwright](how-to-handle-cookie-consent-banners-playwright.md),
+[How to scrape into a SQLite database with
+Playwright](how-to-scrape-into-a-database-playwright.md)
+
+## Sources
+
+- Playwright, Locators, https://playwright.dev/python/docs/api/class-locator - driving
+  a product or region picker that changes content with no URL change, and waiting for
+  the table to repopulate before reading it.
+- This project's page on geotargeted content, which covers the region half of the same
+  problem.

--- a/docs/how-to-scrape-conference-agendas-playwright.md
+++ b/docs/how-to-scrape-conference-agendas-playwright.md
@@ -225,3 +225,37 @@ organisers would like, and it is only visible when track and time are both kept.
 The clash query is the one that justifies the grid work at the start of this page. Two
 sessions clash when they share a day and overlap in time on different tracks, and that is a
 single join once the track is a real column rather than a heading you read past.
+
+## Short answers to the questions that lead here
+
+**Where does the track name live in a grid agenda?** In the column header, once, and
+not in the cells. Read the header first and map each session to its column, or every
+session arrives without the one field that makes a grid a schedule.
+
+**The agenda prints times with no timezone. Which one applies?** The event's,
+essentially always. Agendas print local times bare, so resolve the event zone once and
+attach it to every session; your own machine's zone is the wrong answer and the
+easiest one to record by accident.
+
+**Why is my capture missing half the sessions?** Because the agenda splits by day
+behind tabs that swap the grid without changing the URL. The failure is quiet: you get
+a full, valid, complete-looking grid for one day.
+
+**How stable is a conference agenda?** Not stable at all in the final weeks. Rooms
+move, speakers cancel and sessions swap slots up to the morning of the event, which is
+why a capture is stored as a dated record and not as the truth.
+
+**See also:** [How to scrape accordion and tab content with
+Playwright](how-to-scrape-accordion-and-tab-content-playwright.md), [How to rate limit
+your own Playwright scraper](how-to-rate-limit-your-scraper-playwright.md), [How to
+scrape without getting blocked](how-to-scrape-without-getting-blocked.md)
+
+## Sources
+
+- MDN, the `time` element,
+  https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/time - the
+  `datetime` attribute as the machine-readable form of a printed time, checked for
+  where an agenda may carry a zone the visible text omits.
+- Playwright, Locators, https://playwright.dev/python/docs/api/class-locator - reading
+  a header row once and mapping cells to it, and driving tabs that swap content
+  without a navigation.

--- a/docs/how-to-scrape-construction-permits-playwright.md
+++ b/docs/how-to-scrape-construction-permits-playwright.md
@@ -228,3 +228,36 @@ On the personal data, one practical default: keep `contractor` and drop `applica
 your question genuinely needs the individual. Contractor activity is commercial and is the
 subject of most legitimate analysis; applicant names are the part that makes a permit
 dataset a dataset about people.
+
+## Short answers to the questions that lead here
+
+**Why does my search return nothing when the same query works by hand?** Order. Permit
+search forms have dependent fields, and a type or status list only populates after the
+date range or the jurisdiction is set. Filling them out of order leaves a control
+empty and the search runs against a filter that was never applied.
+
+**Page two does nothing when I change the URL. Why?** Because paging is a form
+submission, not a navigation. Click the control and wait for the first row to change;
+waiting for a navigation returns immediately and you read page one twice.
+
+**Should I capture the current status or the whole history?** The history. These
+records exist to answer questions about duration - how long a permit sat in each
+review stage - and a single current status cannot answer any of them.
+
+**How do I know the portal is not silently capping my results?** Ask it for the count
+and compare. These systems cap without saying so, and a month that returns exactly the
+cap is a month you have not actually read.
+
+**See also:** [Scrape a multi-step wizard flow with
+Playwright](how-to-scrape-multi-step-wizard-flow-playwright.md), [How to resume an
+interrupted scrape with
+Playwright](how-to-resume-an-interrupted-scrape-playwright.md), [How to retry failed
+requests when scraping Playwright](how-to-retry-failed-requests-playwright.md)
+
+## Sources
+
+- Playwright, Locators, https://playwright.dev/python/docs/api/class-locator - waiting
+  for content to change after a form submission rather than waiting for a navigation,
+  checked for the paging behaviour these portals use.
+- This project's page on resuming an interrupted scrape, which this page depends on
+  because a months-long sequential crawl is the job that dies partway through.

--- a/docs/how-to-scrape-court-dockets-playwright.md
+++ b/docs/how-to-scrape-court-dockets-playwright.md
@@ -218,3 +218,34 @@ rest, rather than accumulating dockets because they were cheap to fetch. The val
 data is in answering a specific question about court activity; the risk in it is that a
 general archive of dockets is a general archive about people, and the second grows quietly
 out of the first if nobody decides otherwise.
+
+## Short answers to the questions that lead here
+
+**Can I search for cases by name?** This page does not, and that is deliberate. It
+looks up cases already identified by number. Bulk identification of people through a
+court portal is a different activity with different consequences.
+
+**Why is the docket numbering full of gaps?** Because courts skip numbers, add entries
+out of sequence and amend them later. Keep the court's sequence number exactly as
+given and never renumber: the gaps are part of the record.
+
+**The document did not download, it opened in a viewer.** That is the normal behaviour
+on these systems: attachments open a PDF in a viewer tab instead of triggering a
+download, so the download-handling route does not apply.
+
+**A case returned nothing. Does that mean it does not exist?** Not necessarily.
+Sealed, expunged and mistyped cases all render as the same absence, so keep the
+not-found branch explicit instead of treating it as an empty result.
+
+**See also:** [How to Handle a PDF That Opens in a New Tab with
+Playwright](how-to-handle-pdf-opens-new-tab-playwright.md), [Download and read PDFs
+linked from a page with Playwright](how-to-scrape-linked-pdfs-playwright.md), [How to
+rate limit your own Playwright scraper](how-to-rate-limit-your-scraper-playwright.md)
+
+## Sources
+
+- Playwright, Network, https://playwright.dev/python/docs/network - request
+  interception and response capture, checked for the case where a document opens in a
+  viewer instead of arriving as a download.
+- This project's pages on PDFs that open in a new tab and on scraping linked PDFs,
+  which carry the mechanics this page points at instead of repeating them.

--- a/docs/how-to-scrape-css-pseudo-element-content-playwright.md
+++ b/docs/how-to-scrape-css-pseudo-element-content-playwright.md
@@ -271,3 +271,36 @@ Two columns for one visible string looks redundant and costs almost nothing. It 
 class of silent breakage into a visible one: a diff between the two columns is a fact about
 the site's markup, and a diff that suddenly disappears across a whole crawl is the earliest
 warning you will get that the page was redesigned under you.
+
+## Short answers to the questions that lead here
+
+**Why does the value come back with quotation marks?** Because `content` is a CSS
+value and not a string, so it arrives quoted and needs unwrapping. It can also come
+back as `none`, which means the pseudo-element is not generating anything at all.
+
+**Can `content` hold something that is not text?** Yes, and each form needs different
+handling: a counter, an attribute reference, a URL, or a concatenation of several of
+those. A parser that assumes a plain string quietly mangles all four.
+
+**Is reading this per element slow?** It costs a round trip each time. For a list,
+collect the values in a single evaluation in the page and return them together.
+
+**How do I find out whether a page uses this at all?** Ask once, before writing any
+selector, instead of discovering it from a column of missing values. Nothing here is a
+defence, so it fails by silence: the text is simply absent from what an extractor
+sees.
+
+**See also:** [How to scrape shadow DOM content with
+Playwright](how-to-scrape-shadow-dom-playwright.md), [Extract data from canvas charts
+with Playwright](how-to-extract-data-from-canvas-charts-playwright.md), [How to scrape
+without getting blocked](how-to-scrape-without-getting-blocked.md)
+
+## Sources
+
+- MDN, `Window.getComputedStyle()`,
+  https://developer.mozilla.org/en-US/docs/Web/API/Window/getComputedStyle - reading a
+  pseudo-element's computed style through the second argument, which is the mechanism
+  this page rests on.
+- MDN, the `content` property,
+  https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/content - the
+  value types the property accepts, checked for the four forms this page separates.

--- a/docs/how-to-scrape-energy-tariffs-playwright.md
+++ b/docs/how-to-scrape-energy-tariffs-playwright.md
@@ -222,3 +222,33 @@ than another scrape: for two tariffs, the consumption at which their annual cost
 is the difference in standing charges divided by the difference in unit rates. That number
 is the actual advice a household needs, it is not published anywhere, and it is
 unreachable from the annual estimate the site puts in large type.
+
+## Short answers to the questions that lead here
+
+**Why does the quote form reject my inputs?** Usually order. These forms branch on
+whether you know your consumption, and the fields that appear depend on that answer,
+so filling them in the wrong sequence leaves a control the engine still expects.
+
+**Should I store one price per tariff?** No. A standing charge and a unit rate are
+separate numbers and the ranking between two tariffs flips depending on consumption.
+Keep them apart, and copy the inputs into every row even though it looks redundant.
+
+**Two runs an hour apart disagree. Which is right?** Both. A quote is a moment:
+tariffs change often and comparison sites cache aggressively, so the run timestamp
+belongs in the row and a disagreement is data about the market.
+
+**Can I follow the switch flow to get more detail?** No. Everything here is the public
+quote engine. A switch requires personal details and creates a real commercial action,
+which is a different activity entirely.
+
+**See also:** [Scrape a multi-step wizard flow with
+Playwright](how-to-scrape-multi-step-wizard-flow-playwright.md), [How to retry failed
+requests when scraping Playwright](how-to-retry-failed-requests-playwright.md), [How
+to scrape to JSON Lines with Playwright](how-to-scrape-to-json-lines-playwright.md)
+
+## Sources
+
+- Playwright, Input, https://playwright.dev/python/docs/input - `check()` and
+  `fill()`, checked for driving a branching form in the order the engine expects.
+- This project's page on multi-step wizard flows, which carries the general shape this
+  page applies to a pricing engine.

--- a/docs/how-to-scrape-ev-charging-availability-playwright.md
+++ b/docs/how-to-scrape-ev-charging-availability-playwright.md
@@ -257,3 +257,37 @@ is the shape almost every first attempt produces. One row per state change, with
 Write it as [JSON Lines](how-to-scrape-to-json-lines-playwright.md) while collecting and
 load it into a database for querying. Appending is what makes an interrupted poll leave
 usable data instead of a hole, and a poll that runs for weeks will be interrupted.
+
+## Short answers to the questions that lead here
+
+**Should I read the map pins or the network request behind them?** The request.
+Charger maps draw their pins from a JSON response, and the pins are a rendering of it
+that has already lost fields. Capture the response and you get the operator's own
+model, including the parts the map does not draw.
+
+**Why is my charger count wrong?** Almost always because a pin was treated as a
+charger. A pin is a site, a site holds several charging points, and a point holds
+several connectors. Availability lives at the connector, so a count taken at the pin
+level answers a different question.
+
+**How often should I poll charger status?** On the data's clock, not yours. Status
+changes on the scale of a charging session, so a ten-second poll produces almost
+entirely duplicate rows and looks like exactly what it is: a script that never sleeps.
+
+**Which timestamp should I store?** Both. When you read the value and when the
+operator says the value was true are different facts, and only the second one lets you
+tell a stale feed from a busy charger.
+
+**See also:** [How to capture XHR and API responses in
+Playwright](how-to-capture-xhr-api-responses-playwright.md), [How to rate limit your
+own Playwright scraper](how-to-rate-limit-your-scraper-playwright.md), [How to scrape
+into a SQLite database with Playwright](how-to-scrape-into-a-database-playwright.md)
+
+## Sources
+
+- Playwright, Network, https://playwright.dev/python/docs/network -
+  `page.expect_response()` and `page.route()`, checked for the response-capture
+  pattern this page uses and for attaching and detaching a listener around a single
+  query.
+- This project's page on capturing XHR and API responses, which covers the general
+  form that this page applies to a live availability feed.

--- a/docs/how-to-scrape-ferry-schedules-playwright.md
+++ b/docs/how-to-scrape-ferry-schedules-playwright.md
@@ -225,3 +225,38 @@ sailing that was scheduled on Monday and gone by Thursday is a cancellation, and
 the number a seasonal PDF can never give you: not what the operator plans to run, but what
 the operator actually ran. Storing every capture rather than updating in place is what
 makes that question answerable at all.
+
+## Short answers to the questions that lead here
+
+**Why does the same route return a different timetable on different days?** Because
+the season decides the timetable. Ferry operators publish per-date, not a single
+annual grid, so a query without an explicit date returns whatever the site thinks
+today is and a series built that way silently mixes seasons.
+
+**Do I need to scrape each direction separately?** Direction is part of a sailing's
+identity, not a column you can add afterwards. Operators often show both directions on
+one page, sometimes in two tables and sometimes in one with a toggle, so decide which
+you are reading before you store a row.
+
+**The date field ignores what I type. What now?** It is a calendar widget, not a text
+input. Open it and click the day, the way a person does. A written value leaves the
+widget's internal state unchanged and the search runs against the previous date.
+
+**Where do cancellations show up?** Separately from the timetable, usually as a notice
+banner or a status column, and they are the most interesting part of the data. A
+timetable without the disruption record describes an intention, not a service.
+
+**See also:** [Scrape date-picker calendars with
+Playwright](how-to-scrape-date-picker-calendar-playwright.md), [How to resume an
+interrupted scrape with
+Playwright](how-to-resume-an-interrupted-scrape-playwright.md), [How to rate limit
+your own Playwright scraper](how-to-rate-limit-your-scraper-playwright.md)
+
+## Sources
+
+- Playwright, Input, https://playwright.dev/python/docs/input - `locator.fill()`,
+  which focuses the element and fires an input event, against `press_sequentially()`,
+  which types character by character with an optional delay. Checked for why a written
+  date does not commit in a calendar widget.
+- This project's page on driving date pickers and calendar widgets, which this page
+  relies on instead of restating.

--- a/docs/how-to-scrape-flight-status-boards-playwright.md
+++ b/docs/how-to-scrape-flight-status-boards-playwright.md
@@ -252,3 +252,37 @@ turns a live board into an answerable dataset:
 None of these come from a snapshot table holding today's board. They all come from the
 transitions, which is why the loop above writes changes rather than states, and why the
 last status travels with the disappearance.
+
+## Short answers to the questions that lead here
+
+**Why should I read the whole board in one evaluation?** Because the board rewrites
+itself while you read. Iterating the DOM row by row from Python crosses into the page
+once per call, and a refresh between two calls gives you half of one board and half of
+the next. One evaluation returns one consistent snapshot.
+
+**Scheduled, estimated, actual: which one do I store?** All of them, in separate
+fields. Collapsing them into a single time destroys the only thing a status board is
+for, which is the difference between what was planned and what happened.
+
+**What key identifies a row?** Flight number plus service day plus direction.
+Direction belongs in the key because a code-shared arrival and a departure can carry
+the same number at the same airport on the same day.
+
+**A flight disappeared from the board. Is that an error?** No, it is data. Boards show
+a window around now, so a flight leaves the board when it ages out. Record the
+disappearance with the last status you saw, or the series will look like the flight
+never landed.
+
+**See also:** [How to scrape virtual scrolling tables with
+Playwright](how-to-scrape-virtual-scrolling-tables-playwright.md), [How to retry
+failed requests when scraping Playwright](how-to-retry-failed-requests-playwright.md),
+[How to scrape without getting blocked](how-to-scrape-without-getting-blocked.md)
+
+## Sources
+
+- Playwright, Locators, https://playwright.dev/python/docs/api/class-locator -
+  `locator.evaluate_all`, which runs one piece of JavaScript over every matching
+  element, checked as the mechanism for taking a whole board in a single pass instead
+  of one round trip per row.
+- This project's page on virtual scrolling tables, for the case where the board is
+  windowed in the DOM as well as in time.

--- a/docs/how-to-scrape-fuel-prices-playwright.md
+++ b/docs/how-to-scrape-fuel-prices-playwright.md
@@ -256,3 +256,40 @@ The series is then one row per station, grade and observation, with `queried_loc
 `unit`, `currency`, `reported_age` and `observed_at`. That is enough to answer where fuel
 is cheapest today, how fast a price change propagates across a chain, and how stale a
 given site's data really is, which is the question the site itself will never answer.
+
+## Short answers to the questions that lead here
+
+**Why do two runs return different stations for the same site?** Because the page
+decides where you are before it shows you anything, and with no explicit location it
+decides from the exit IP. The data is not noisy, it is unlabelled: write the queried
+location into every row and the difference becomes readable.
+
+**Why does typing into the location box work when setting the value does not?**
+Location fields are usually autocomplete widgets that only commit on a real key
+sequence. A value written straight into the element leaves the widget's internal state
+empty, so the search runs against nothing.
+
+**Should I convert the price to a float at capture time?** No. The string carries the
+currency and the unit, and those are exactly what a float conversion throws away. A
+page can show a price per litre and a price per gallon in different regions, and a
+series that mixes them has a step nobody can explain.
+
+**How reliable are these prices?** Many fuel price sites are crowd-sourced, so the
+number is what a visitor said they paid. Capture the reported age next to it: a price
+from two hours ago and one from nine days ago are not comparable, and that gap is
+often the largest source of variance you have.
+
+**See also:** [Scrape autocomplete and typeahead inputs with
+Playwright](how-to-scrape-autocomplete-typeahead-playwright.md), [How to scrape
+geotargeted content with Playwright](how-to-scrape-geotargeted-content-playwright.md),
+[How to rate limit your own Playwright
+scraper](how-to-rate-limit-your-scraper-playwright.md)
+
+## Sources
+
+- Playwright, Input, https://playwright.dev/python/docs/input - `locator.fill()`,
+  which focuses the element and fires an input event, and `press_sequentially()`,
+  which types character by character with an optional delay. Checked for why an
+  autocomplete commits on typing and not on an assigned value.
+- This project's pages on autocomplete inputs and on geotargeted content, which carry
+  the two mechanics this page depends on.

--- a/docs/how-to-scrape-library-catalog-availability-playwright.md
+++ b/docs/how-to-scrape-library-catalog-availability-playwright.md
@@ -233,3 +233,35 @@ interface does not:
 All three need history, which is why the write is append-only and the status string is
 kept verbatim. A table holding the current availability per title answers none of them,
 and is also the exact thing the library's own search page already does better.
+
+## Short answers to the questions that lead here
+
+**Can I just save the result URL and reload it later?** Usually not. Public catalogues
+carry the search in session state, so a replayed result URL returns an empty set or a
+fresh session. Run the query in the browser and read the results in the same session.
+
+**Why does the availability badge disagree with the holdings table?** The badge
+summarises, the table states. Availability is per copy and per branch, so a record
+showing available can still have nothing on the shelf at the branch you care about.
+
+**Should I normalise the status to available or not available?** Not at capture time.
+Library systems use a vocabulary that carries real distinctions - in transit, on hold,
+reference only, missing - and collapsing it to a boolean throws away the part that
+answers most questions.
+
+**Is any of this touching patron data?** No, and it should stay that way. Everything
+here works against the public catalogue with no login. A patron account is a different
+system with a different answer.
+
+**See also:** [How to handle cookie consent banners in
+Playwright](how-to-handle-cookie-consent-banners-playwright.md), [How to scrape
+paginated pages with Playwright](how-to-scrape-paginated-pages-playwright.md), [How to
+rate limit your own Playwright scraper](how-to-rate-limit-your-scraper-playwright.md)
+
+## Sources
+
+- Playwright, Locators, https://playwright.dev/python/docs/api/class-locator - the
+  locator model and clicking a result instead of navigating to its href, checked for
+  keeping a session token valid across a search and its record pages.
+- This project's pages on consent interstitials and on pacing, which describe the two
+  failure modes this page runs into most.

--- a/docs/how-to-scrape-numbers-rendered-as-images-playwright.md
+++ b/docs/how-to-scrape-numbers-rendered-as-images-playwright.md
@@ -245,3 +245,37 @@ is the outcome that a pipeline without a threshold produces by default. Set the 
 high enough that the nulls annoy you, then fix the extraction rather than lowering the bar,
 because the alternative is a dataset whose errors are invisible and whose consumers have no
 way to find them.
+
+## Short answers to the questions that lead here
+
+**Where do I look before trying to read pixels?** The accessible layer. In practice
+one of `alt`, `aria-label`, a `data-` attribute or a visually hidden span carries the
+digits, because the site still has to be readable by a screen reader.
+
+**The image is one file for the whole number. Now what?** Check whether it is a
+sprite. A common technique renders each digit as a background offset into a single
+image, and the offsets decode to digits without any recognition.
+
+**The DOM text is there but wrong.** That is the third variant: a custom font whose
+glyph for one digit draws another. The text is misleading instead of missing, which is
+worse, because nothing looks broken.
+
+**When should I give up?** Sooner than feels comfortable, and that is a real answer.
+Sprite shuffling, per-session glyph remapping and an image with no accessible label
+are deliberate, and recognition output is a measurement with an error rate, not a
+fact.
+
+**See also:** [How to take full-page screenshots with
+Playwright](how-to-take-full-page-screenshots-playwright.md), [How to extract JSON-LD
+structured data with
+Playwright](how-to-extract-json-ld-structured-data-playwright.md), [How to scrape
+without getting blocked](how-to-scrape-without-getting-blocked.md)
+
+## Sources
+
+- MDN, `aria-label`,
+  https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-label
+  - the attribute that most often carries the digits a site renders as an image,
+  checked as the first place this page looks.
+- Playwright, Locators, https://playwright.dev/python/docs/api/class-locator - reading
+  attributes and taking an element screenshot scoped to one node.

--- a/docs/how-to-scrape-package-download-stats-playwright.md
+++ b/docs/how-to-scrape-package-download-stats-playwright.md
@@ -235,3 +235,37 @@ unless both series carry the same window, the same interval and the same caveats
 mirrors and continuous integration. Keeping `version` in the key at least surfaces the
 usual explanation, which is that most of a popular library's traffic is one old pinned
 release being pulled by machines.
+
+## Short answers to the questions that lead here
+
+**Do I need a browser for download counts at all?** Often not, and that is the first
+thing to check. Several registries publish the numbers as a dataset or an endpoint,
+which is faster and more complete than any dashboard. Reach for a browser when the
+dashboard is the only published form.
+
+**Should I read the chart or the request behind it?** The request. It usually carries
+the window as parameters, which is the handle for getting more than the dashboard
+chooses to draw.
+
+**Why do recent days keep changing?** Registries revise the last few days as mirrors
+and logs settle. Append one row per day per observation instead of overwriting, or the
+revisions erase themselves.
+
+**Can I compare two packages by download count?** This is the tempting use and the
+least reliable one. The same headline number can be made of very different traffic, so
+keep the qualifiers the registry publishes in the row itself, where they stay attached
+to the number they qualify.
+
+**See also:** [How to capture XHR and API responses in
+Playwright](how-to-capture-xhr-api-responses-playwright.md), [Extract data from canvas
+charts with Playwright](how-to-extract-data-from-canvas-charts-playwright.md), [How to
+scrape to JSON Lines with Playwright](how-to-scrape-to-json-lines-playwright.md)
+
+## Sources
+
+- PyPI, Stats API, https://docs.pypi.org/api/stats/ - an example of a registry
+  publishing download data directly, checked for the first step this page recommends,
+  which is to look for the dataset before opening a browser.
+- Playwright, Network, https://playwright.dev/python/docs/network -
+  `page.expect_response()`, checked for taking the dashboard's own request instead of
+  its rendering.

--- a/docs/how-to-scrape-package-tracking-playwright.md
+++ b/docs/how-to-scrape-package-tracking-playwright.md
@@ -238,3 +238,36 @@ which is a table that quietly rewrites its own history every time the carrier do
 For retention, delete captures once a parcel is delivered plus whatever window your use
 actually needs. A tracking archive is a movement record, and the honest default is to keep
 it only as long as it is answering a question.
+
+## Short answers to the questions that lead here
+
+**Why are the scan events out of order?** Because facilities upload in batches and a
+later scan can be written before an earlier one. Order is not guaranteed and neither
+is stability: a timeline can be revised between two reads, so store what you saw and
+when you saw it instead of assuming the last read is the truth.
+
+**Should I map the carrier's wording to my own status?** Keep both. Carriers use
+different vocabularies for the same physical event and change them without notice, so
+the carrier's words are the record and your status is a derivation you can redo when
+the mapping turns out to be wrong.
+
+**Why does the tracking page reject my URL?** Many carriers only accept a tracking
+number that was entered on the page, not one placed in the address bar. Type it into
+the field and submit the form.
+
+**How often should I check a parcel?** On the shipment's clock. Parcels produce events
+at handoffs, a few times a day at most, so a tight poll loop buys nothing and is the
+easiest possible thing for a carrier to spot.
+
+**See also:** [How to handle cookie consent banners in
+Playwright](how-to-handle-cookie-consent-banners-playwright.md), [How to rate limit
+your own Playwright scraper](how-to-rate-limit-your-scraper-playwright.md), [How to
+scrape without getting blocked](how-to-scrape-without-getting-blocked.md)
+
+## Sources
+
+- Playwright, Input, https://playwright.dev/python/docs/input - `locator.fill()` and
+  `press_sequentially()`, checked for entering a tracking number into a form that
+  refuses a value placed in the URL.
+- This project's page on scraping without getting blocked, for the debug order when a
+  read starts degrading instead of failing.

--- a/docs/how-to-scrape-parking-rates-playwright.md
+++ b/docs/how-to-scrape-parking-rates-playwright.md
@@ -285,3 +285,39 @@ query it, or [JSON Lines](how-to-scrape-to-json-lines-playwright.md) if you will
 reprocess it. Either way, append rather than overwrite: a parking tariff that changed last
 month is the most interesting row in the table, and an updated-in-place record cannot tell
 you it ever moved.
+
+## Short answers to the questions that lead here
+
+**Why does the price I scraped not match what the garage charges?** Because a tariff
+table is a set of duration bands and the amount depends on when the car arrives and
+how long it stays. A single headline number is one band read out of context, and the
+small print underneath the table, the daily maximum and the minimum charge, usually
+outranks the table itself.
+
+**How do I know which tariff table I am looking at?** Read the scope, not just the
+rows. The same garage publishes weekday, weekend, event-day and overnight tables, and
+the page often names the scope once, above the table, then never again. Store the
+scope on every band you capture.
+
+**The rates only appear after I fill in a date. Is that a block?** No, it is the
+normal flow on most operator sites: the table is computed from the arrival and
+departure you enter. Drive the date control the way a person would and wait for the
+table to repopulate before reading it.
+
+**How fast can I crawl parking sites?** Slowly. These are small sites and a city-wide
+sweep at full speed is a visible load on infrastructure that was sized for a few
+hundred human visitors a day.
+
+**See also:** [How to scrape accordion and tab content with
+Playwright](how-to-scrape-accordion-and-tab-content-playwright.md), [How to rate limit
+your own Playwright scraper](how-to-rate-limit-your-scraper-playwright.md), [How to
+resume an interrupted scrape with
+Playwright](how-to-resume-an-interrupted-scrape-playwright.md)
+
+## Sources
+
+- Playwright, Locators, https://playwright.dev/python/docs/api/class-locator -
+  `evaluate_all` and the locator waiting model, checked for reading a whole table in
+  one pass instead of one call per row.
+- This project's pages on pacing and on resuming an interrupted run, which carry the
+  behaviour this page depends on instead of repeating it.

--- a/docs/how-to-scrape-pet-adoption-listings-playwright.md
+++ b/docs/how-to-scrape-pet-adoption-listings-playwright.md
@@ -235,3 +235,35 @@ Two honest caveats belong next to it. `disappeared` is not `adopted`, so any pub
 figure should say so. And animals that are relisted after a returned adoption appear twice
 with the same id, which is real signal rather than noise, but only if your analysis expects
 it rather than deduplicating it away.
+
+## Short answers to the questions that lead here
+
+**What should I key an animal on?** The shelter's own identifier, taken from the
+record URL. Names repeat, photographs change, and a hash of the visible fields moves
+the moment the shelter edits a description.
+
+**An animal vanished from the list. What happened?** That is the most valuable event
+on these sites and it has more than one cause: adopted, withdrawn, or filtered out by
+a default the site applied before you saw the page. Reconcile the set against the
+previous run and record the disappearance as its own event.
+
+**Am I seeing every animal?** Probably not on the first request. Shelter sites default
+to filters more often than most listing sites - species, adoptable status, location -
+so set the filters explicitly instead of accepting whatever the page opens with.
+
+**Should I download the photographs?** Keep the URL, not the file. Mirroring images
+costs a volunteer-run shelter real bandwidth and takes on a licensing question that
+the URL does not.
+
+**See also:** [Scrape load-more button pages with
+Playwright](how-to-scrape-load-more-button-playwright.md), [Scrape lazy-loaded images
+with Playwright](how-to-scrape-lazy-loaded-images-playwright.md), [How to rate limit
+your own Playwright scraper](how-to-rate-limit-your-scraper-playwright.md)
+
+## Sources
+
+- Playwright, Locators, https://playwright.dev/python/docs/api/class-locator - the
+  locator model used to enumerate cards and read a record URL, checked for keying on
+  the shelter's identifier instead of on visible text.
+- This project's pages on load-more pagination and lazy-loaded images, which cover the
+  two mechanics an aggregator adds on top of a plain shelter list.

--- a/docs/how-to-scrape-scholarship-listings-playwright.md
+++ b/docs/how-to-scrape-scholarship-listings-playwright.md
@@ -244,3 +244,37 @@ The `unparsed` kind is the field that makes this dataset honest. Every alternati
 invents a date for a listing that does not have one, and the cost of that invention is
 borne by whoever trusts the row. Surfacing "we could not read this deadline, here is what
 it said" is both easier to build and more useful than a confident wrong date.
+
+## Short answers to the questions that lead here
+
+**How should I store a deadline that is not a date?** As a shape that admits it.
+Scholarship deadlines are often rolling, or a term, or a phrase with a condition
+attached. Keep an unparsed branch: a pipeline that coerces everything into a date
+silently invents precision the source never had.
+
+**Can I compress the eligibility rules into fields?** Not without doing harm.
+Eligibility combines study level, field, nationality, residency, income and
+institution, and a student excluded by a field you dropped never finds that out. Keep
+the prose and derive alongside it.
+
+**Should I trust the aggregator's deadline?** Follow through to the provider. The
+aggregator row is a pointer, and the current deadline lives at the source, which is
+also where a withdrawn award disappears first.
+
+**How often is a refresh worth it?** On the deadline calendar. Providers update in a
+season and deadlines cluster, so a pass timed to that rhythm sees the changes; a daily
+pass mostly re-reads rows that have not moved.
+
+**See also:** [How to scrape multi-select facet filters with
+Playwright](how-to-scrape-multi-select-facets-playwright.md), [How to extract JSON-LD
+structured data with
+Playwright](how-to-extract-json-ld-structured-data-playwright.md), [How to rate limit
+your own Playwright scraper](how-to-rate-limit-your-scraper-playwright.md)
+
+## Sources
+
+- Playwright, Locators, https://playwright.dev/python/docs/api/class-locator - waiting
+  for a facet to repopulate a list with no navigation, checked for the filtering
+  behaviour these aggregators use.
+- This project's pages on multi-select facets and on JSON-LD, which cover the two
+  routes into an aggregator's own model of a listing.

--- a/docs/how-to-scrape-school-term-calendars-playwright.md
+++ b/docs/how-to-scrape-school-term-calendars-playwright.md
@@ -217,3 +217,35 @@ Expanding to days at read time rather than at capture keeps the correction path 
 you discover that a particular school writes "w/c 14 October" meaning the whole week, you
 fix the expansion and re-derive, instead of re-scraping a hundred small sites that were
 kind enough to publish the dates in the first place.
+
+## Short answers to the questions that lead here
+
+**Is there a faster route than parsing the page?** Look for the feed first. Many
+schools publish the calendar as a subscribable feed, which is complete, dated and far
+less likely to change shape than a hand-built table.
+
+**Why is my last holiday day always wrong?** The inclusive end. A half-term written as
+one date to another includes the second date, and an exclusive range comparison drops
+it every single time.
+
+**Are all non-teaching days the same?** No, and parents care about the difference.
+Term calendars mix holidays, staff training days and closures, so keep the category
+the school gives instead of flattening them into one kind of day.
+
+**The district calendar and the school calendar disagree.** The school page wins.
+Districts publish a base calendar and individual schools override it, so record which
+source each day came from or the merge becomes unresolvable later.
+
+**See also:** [Download and read PDFs linked from a page with
+Playwright](how-to-scrape-linked-pdfs-playwright.md), [How to scrape to JSON Lines
+with Playwright](how-to-scrape-to-json-lines-playwright.md), [How to rate limit your
+own Playwright scraper](how-to-rate-limit-your-scraper-playwright.md)
+
+## Sources
+
+- IETF, RFC 5545, Internet Calendaring and Scheduling Core Object Specification,
+  https://datatracker.ietf.org/doc/html/rfc5545 - the iCalendar format these feeds
+  publish, checked for the inclusive and exclusive end semantics that this page warns
+  about.
+- This project's page on linked PDFs, for the schools that publish the calendar only
+  as a document.

--- a/docs/how-to-scrape-snow-reports-playwright.md
+++ b/docs/how-to-scrape-snow-reports-playwright.md
@@ -243,3 +243,36 @@ summit diverge through a season, how often a resort's published depth moves at a
 track the calendar. The last one is the interesting one, and it needs the numerator and
 denominator kept separately, which is why lifts are stored as their original `"8 / 14"`
 string rather than a percentage.
+
+## Short answers to the questions that lead here
+
+**Why do my snow numbers jump between runs?** Usually the unit toggle. Resorts serve
+centimetres or inches depending on a control that remembers a previous choice, so a
+series that never pins the unit mixes two scales that differ by a factor of two and a
+half.
+
+**What does new snow mean on these pages?** Nothing, without the window it covers. New
+snow is measured over a period that varies by resort and sometimes by season, so store
+the window with the number or the figure is not comparable to anything.
+
+**Should I use my fetch time as the observation time?** No. Snow reports are published
+once or twice a day and the page says when. The report time is the fact; your fetch
+time only tells you when you looked.
+
+**The numbers have not changed in weeks. Is the scraper broken?** Check the calendar
+before the code. Out of season these pages often keep last season's figures frozen
+instead of clearing them, which reads as fresh data to anything that only looks at the
+numbers.
+
+**See also:** [How to scrape geotargeted content with
+Playwright](how-to-scrape-geotargeted-content-playwright.md), [How to scrape stock
+levels with Playwright](how-to-scrape-stock-levels-playwright.md), [How to rate limit
+your own Playwright scraper](how-to-rate-limit-your-scraper-playwright.md)
+
+## Sources
+
+- Playwright, Input, https://playwright.dev/python/docs/input - clicking a toggle and
+  waiting for the value to repopulate, checked for pinning the unit before any number
+  is read.
+- This project's page on stock levels, which carries the same distinction between an
+  absent measurement and a measurement of zero.

--- a/docs/how-to-scrape-spare-part-compatibility-playwright.md
+++ b/docs/how-to-scrape-spare-part-compatibility-playwright.md
@@ -244,3 +244,36 @@ vehicles take this part. The second is the one a schema keyed on part number wit
 embedded compatibility blob cannot answer without unpacking every row, and it is the query
 that matters commercially, because it is the one that tells you how much inventory risk a
 part carries.
+
+## Short answers to the questions that lead here
+
+**How do I wait for a cascading dropdown correctly?** Wait on the option count of the
+next control, not on a fixed timeout. Each level repopulates the one below it, and a
+sleep long enough today is a race tomorrow.
+
+**What identifies a fitment row?** The whole path, not the part number. A part fits a
+combination, and the question runs in both directions: which parts fit this vehicle,
+and which vehicles take this part. Only the full path answers both.
+
+**Why keep the fitment notes as text?** Because they are the difference between a
+right part and a wrong one: a build-date cutoff, an engine code, a market, an
+equipment condition. A boolean fit with the qualifier discarded is worse than no
+answer.
+
+**Should I sweep the whole cross product?** No. Decide the slice explicitly. Every
+combination is a lookup against a real catalogue database, not a cached page, so the
+cost is carried by the catalogue and the sweep is the most visible thing you can do.
+
+**See also:** [How to capture XHR and API responses in
+Playwright](how-to-capture-xhr-api-responses-playwright.md), [How to resume an
+interrupted scrape with
+Playwright](how-to-resume-an-interrupted-scrape-playwright.md), [How to rate limit
+your own Playwright scraper](how-to-rate-limit-your-scraper-playwright.md)
+
+## Sources
+
+- Playwright, Locators, https://playwright.dev/python/docs/api/class-locator - waiting
+  on the state of a dependent control, checked for the cascade this page drives.
+- Playwright, Network, https://playwright.dev/python/docs/network -
+  `page.expect_response()`, for the catalogues that answer each cascade level with a
+  request you can read directly.


### PR DESCRIPTION
The twenty guides published on 7 September went out without three things every
other article on this wiki has: the question block, the See also line and the
Sources section. 416 of the other engine pages carry the question block, so the
gap was in these twenty and not in the convention.

Each page gets four questions in the words people type, answered from what the
page already argues, so nothing new is claimed. Each See also names pages the
article already links in its body, using their real titles. Each Sources section
names what the page was checked against: the Playwright reference for the calls
the code makes, plus a primary source where one is genuinely on point (RFC 5545
for calendar feeds, getComputedStyle and content for the pseudo-element page,
aria-label for numbers drawn as images, the PyPI stats API for download counts).
All nine URLs were fetched and return 200.

Additive only: 668 lines added, none removed, no line endings touched.
