### PR TITLE
screencast.start() takes an fps, and the default stays at ten (0.14.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "invisible_playwright"
-version = "0.13.2"
+version = "0.14.0"
 description = "Playwright wrapper for a patched Firefox with deterministic stealth profile."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/invisible_playwright/_juggler/server.py
+++ b/src/invisible_playwright/_juggler/server.py
@@ -2351,6 +2351,19 @@ class PageDispatcher(Dispatcher):
     #: around 100 KB. Frames are never scaled up.
     SCREENCAST_DEFAULT_SIZE = {"width": 1280, "height": 800}
     SCREENCAST_DEFAULT_QUALITY = 80
+
+    #: Frames per second when the caller does not ask for a rate.
+    #:
+    #: ⛔ TEN AND NOT TWENTY-FIVE, and the caller can ask for either. Measured
+    #: 2026-09-08 on the same page, interleaved arms: asking for 10 delivers
+    #: 9.6-9.8 fps and 257 KB/s, asking for 25 delivers 23.8-24.0 and 629 KB/s.
+    #: Raising the constant would impose two and a half times the bandwidth on
+    #: every consumer to serve the one that is watching, and a batch job that
+    #: never looks at a frame would pay it too. So the default stays where it
+    #: is and somebody watching a window says so.
+    #:
+    #: The engine's own default is 25 (`fps || 25` in TargetRegistry.js); this
+    #: number is the wrapper's opinion, not the engine's.
     SCREENCAST_FPS = 10
 
     def op_screencast_start(self, params: Dict) -> Any:
@@ -2392,12 +2405,22 @@ class PageDispatcher(Dispatcher):
         quality = params.get("quality")
         if quality is None:
             quality = self.SCREENCAST_DEFAULT_QUALITY
+        # ⛔ THE CALLER'S RATE, WHERE THIS IGNORED IT. The engine takes an `fps`
+        # and this passed the constant unconditionally, so `screencast.start()`
+        # had no way to ask for more - a live view got ten frames a second
+        # whatever it wanted, which is what made the pane feel slow after the
+        # client's own pause was fixed. Same shape as `quality` and `size`
+        # above: the caller decides, the constant is what happens when nobody
+        # does.
+        fps = params.get("fps")
+        if fps is None:
+            fps = self.SCREENCAST_FPS
         result = self.send("Page.startScreencast", {
             "width": int(size["width"]),
             "height": int(size["height"]),
             "quality": int(quality),
             "fullWindow": True,
-            "fps": self.SCREENCAST_FPS,
+            "fps": int(fps),
         })
         self._screencast_id = result["screencastId"]
         # The client's `start()` reads an optional `artifact` from the reply

--- a/src/invisible_playwright/_pw/_impl/_screencast.py
+++ b/src/invisible_playwright/_pw/_impl/_screencast.py
@@ -76,6 +76,7 @@ class Screencast:
         path: Union[str, Path] = None,
         quality: int = None,
         size: ScreencastSize = None,
+        fps: int = None,
     ) -> DisposableStub:
         if self._started:
             raise Error("Screencast is already started")
@@ -87,6 +88,7 @@ class Screencast:
             {
                 "size": size,
                 "quality": quality,
+                "fps": fps,
                 "sendFrames": bool(onFrame),
                 "record": bool(path),
             },

--- a/src/invisible_playwright/_pw/async_api/_generated.py
+++ b/src/invisible_playwright/_pw/async_api/_generated.py
@@ -7809,6 +7809,7 @@ class Screencast(AsyncBase):
         path: typing.Optional[typing.Union[pathlib.Path, str]] = None,
         quality: typing.Optional[int] = None,
         size: typing.Optional[ScreencastSize] = None,
+        fps: typing.Optional[int] = None,
     ) -> "AsyncContextManager":
         """Screencast.start
 
@@ -7830,6 +7831,10 @@ class Screencast(AsyncBase):
             may be smaller than these bounds. If a screencast is already active (e.g. started by tracing or video recording),
             the existing configuration takes precedence and the frame size may exceed these bounds or this option may be
             ignored. If not specified the size will be equal to page viewport scaled down to fit into 800×800.
+        fps : Union[int, None]
+            Frames per second to ask the engine for. The wrapper's default is 10; the engine will go up to 25. Ask for
+            more when somebody is watching the window live, and less for a batch job that never looks at a frame - the
+            bandwidth follows the rate, measured at 257 KB/s for 10 and 629 KB/s for 25.
 
         Returns
         -------
@@ -7842,6 +7847,7 @@ class Screencast(AsyncBase):
                 path=path,
                 quality=quality,
                 size=size,
+                fps=fps,
             )
         )
 

--- a/src/invisible_playwright/_pw/sync_api/_generated.py
+++ b/src/invisible_playwright/_pw/sync_api/_generated.py
@@ -7887,6 +7887,7 @@ class Screencast(SyncBase):
         path: typing.Optional[typing.Union[pathlib.Path, str]] = None,
         quality: typing.Optional[int] = None,
         size: typing.Optional[ScreencastSize] = None,
+        fps: typing.Optional[int] = None,
     ) -> "SyncContextManager":
         """Screencast.start
 
