### PR TITLE
Shorten the closed shadow root paragraph to the claim and the link

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,9 @@ Anti-bots ask two questions, and reCAPTCHA, hCaptcha and Cloudflare Turnstile sc
 - Every click, hover and drag follows a natural mouse path with human timing, no teleporting cursor.
 - Each input is byte-identical to a real mouse: real input source, pressure, trusted events.
 
-**And one thing the stock driver cannot do.** Playwright's own documentation says
-"Closed-mode shadow roots are not supported", and measured on 2026-09-05 against a page
-carrying one open and one closed root, stock Playwright returned zero matches for the
-closed content in Firefox and in Chromium alike. This engine returns the element, while
-the page still reads `null` from `element.shadowRoot`, so nothing observable to the page
-changes. The three-arm table and the page that reproduces it:
+**And one thing the stock driver cannot do.** Playwright cannot see into closed-mode
+shadow roots, in Firefox or in Chromium. This engine returns the element, and the page
+still reads `null` from `element.shadowRoot`, so nothing it can observe changes:
 [closed shadow roots](https://github.com/feder-cr/invisible_playwright/wiki/closed-shadow-root-playwright).
 
 ---


### PR DESCRIPTION
Six lines of prose in a section otherwise made of one-line bullets, and most of it was evidence: the quote from Playwright's documentation, the date of the measurement, the zero-match result, the three-arm table. That belongs to the wiki page the paragraph already links, and the link was the last thing a reader reached.

Three lines now, carrying what a reader decides on: stock Playwright cannot see into closed-mode shadow roots in either engine, this one returns the element, and the page still reads `null` from `element.shadowRoot` so nothing it can observe changes. The last clause stays because it is the point - reaching the element is useless if reaching it is visible.
