### PR TITLE
Drop the proxy section and the macOS note from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,13 +31,6 @@ the page still reads `null` from `element.shadowRoot`, so nothing observable to 
 changes. The three-arm table and the page that reproduces it:
 [closed shadow roots](https://github.com/feder-cr/invisible_playwright/wiki/closed-shadow-root-playwright).
 
-Driven by the standard Playwright API. Full breakdown: [feder-cr/firefox_antidetect_patch](https://github.com/feder-cr/firefox_antidetect_patch).
-
----
-
-## Still seeing captchas or anti-bot? It's the proxy.
-Once the browser is handled it stops being the variable. If you are still getting challenged, the tell is no longer the browser, it is the IP you come from. Around 90% of proxies are public: anyone can rent the same address, so it is already known and sits on the blocked-IP lists sites check. A perfect browser on a known IP still loses.
-
 ---
 
 ## Install
@@ -49,7 +42,7 @@ python -m invisible_playwright fetch      # one-time download, sha256-verified: 
 
 Requires **Python 3.11 or newer**.
 
-Supported platforms: **Windows x86_64**, **Linux x86_64 / arm64**. macOS is no longer supported (releases stopped at firefox-20); on a Mac the package refuses at launch with a clear message rather than downloading a binary that no longer exists.
+Supported platforms: **Windows x86_64**, **Linux x86_64 / arm64**.
 
 ### If you would rather prompt than script
 


### PR DESCRIPTION
Two removals from the README, both asked for.

The proxy section answered a question the README does not need to raise: it opened by conceding that challenges still happen and then explained whose fault that is. The line above it pointing at the engine repository went with it - the wiki and the sibling block already carry that link where a reader is looking for it.

The macOS sentence spent a full line explaining a platform the package does not ship for. The supported list says which platforms work, which is what a reader is checking; anyone on a Mac gets the same explanation from the package itself at launch, where it is actionable.

Nothing else moves. The `Around 90% of proxies are public` figure still lives in `docs/configuration.md` and `docs/vs-ulixee-hero.md`, where it belongs to an argument rather than to a front page.
