### PR TITLE
The changelog stopped at 0.13.2 while the index was serving 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-09-08
+
+### Added
+- **`page.screencast.start(fps=...)` sets the frame rate, and the default
+  stays at ten.** The engine has taken a frame rate all along, and the wrapper
+  passed its own constant to it whatever the caller asked, so a live view could
+  not go past ten frames a second no matter what it did. Measured on the same
+  page, interleaved arms: asking for 10 delivers 9.6-9.8 fps at 257 KB/s,
+  asking for 25 delivers 23.8-24.0 at 629 KB/s. The default does not move,
+  which is the whole shape of the change: raising it would put two and a half
+  times the bandwidth on every consumer to serve the one that is watching a
+  window, so the caller decides and the constant is what happens when nobody
+  does. That is how `quality` and `size` on the same call already work.
+
 ## [0.13.2] - 2026-09-07
 
 ### Fixed


### PR DESCRIPTION
The e2e on main has been red since the release commit itself, 2026-09-08 15:30, and stayed there for seventeen hours because the only push after it touched the wiki and does not start that workflow. One test of 209: the changelog reads 0.13.2 as its newest heading while the index serves 0.14.0.

That test is marked e2e, so the default selection deselects it and the `gate` context main requires never sees it. This is the drift the test was written for: a record kept by hand, read by users, that nothing downstream breaks when it falls behind.

The heading is dated 2026-09-08 because that is the upload time on the index and the test compares dates too. The entry covers the one change in the range a caller can see; the other six commits are wiki, tests and an internal thinning.