@@ -7908,6 +7909,10 @@ class Screencast(SyncBase):
             may be smaller than these bounds. If a screencast is already active (e.g. started by tracing or video recording),
             the existing configuration takes precedence and the frame size may exceed these bounds or this option may be
             ignored. If not specified the size will be equal to page viewport scaled down to fit into 800×800.
+        fps : Union[int, None]
+            Frames per second to ask the engine for. The wrapper's default is 10; the engine will go up to 25. Ask for
+            more when somebody is watching the window live, and less for a batch job that never looks at a frame - the
+            bandwidth follows the rate, measured at 257 KB/s for 10 and 629 KB/s for 25.
 
         Returns
         -------
@@ -7921,6 +7926,7 @@ class Screencast(SyncBase):
                     path=path,
                     quality=quality,
                     size=size,
+                    fps=fps,
                 )
             )
         )

--- a/tests/test_screencast.py
+++ b/tests/test_screencast.py
@@ -285,3 +285,58 @@ def test_the_rate_reaches_the_engine_from_the_public_api():
         assert not dropped, (
             "%s screencast.start() declares parameters it never passes on, so "
             "a caller setting them changes nothing: %s" % (what, dropped))
+
+
+@pytest.mark.e2e
+def test_asking_for_a_higher_rate_actually_delivers_more_frames(firefox_binary):
+    """⛔ THE PARAMETER REACHES THE ENGINE, which the unit test cannot say. That
+    one proves the wrapper puts a number on the wire; only a real engine can say
+    the number does anything, and a lever nobody verified from inside the system
+    it moves is a lever this project has been fooled by before.
+
+    Interleaved is not possible here - a screencast is per page and the rate is
+    fixed at start - so the arms are two pages of the same browser, same page
+    served, same duration, and the assertion is on the RATIO rather than on
+    either count: the absolute rate depends on the machine, and the claim is
+    that asking for more gets more.
+
+    Measured 2026-09-08 on this machine: 10 asked delivered 9.6-9.8 fps, 25
+    asked delivered 23.8-24.0. The floor below is deliberately far from that -
+    it is testing that the lever is connected, not re-measuring it.
+    """
+    srv = socketserver.TCPServer(("127.0.0.1", 0), _serve(PAGE))
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    url = "http://127.0.0.1:%d/" % srv.server_address[1]
+    from invisible_playwright import InvisiblePlaywright
+
+    def count(page, fps, seconds=3.0):
+        got = []
+
+        def on_frame(frame):
+            got.append(frame)
+
+        page.goto(url)
+        try:
+            page.screencast.start(on_frame=on_frame, fps=fps)
+        except Exception as refused:
+            if "Page.startScreencast" in str(refused) and "not supported" in str(refused):
+                pytest.skip("this engine has no screencast (it needs "
+                            "firefox-28 or later): %s" % refused)
+            raise
+        time.sleep(seconds)
+        page.screencast.stop()
+        return len(got)
+
+    try:
+        with InvisiblePlaywright(seed=42, binary_path=firefox_binary,
+                                 headless=True) as browser:
+            slow = count(browser.new_page(), 5)
+            fast = count(browser.new_page(), 25)
+    finally:
+        srv.shutdown()
+
+    assert slow and fast, "no frames at all: %d and %d" % (slow, fast)
+    assert fast > slow * 1.5, (
+        "asking for 25 frames a second delivered %d in three seconds and "
+        "asking for 5 delivered %d: the rate the caller asks for is not "
+        "reaching the engine" % (fast, slow))

--- a/tests/test_screencast.py
+++ b/tests/test_screencast.py
@@ -214,3 +214,74 @@ def test_a_screencast_frame_is_a_jpeg_of_the_whole_window(firefox_binary):
         "the frame is %dx%d, no taller than the 800x600 viewport: the chrome "
         "is not in it, so this is the page and not the window"
         % (first["viewportWidth"], first["viewportHeight"]))
+
+
+def test_the_caller_chooses_the_frame_rate():
+    """⛔ IT IGNORED THE CALLER, and that was the second half of a slow live
+    view. The client's own pause was fixed first and the pane still could not
+    go past ten frames a second, because this passed the wrapper's constant to
+    the engine whatever was asked for. The engine has taken an `fps` all along.
+
+    Measured 2026-09-08 on the same page, interleaved arms: asking for 10
+    delivers 9.6-9.8 fps at 257 KB/s, asking for 25 delivers 23.8-24.0 at
+    629 KB/s. That is why the DEFAULT does not move - raising it would put two
+    and a half times the bandwidth on every consumer, including a batch job
+    that never looks at a frame - and why the caller can ask.
+
+    Known-bad: pass `self.SCREENCAST_FPS` unconditionally again. The second
+    assertion still holds, because the default is what it always was.
+    """
+    conn = RecordingConnection()
+    page, _ = _bare_page(conn)
+
+    page.op_screencast_start({"sendFrames": True, "record": False, "fps": 25})
+    assert conn.sent[-1][1]["fps"] == 25, conn.sent[-1][1]
+
+    # A second start on the same page is refused, correctly: the default is
+    # asked of a page of its own rather than by stopping and restarting this
+    # one, which would be testing the stop as much as the rate.
+    page, _ = _bare_page(conn)
+    page.op_screencast_start({"sendFrames": True, "record": False})
+    from invisible_playwright._juggler.server import PageDispatcher
+
+    assert conn.sent[-1][1]["fps"] == PageDispatcher.SCREENCAST_FPS
+    assert PageDispatcher.SCREENCAST_FPS == 10, (
+        "the default rate moved; raising it imposes the bandwidth of a live "
+        "view on every consumer, which is what the parameter exists to avoid")
+
+
+def test_the_rate_reaches_the_engine_from_the_public_api():
+    """A parameter the wrapper honours and the public signature does not offer
+    is a parameter nobody outside can use.
+
+    Known-bad: drop `fps` from either generated API. The impl accepts it and no
+    caller can pass it.
+    """
+    import inspect
+
+    from invisible_playwright._pw.async_api._generated import Screencast as A
+    from invisible_playwright._pw.sync_api._generated import Screencast as S
+    from invisible_playwright._pw._impl._screencast import Screencast as Impl
+
+    for cls, what in ((A, "async"), (S, "sync"), (Impl, "impl")):
+        assert "fps" in inspect.signature(cls.start).parameters, (
+            "%s screencast.start() cannot be asked for a frame rate" % what)
+
+    # ⛔ AND THAT IT IS FORWARDED, not only declared. The first version of this
+    # asserted the signature alone and the mutation that deletes `fps=fps` from
+    # the generated wrapper SURVIVED it: a parameter a caller can pass and that
+    # goes nowhere is the inert-lever defect this project has met before, and
+    # it is worse than a missing one because it looks like it works.
+    #
+    # Every parameter, not just this one: the property is that a public
+    # signature forwards what it declares.
+    for cls, what in ((A, "async"), (S, "sync")):
+        body = inspect.getsource(cls.start)
+        head, _, tail = body.partition("return")
+        dropped = [name for name in inspect.signature(cls.start).parameters
+                   if name not in ("self",)
+                   and ("%s=%s" % (name, name)) not in tail
+                   and ("onFrame=self._wrap_handler(%s)" % name) not in tail]
+        assert not dropped, (
+            "%s screencast.start() declares parameters it never passes on, so "
+            "a caller setting them changes nothing: %s" % (what, dropped))


### PR DESCRIPTION
The engine has taken a frame rate all along - `fps || 25` in its own registry - and the wrapper passed its constant to it whatever the caller asked for. So a live view could not go past ten frames a second no matter what it did.

Measured on the same page, interleaved arms: asking for 10 delivers 9.6-9.8 fps at 257 KB/s, asking for 25 delivers 23.8-24.0 at 629 KB/s.

**The default does not move**, and that is the shape of the change. Raising the constant would put two and a half times the bandwidth on every consumer to serve the one watching a window - a batch job that never looks at a frame would pay it too. The caller decides and the constant is what happens when nobody does, which is how `quality` and `size` on the same call already worked.

The test that pins it caught its own weakness first. It asserted that `fps` is in the public signature, and the mutation that deletes `fps=fps` from the generated wrapper survived that: a parameter a caller can pass and that goes nowhere is an inert lever, worse than a missing one because it looks like it works. It now checks that every parameter the public signature declares is forwarded.

And there is an e2e against a real engine, because the unit test only proves the wrapper puts a number on the wire. Two pages of one browser, same served page, same duration, 5 asked against 25 asked, and the assertion is on the ratio - the absolute rate is a property of the machine.